### PR TITLE
Add a LineItem model and dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -91,7 +91,7 @@ class DashboardController < ApplicationController
   end
 
   def resource_class_name
-    resource_name.to_s.titleize
+    resource_name.to_s.camelcase
   end
 
   def instance_variable
@@ -102,11 +102,15 @@ class DashboardController < ApplicationController
     Rails.application.routes.url_helpers.public_send(:"#{resource_name}s_path")
   end
 
+  def resource_title
+    resource_class_name.titleize
+  end
+
   def notices
     {
-      created: "#{resource_class_name} was successfully created.",
-      updated: "#{resource_class_name} was successfully updated.",
-      destroyed: "#{resource_class_name} was successfully destroyed.",
+      created: "#{resource_title} was successfully created.",
+      updated: "#{resource_title} was successfully updated.",
+      destroyed: "#{resource_title} was successfully destroyed.",
     }
   end
 end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,0 +1,5 @@
+class LineItemsController < DashboardController
+  def resource_name
+    :line_item
+  end
+end

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -1,0 +1,36 @@
+require "base_dashboard"
+
+class LineItemDashboard < BaseDashboard
+  def index_page_attributes
+    attributes + [:total_price]
+  end
+
+  def show_page_attributes
+    attributes + [:total_price]
+  end
+
+  def form_attributes
+    attributes
+  end
+
+  def attribute_adapters
+    {
+      order: :belongs_to,
+      product: :belongs_to,
+      quantity: :string,
+      total_price: :string,
+      unit_price: :string,
+    }
+  end
+
+  private
+
+  def attributes
+    [
+      :order,
+      :product,
+      :quantity,
+      :unit_price,
+    ]
+  end
+end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,0 +1,17 @@
+class LineItem < ActiveRecord::Base
+  belongs_to :order
+  belongs_to :product
+
+  validates :product, presence: true
+  validates :order, presence: true
+  validates :unit_price, presence: true
+  validates :quantity, presence: true
+
+  def to_s
+    "Line Item #%04d" % id
+  end
+
+  def total_price
+    unit_price * quantity
+  end
+end

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag "logo.svg" %>
   </div>
 
-  <% [:customers, :products, :orders].each do |resource| %>
+  <% [:customers, :line_items, :orders, :products].each do |resource| %>
     <li>
       <%= link_to(
         resource.to_s.titleize,

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,7 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1><%= @presenter.resource_name.pluralize.titleize %></h1>
-<%= link_to "New #{@presenter.resource_name.downcase}", @presenter.new_path %>
+<%= link_to "New #{@presenter.resource_name.titleize.downcase}", @presenter.new_path %>
 
 <table>
   <thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :customers
+  resources :line_items
   resources :products
   resources :orders
 end

--- a/db/migrate/20150417044505_create_line_items.rb
+++ b/db/migrate/20150417044505_create_line_items.rb
@@ -1,0 +1,14 @@
+class CreateLineItems < ActiveRecord::Migration
+  def change
+    create_table :line_items do |t|
+      t.references :order, index: true
+      t.references :product, index: true
+      t.float :unit_price
+      t.integer :quantity
+
+      t.timestamps null: false
+    end
+    add_foreign_key :line_items, :orders
+    add_foreign_key :line_items, :products
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150411204433) do
+ActiveRecord::Schema.define(version: 20150417044505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,18 @@ ActiveRecord::Schema.define(version: 20150411204433) do
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
+  create_table "line_items", force: :cascade do |t|
+    t.integer  "order_id"
+    t.integer  "product_id"
+    t.float    "unit_price"
+    t.integer  "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "line_items", ["order_id"], name: "index_line_items_on_order_id", using: :btree
+  add_index "line_items", ["product_id"], name: "index_line_items_on_product_id", using: :btree
+
   create_table "orders", force: :cascade do |t|
     t.integer  "customer_id"
     t.string   "address_line_one"
@@ -61,5 +73,7 @@ ActiveRecord::Schema.define(version: 20150411204433) do
     t.datetime "updated_at",  null: false
   end
 
+  add_foreign_key "line_items", "orders"
+  add_foreign_key "line_items", "products"
   add_foreign_key "orders", "customers"
 end

--- a/lib/presenters/base_presenter.rb
+++ b/lib/presenters/base_presenter.rb
@@ -6,7 +6,7 @@ require "adapters/string_adapter"
 class BasePresenter
   def resource_name
     @resource_name ||=
-      dashboard.class.to_s.scan(/(.+)Dashboard/).first.first.downcase
+      dashboard.class.to_s.scan(/(.+)Dashboard/).first.first.underscore
   end
 
   protected

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,13 @@ FactoryGirl.define do
     email { name.downcase.gsub(" ", "_") + "@example.com" }
   end
 
+  factory :line_item do
+    order
+    product
+    unit_price 1.5
+    quantity 1
+  end
+
   factory :order do
     customer
     address_line_one "85 2nd St"

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "line item index page" do
+  it "displays line items' information" do
+    line_item = create(:line_item)
+
+    visit line_items_path
+
+    expect(page).to have_header("Line Items")
+    expect(page).to have_content(line_item.to_s)
+    expect(page).to have_content(line_item.product.to_s)
+  end
+
+  it "links to the line item show page" do
+    line_item = create(:line_item)
+
+    visit line_items_path
+    click_on line_item.to_s
+
+    expect(current_path).to eq(line_item_path(line_item))
+    expect(page).to have_content(line_item.to_s)
+    expect(page).to have_content(line_item.product.to_s)
+  end
+
+  it "links to the edit page" do
+    line_item = create(:line_item)
+
+    visit line_items_path
+    click_on "Edit"
+
+    expect(current_path).to eq(edit_line_item_path(line_item))
+  end
+
+  it "links to the new page" do
+    visit line_items_path
+    click_on("New line item")
+
+    expect(current_path).to eq(new_line_item_path)
+  end
+end

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe LineItem do
+  it { should validate_presence_of :product }
+  it { should validate_presence_of :order }
+  it { should validate_presence_of :unit_price }
+  it { should validate_presence_of :quantity }
+
+  describe "#total_price" do
+    it "is the product of the unit price and the quantity" do
+      item = build(:line_item, unit_price: 20, quantity: 2)
+
+      expect(item.total_price).to eq 40
+    end
+  end
+end


### PR DESCRIPTION
Setting up for https://trello.com/c/NygJOCUM - the `Order` model will soon
`have_many` `LineItems`.
- Add a computed method to the line item dashboard
  - `LineItem#total_price` is computed from `unit_price` and `quantity`
- Adjust controller, presenter, and view code to handle multi-word model
  names
