### PR TITLE
Highlight the current resource's sidebar link

### DIFF
--- a/app/assets/stylesheets/_sidebar.css.sass
+++ b/app/assets/stylesheets/_sidebar.css.sass
@@ -15,11 +15,12 @@ $sidebar-color: #2A3B4C
       height: 80%
   ul
     @include fill-parent
-  li
+  a
+    display: block
     padding: $gutter/2
     @include fill-parent
+    color: white
+    &.active
+      background-color: lighten($sidebar-color, 10%)
     &:hover
       background-color: lighten($sidebar-color, 20%)
-  a
-    color: white
-    display: block

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -53,6 +53,13 @@ class DashboardController < ApplicationController
 
   private
 
+  helper_method :link_class
+  def link_class(resource)
+    if params[:controller] == resource.to_s
+      :active
+    end
+  end
+
   def resource_class
     Object.const_get(resource_class_name)
   end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -3,7 +3,13 @@
     <%= image_tag "logo.svg" %>
   </div>
 
-  <li><%= link_to "Customers", customers_path %></li>
-  <li><%= link_to "Products", products_path %></li>
-  <li><%= link_to "Orders", orders_path %></li>
+  <% [:customers, :products, :orders].each do |resource| %>
+    <li>
+      <%= link_to(
+        resource.to_s.titleize,
+        polymorphic_path(resource),
+        class: link_class(resource)
+      ) %>
+    </li>
+  <% end %>
 </ul>

--- a/spec/features/sidebar_spec.rb
+++ b/spec/features/sidebar_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "sidebar" do
+  it "highlights the link to the current page's resource type" do
+    visit customers_path
+
+    active_link = find(".sidebar .active")
+
+    expect(active_link.text).to eq "Customers"
+  end
+end


### PR DESCRIPTION
https://trello.com/c/KCgSkWS0

Also, use `<a>` instead of `<li>` on sidebar

This makes it so the entire highlighted area responds to clicks.

Previously (when there was an `<a>` inside of a `<li>`)
the entire `<li>` was highlighted, but only the internal `<a>`
responded to clicks. 'Twas a bit misleading.
