### PR TITLE
Set up UI and form for belongs_to relationships

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -77,7 +77,11 @@ class DashboardController < ApplicationController
   end
 
   def resource_params
-    params.require(:"#{resource_name}").permit(*dashboard.form_attributes)
+    params.require(:"#{resource_name}").permit(*permitted_attributes)
+  end
+
+  def permitted_attributes
+    dashboard.permitted_attributes
   end
 
   def dashboard_class

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -1,4 +1,6 @@
-class CustomerDashboard
+require "base_dashboard"
+
+class CustomerDashboard < BaseDashboard
   def attribute_adapters
     {
       email: :email,

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -1,4 +1,6 @@
-class OrderDashboard
+require "base_dashboard"
+
+class OrderDashboard < BaseDashboard
   def attribute_adapters
     {
       id: :string,
@@ -7,6 +9,7 @@ class OrderDashboard
       address_city: :string,
       address_state: :string,
       address_zip: :string,
+      customer: :belongs_to,
     }
   end
 
@@ -32,6 +35,7 @@ class OrderDashboard
       :address_city,
       :address_state,
       :address_zip,
+      :customer,
     ]
   end
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -1,4 +1,6 @@
-class ProductDashboard
+require "base_dashboard"
+
+class ProductDashboard < BaseDashboard
   def attribute_adapters
     {
       description: :string,

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -2,11 +2,11 @@ class Customer < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true
 
-  def to_s
-    name
-  end
-
   def lifetime_value
     "$#{rand(100)}"
+  end
+
+  def to_s
+    name
   end
 end

--- a/app/views/dashboard/_form.html.erb
+++ b/app/views/dashboard/_form.html.erb
@@ -1,13 +1,14 @@
-<%= simple_form_for(@presenter.resource) do |f| %>
-  <%= f.error_notification %>
-
+<%= form_for(@presenter.resource) do |f| %>
   <div class="form-inputs">
-    <% @presenter.attribute_names.each do |attr_name| %>
-      <%= f.input attr_name %>
-    <% end %>
+    <% @presenter.attribute_names.each do |attr_name| -%>
+      <div class="field">
+        <%= @presenter.render_form_label(f, attr_name) %><br>
+        <%= @presenter.render_form_field(f, attr_name) %>
+      </div>
+    <% end -%>
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit %>
+    <%= f.submit %>
   </div>
 <% end %>

--- a/lib/adapters/base_adapter.rb
+++ b/lib/adapters/base_adapter.rb
@@ -11,8 +11,16 @@ class BaseAdapter
     data
   end
 
-  def render_edit(form, attribute_name)
-    form.text_field(attribute_name)
+  def render_form_field(form, attribute)
+    form.text_field(attribute)
+  end
+
+  def render_form_label(form, attribute)
+    form.label attribute
+  end
+
+  def self.permitted_attribute(attr)
+    attr
   end
 
   protected

--- a/lib/adapters/belongs_to_adapter.rb
+++ b/lib/adapters/belongs_to_adapter.rb
@@ -1,0 +1,44 @@
+require_relative "base_adapter"
+require "action_controller/base"
+
+class BelongsToAdapter < BaseAdapter
+  include Rails.application.routes.url_helpers
+
+  def render_show
+    ActionController::Base.helpers.link_to data.to_s, url_to_data
+  end
+
+  def render_index
+    render_show
+  end
+
+  def render_form_field(form, attribute)
+    options = attribute_class(attribute).all.map do |option|
+      [option.to_s, option.id]
+    end
+
+    form.select("#{attribute}_id", options)
+  end
+
+  def render_form_label(form, attribute)
+    form.label "#{attribute}_id"
+  end
+
+  def self.permitted_attribute(attr)
+    :"#{attr}_id"
+  end
+
+  private
+
+  def attribute_class(attribute)
+    Object.const_get(attribute.to_s.camelcase)
+  end
+
+  def url_to_data
+    Rails.application.routes.url_helpers.public_send(data_path_helper, data)
+  end
+
+  def data_path_helper
+    "#{data.class.to_s.underscore}_path"
+  end
+end

--- a/lib/base_dashboard.rb
+++ b/lib/base_dashboard.rb
@@ -1,0 +1,23 @@
+class BaseDashboard
+  def permitted_attributes
+    form_attributes.map do |attr|
+      adapter_class(attr).permitted_attribute(attr)
+    end.uniq
+  end
+
+  private
+
+  def adapter_class(attr)
+    adapter_name = attribute_adapters[attr]
+
+    adapter_registry.fetch(adapter_name)
+  end
+
+  def adapter_registry
+    {
+      belongs_to: BelongsToAdapter,
+      email: EmailAdapter,
+      string: StringAdapter,
+    }
+  end
+end

--- a/lib/presenters/base_presenter.rb
+++ b/lib/presenters/base_presenter.rb
@@ -1,3 +1,4 @@
+require "adapters/belongs_to_adapter"
 require "adapters/email_adapter"
 require "adapters/image_adapter"
 require "adapters/string_adapter"
@@ -26,6 +27,7 @@ class BasePresenter
 
   def adapter_registry
     {
+      belongs_to: BelongsToAdapter,
       email: EmailAdapter,
       image: ImageAdapter,
       string: StringAdapter,

--- a/lib/presenters/form_presenter.rb
+++ b/lib/presenters/form_presenter.rb
@@ -20,6 +20,14 @@ class FormPresenter < BasePresenter
     route(nil, resource_name.pluralize)
   end
 
+  def render_form_label(form, attribute)
+    adapter(dashboard, resource, attribute).render_form_label(form, attribute)
+  end
+
+  def render_form_field(form, attribute)
+    adapter(dashboard, resource, attribute).render_form_field(form, attribute)
+  end
+
   protected
 
   attr_reader :dashboard

--- a/spec/dashboards/order_dashboard_spec.rb
+++ b/spec/dashboards/order_dashboard_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe CustomerDashboard do
+  describe "#permitted_attributes" do
+    it "returns the attribute name by default" do
+      dashboard = OrderDashboard.new
+
+      expect(dashboard.permitted_attributes).to include(:address_line_one)
+    end
+
+    it "returns the attribute_id name for belongs_to relationships" do
+      dashboard = OrderDashboard.new
+
+      expect(dashboard.permitted_attributes).to include(:customer_id)
+    end
+  end
+end

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "order form" do
+  it "displays a select box for the customer" do
+    customer = create(:customer)
+
+    visit new_order_path
+    select(customer.name, from: "Customer")
+    fill_in "Address line one", with: "Example"
+    fill_in "Address line two", with: "Example"
+    fill_in "Address city", with: "Example"
+    fill_in "Address state", with: "Example"
+    fill_in "Address zip", with: "Example"
+    click_on "Create Order"
+
+    expect(page).to have_link(customer.name)
+  end
+end

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -1,17 +1,25 @@
 require "rails_helper"
 
-RSpec.describe "order index page" do
-  pending "displays orders' name and description" do
+describe "order index page" do
+  it "displays the order id" do
     order = create(:order)
 
     visit orders_path
 
     expect(page).to have_header("Orders")
     expect(page).to have_content(order.id)
-    expect(page).to have_link(order.customer.name)
   end
 
-  pending "links to the order show page" do
+  it "links to the customer" do
+    order = create(:order)
+
+    visit orders_path
+    click_on(order.customer.name)
+
+    expect(page).to have_header(order.customer.name)
+  end
+
+  it "links to the order show page" do
     order = create(:order)
 
     visit orders_path

--- a/spec/lib/adapters/email_adapter_spec.rb
+++ b/spec/lib/adapters/email_adapter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe EmailAdapter do
     form_object_double = double(text_field: email)
 
     adapter = EmailAdapter.new(email)
-    rendered = adapter.render_edit(form_object_double, :attribute)
+    rendered = adapter.render_form_field(form_object_double, :attribute)
 
     expect(rendered).to eq email
     expect(form_object_double).to have_received(:text_field).with(:attribute)

--- a/spec/lib/adapters/string_adapter_spec.rb
+++ b/spec/lib/adapters/string_adapter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StringAdapter do
     form_object_double = double(text_field: string)
 
     adapter = StringAdapter.new(string)
-    rendered = adapter.render_edit(form_object_double, :attribute)
+    rendered = adapter.render_form_field(form_object_double, :attribute)
 
     expect(rendered).to eq string
     expect(form_object_double).to have_received(:text_field).with(:attribute)


### PR DESCRIPTION
- Extract a base adapter with sensible defaults
  The default behavior is to display the data as a string on the index and
  show pages, and render a text field on the form page.
- Rename `Adapter#render_edit` to `#render_form_field`
