### PR TITLE
Render fields with String and Email presenters

### DIFF
--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -5,6 +5,14 @@ class CustomerDashboard
     :name
   end
 
+  def attribute_adapters
+    {
+      email: :email,
+      lifetime_value: :string,
+      name: :string,
+    }
+  end
+
   def index_page_attributes
     attributes
   end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -1,27 +1,32 @@
 class ProductDashboard
+  def attribute_adapters
+    {
+      description: :string,
+      image_url: :string,
+      name: :string,
+      price: :string,
+    }
+  end
+
   def index_page_attributes
-    [
-      :name,
-      :price,
-      :description,
-      :image_url,
-    ]
+    attributes
+  end
+
+  def form_attributes
+    attributes
+  end
+
+  def show_page_attributes
+    attributes
   end
 
   def title_attribute
     :name
   end
 
-  def form_attributes
-    [
-      :name,
-      :price,
-      :description,
-      :image_url,
-    ]
-  end
+  private
 
-  def show_page_attributes
+  def attributes
     [
       :name,
       :price,

--- a/lib/adapters/email_adapter.rb
+++ b/lib/adapters/email_adapter.rb
@@ -1,0 +1,21 @@
+require "action_controller/base"
+
+class EmailAdapter
+  def initialize(data)
+    @data = data
+  end
+
+  def render_index
+    data
+  end
+
+  def render_show
+    ActionController::Base.helpers.mail_to(data)
+  end
+
+  def render_edit(form, attribute_name)
+    form.text_field(attribute_name)
+  end
+
+  attr_reader :data
+end

--- a/lib/adapters/string_adapter.rb
+++ b/lib/adapters/string_adapter.rb
@@ -1,0 +1,19 @@
+class StringAdapter
+  def initialize(data)
+    @data = data
+  end
+
+  def render_show
+    data
+  end
+
+  def render_index
+    data
+  end
+
+  def render_edit(form, attribute_name)
+    form.text_field(attribute_name)
+  end
+
+  attr_reader :data
+end

--- a/lib/presenters/base_presenter.rb
+++ b/lib/presenters/base_presenter.rb
@@ -1,3 +1,6 @@
+require "adapters/email_adapter"
+require "adapters/string_adapter"
+
 class BasePresenter
   def resource_name
     @resource_name ||=
@@ -11,5 +14,19 @@ class BasePresenter
     arguments = [path_helper, resource].compact
 
     Rails.application.routes.url_helpers.public_send(*arguments)
+  end
+
+  def adapter(dashboard, resource, attribute_name)
+    adapter_name = dashboard.attribute_adapters[attribute_name]
+    value = resource.public_send(attribute_name)
+
+    adapter_registry[adapter_name].new(value)
+  end
+
+  def adapter_registry
+    {
+      email: EmailAdapter,
+      string: StringAdapter,
+    }
   end
 end

--- a/lib/presenters/index_presenter.rb
+++ b/lib/presenters/index_presenter.rb
@@ -32,7 +32,7 @@ class IndexPresenter < BasePresenter
   attr_reader :dashboard
 
   def attribute_html(resource, attribute_name)
-    resource.public_send(attribute_name)
+    adapter(dashboard, resource, attribute_name).render_index
   end
 
   def show_path(resource)

--- a/lib/presenters/show_presenter.rb
+++ b/lib/presenters/show_presenter.rb
@@ -19,7 +19,7 @@ class ShowPresenter < BasePresenter
   end
 
   def render_attribute(attribute_name)
-    resource.public_send(attribute_name)
+    adapter(dashboard, resource, attribute_name).render_show
   end
 
   def edit_path

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -17,4 +17,14 @@ RSpec.describe CustomerDashboard do
       expect(dashboard.index_page_attributes).to include(:email)
     end
   end
+
+  describe "#attribute_adapters" do
+    it "maps each attribute to an adapter" do
+      dashboard = CustomerDashboard.new
+
+      expect(dashboard.attribute_adapters[:name]).to eq :string
+      expect(dashboard.attribute_adapters[:email]).to eq :email
+      expect(dashboard.attribute_adapters[:lifetime_value]).to eq :string
+    end
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :customer do
     sequence(:name) { |n| "Customer #{n}" }
-    email { name.downcase.underscore + "@example.com" }
+    email { name.downcase.gsub(" ", "_") + "@example.com" }
   end
 
   factory :product do

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe "customer show page" do
     expect(page).to have_content(customer.email)
   end
 
+  it "link-ifies the email" do
+    customer = create(:customer)
+
+    visit customer_path(customer)
+
+    expect(page).to have_link(customer.email)
+  end
+
   it "links to the edit page" do
     customer = create(:customer)
     edit_path = edit_customer_path(customer)

--- a/spec/lib/adapters/email_adapter_spec.rb
+++ b/spec/lib/adapters/email_adapter_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "adapters/email_adapter"
+
+RSpec.describe EmailAdapter do
+  it "renders the email with a link for the show page" do
+    email = "hello@example.com"
+
+    adapter = EmailAdapter.new(email)
+    rendered = adapter.render_show
+
+    expect(rendered).to eq "<a href=\"mailto:#{email}\">#{email}</a>"
+  end
+
+  it "renders the email for the index page" do
+    email = "hello@example.com"
+
+    adapter = EmailAdapter.new(email)
+    rendered = adapter.render_index
+
+    expect(rendered).to eq email
+  end
+
+  it "renders an input form for the edit page" do
+    email = "hello@example.com"
+    form_object_double = double(text_field: email)
+
+    adapter = EmailAdapter.new(email)
+    rendered = adapter.render_edit(form_object_double, :attribute)
+
+    expect(rendered).to eq email
+    expect(form_object_double).to have_received(:text_field).with(:attribute)
+  end
+end

--- a/spec/lib/adapters/string_adapter_spec.rb
+++ b/spec/lib/adapters/string_adapter_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "adapters/string_adapter"
+
+RSpec.describe StringAdapter do
+  it "renders the string for the show page" do
+    string = "hello"
+
+    adapter = StringAdapter.new(string)
+    rendered = adapter.render_show
+
+    expect(rendered).to eq string
+  end
+
+  it "renders the string for the index page" do
+    string = "hello"
+
+    adapter = StringAdapter.new(string)
+    rendered = adapter.render_index
+
+    expect(rendered).to eq string
+  end
+
+  it "renders an input form for the edit page" do
+    string = "hello"
+    form_object_double = double(text_field: string)
+
+    adapter = StringAdapter.new(string)
+    rendered = adapter.render_edit(form_object_double, :attribute)
+
+    expect(rendered).to eq string
+    expect(form_object_double).to have_received(:text_field).with(:attribute)
+  end
+end

--- a/spec/lib/presenters/show_presenter_spec.rb
+++ b/spec/lib/presenters/show_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ShowPresenter do
       presenter = ShowPresenter.new(CustomerDashboard.new, customer)
 
       expect(presenter.attributes).to eq(
-        email: customer.email,
+        email: EmailAdapter.new(customer.email).render_show,
         lifetime_value: customer.lifetime_value,
       )
     end
@@ -32,7 +32,7 @@ RSpec.describe ShowPresenter do
 
       rendered = presenter.render_attribute(:email)
 
-      expect(rendered).to eq(email)
+      expect(rendered).to eq(EmailAdapter.new(email).render_show)
     end
   end
 


### PR DESCRIPTION
This is an important step taht allows us to specify how models'
attributes should be displayed. This is a prerequisite for setting up
the UI for belongs_to / has_many associations.
