### PR TITLE
Substitue #to_s for Dashboard#title_attribute

### DIFF
--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -1,8 +1,4 @@
 class CustomerDashboard
-  def title_attribute
-    :name
-  end
-
   def attribute_adapters
     {
       email: :email,
@@ -16,7 +12,7 @@ class CustomerDashboard
   end
 
   def show_page_attributes
-    attributes - [title_attribute]
+    attributes - [:name]
   end
 
   def form_attributes

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -22,10 +22,6 @@ class OrderDashboard
     attributes
   end
 
-  def title_attribute
-    :id
-  end
-
   private
 
   def attributes

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -20,10 +20,6 @@ class ProductDashboard
     attributes
   end
 
-  def title_attribute
-    :name
-  end
-
   private
 
   def attributes

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -2,6 +2,10 @@ class Customer < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true
 
+  def to_s
+    name
+  end
+
   def lifetime_value
     "$#{rand(100)}"
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,4 +8,8 @@ class Order < ActiveRecord::Base
   validates :address_city, presence: true
   validates :address_state, presence: true
   validates :address_zip, presence: true
+
+  def to_s
+    id
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,4 +3,8 @@ class Product < ActiveRecord::Base
   validates :image_url, presence: true
   validates :name, presence: true
   validates :price, presence: true
+
+  def to_s
+    name
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,8 +6,10 @@
 <table>
   <thead>
     <tr>
+      <th><%= @presenter.resource_name.titleize %></th>
+
       <% @presenter.attribute_names.each do |attr_name| %>
-        <th><%= attr_name %></th>
+        <th><%= attr_name.to_s.titleize %></th>
       <% end %>
       <th colspan="2"></th>
     </tr>
@@ -16,6 +18,8 @@
   <tbody>
     <% @resources.each do |resource| %>
       <tr>
+        <td><%= link_to resource.to_s, @presenter.show_path(resource) %></td>
+
         <% @presenter.attribute_names.each do |attr_name| %>
           <td><%= @presenter.render_attribute(resource, attr_name) %></td>
         <% end %>

--- a/lib/presenters/form_presenter.rb
+++ b/lib/presenters/form_presenter.rb
@@ -13,7 +13,7 @@ class FormPresenter < BasePresenter
   end
 
   def page_title
-    resource.public_send(dashboard.title_attribute)
+    resource.to_s
   end
 
   def index_path

--- a/lib/presenters/index_presenter.rb
+++ b/lib/presenters/index_presenter.rb
@@ -20,11 +20,11 @@ class IndexPresenter < BasePresenter
   end
 
   def render_attribute(resource, attribute_name)
-    if attribute_name == dashboard.title_attribute
-      link_to attribute_html(resource, attribute_name), show_path(resource)
-    else
-      attribute_html(resource, attribute_name)
-    end
+    attribute_html(resource, attribute_name)
+  end
+
+  def show_path(resource)
+    route(nil, resource_name, resource)
   end
 
   protected
@@ -33,9 +33,5 @@ class IndexPresenter < BasePresenter
 
   def attribute_html(resource, attribute_name)
     adapter(dashboard, resource, attribute_name).render_index
-  end
-
-  def show_path(resource)
-    route(nil, resource_name, resource)
   end
 end

--- a/lib/presenters/show_presenter.rb
+++ b/lib/presenters/show_presenter.rb
@@ -7,7 +7,7 @@ class ShowPresenter < BasePresenter
   end
 
   def page_title
-    resource.public_send(dashboard.title_attribute)
+    resource.to_s
   end
 
   def attributes

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -1,14 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CustomerDashboard do
-  describe "#title_attribute" do
-    it "is the name" do
-      dashboard = CustomerDashboard.new
-
-      expect(dashboard.title_attribute).to eq(:name)
-    end
-  end
-
   describe "#index_page_attributes" do
     it "includes the name and email" do
       dashboard = CustomerDashboard.new


### PR DESCRIPTION
`title_attribute` was being used to display a link to each resource
throughout the dashboards.

It was acting as a kind of unique identifier, but was restrictive in
several ways:
- The title_attribute had to correspond with a method on the model.
  It couldn't be computed from several methods.
- Only the current dashboard could look up the correct method for
  displaying a resource. This causes problems for relationships like the
  BelongsToAdapter and HasManyAdapter, which need to know how to display
  other objects.

Moving to #to_s is good in several ways:
- It makes representing an object super easy, with a single consistent
  method to call on each object.
- It encourages developers to write good `#to_s` methods on each of
  their objects.

And bad in several ways:
- If `#to_s` is not defined on a model, it defaults to the object's ID.
  This is not tied in any way to the database, so an object's identifier
  wouldn't be consistent throughout the dashboard.
- If the user hasn't defined `#to_s` on a model, it doesn't noisily fail
  by default. If we wanted to noisily fail, we'd have to check against
  the default `#to_s` string and raise an error.

To fix the bad effects, there's room for a separate gem that generates
better default `#to_s` methods for objects, by trying for attributes
like `name` or `title`, and defaulting to `id` if those are not present.
