### PR TITLE
Extract a base adapter with sensible defaults

### DIFF
--- a/lib/adapters/base_adapter.rb
+++ b/lib/adapters/base_adapter.rb
@@ -1,0 +1,21 @@
+class BaseAdapter
+  def initialize(data)
+    @data = data
+  end
+
+  def render_show
+    data
+  end
+
+  def render_index
+    data
+  end
+
+  def render_edit(form, attribute_name)
+    form.text_field(attribute_name)
+  end
+
+  protected
+
+  attr_reader :data
+end

--- a/lib/adapters/email_adapter.rb
+++ b/lib/adapters/email_adapter.rb
@@ -1,21 +1,8 @@
 require "action_controller/base"
+require_relative "base_adapter"
 
-class EmailAdapter
-  def initialize(data)
-    @data = data
-  end
-
-  def render_index
-    data
-  end
-
+class EmailAdapter < BaseAdapter
   def render_show
     ActionController::Base.helpers.mail_to(data)
   end
-
-  def render_edit(form, attribute_name)
-    form.text_field(attribute_name)
-  end
-
-  attr_reader :data
 end

--- a/lib/adapters/string_adapter.rb
+++ b/lib/adapters/string_adapter.rb
@@ -1,19 +1,4 @@
-class StringAdapter
-  def initialize(data)
-    @data = data
-  end
+require_relative "base_adapter"
 
-  def render_show
-    data
-  end
-
-  def render_index
-    data
-  end
-
-  def render_edit(form, attribute_name)
-    form.text_field(attribute_name)
-  end
-
-  attr_reader :data
+class StringAdapter < BaseAdapter
 end

--- a/lib/presenters/base_presenter.rb
+++ b/lib/presenters/base_presenter.rb
@@ -20,7 +20,7 @@ class BasePresenter
     adapter_name = dashboard.attribute_adapters[attribute_name]
     value = resource.public_send(attribute_name)
 
-    adapter_registry[adapter_name].new(value)
+    adapter_registry.fetch(adapter_name).new(value)
   end
 
   def adapter_registry


### PR DESCRIPTION
The default behavior is to display the data as a string on the index and
show pages, and render a text field on the form page.
