### PR TITLE
Implement Field::HasMany

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,11 +1,11 @@
 require "pages/form"
-require "pages/index"
+require "pages/table"
 require "pages/show"
 
 class DashboardController < ApplicationController
   def index
     @resources = resource_class.all
-    @page = Page::Index.new(dashboard)
+    @page = Page::Table.new(dashboard)
   end
 
   def show

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -6,10 +6,11 @@ class CustomerDashboard < BaseDashboard
       email: :email,
       lifetime_value: :string,
       name: :string,
+      orders: :has_many,
     }
   end
 
-  def index_page_attributes
+  def table_attributes
     attributes
   end
 
@@ -31,6 +32,7 @@ class CustomerDashboard < BaseDashboard
       :name,
       :email,
       :lifetime_value,
+      :orders,
     ]
   end
 end

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -1,7 +1,7 @@
 require "base_dashboard"
 
 class LineItemDashboard < BaseDashboard
-  def index_page_attributes
+  def table_attributes
     attributes + [:total_price]
   end
 

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -10,15 +10,17 @@ class OrderDashboard < BaseDashboard
       address_state: :string,
       address_zip: :string,
       customer: :belongs_to,
+      line_items: :has_many,
+      total_price: :string,
     }
   end
 
-  def index_page_attributes
+  def table_attributes
     attributes
   end
 
   def form_attributes
-    attributes - [:id]
+    attributes - [:id, :total_price]
   end
 
   def show_page_attributes
@@ -36,6 +38,8 @@ class OrderDashboard < BaseDashboard
       :address_state,
       :address_zip,
       :customer,
+      :line_items,
+      :total_price,
     ]
   end
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -10,7 +10,7 @@ class ProductDashboard < BaseDashboard
     }
   end
 
-  def index_page_attributes
+  def table_attributes
     attributes
   end
 

--- a/app/views/dashboard/_table.html.erb
+++ b/app/views/dashboard/_table.html.erb
@@ -1,0 +1,31 @@
+<table>
+  <thead>
+    <tr>
+      <th><%= table_presenter.resource_name.titleize %></th>
+
+      <% table_presenter.attribute_names.each do |attr_name| %>
+        <th><%= attr_name.to_s.titleize %></th>
+      <% end %>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr>
+        <td><%= link_to resource.to_s, resource %></td>
+
+        <% table_presenter.attributes_for(resource).each do |attribute| %>
+          <td><%= render attribute %></td>
+        <% end %>
+        <td><%= link_to t("administrate.actions.edit"), [:edit, resource] %></td>
+        <td><%= link_to(
+          t("administrate.actions.destroy"),
+          resource,
+          method: :delete,
+          data: { confirm: t("administrate.actions.confirm") }
+          ) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -4,29 +4,4 @@
 <%= link_to "New #{@page.resource_name.titleize.downcase}",
   [:new, @page.resource_name] %>
 
-<table>
-  <thead>
-    <tr>
-      <th><%= @page.resource_name.titleize %></th>
-
-      <% @page.attribute_names.each do |attr_name| %>
-        <th><%= attr_name.to_s.titleize %></th>
-      <% end %>
-      <th colspan="2"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @resources.each do |resource| %>
-      <tr>
-        <td><%= link_to resource.to_s, resource %></td>
-
-        <% @page.attributes_for(resource).each do |attribute| %>
-          <td><%= render attribute %></td>
-        <% end %>
-        <td><%= link_to 'Edit', [:edit, resource] %></td>
-        <td><%= link_to 'Destroy', resource, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render "table", table_presenter: @page, resources: @resources %>

--- a/app/views/fields/form/_has_many.html.erb
+++ b/app/views/fields/form/_has_many.html.erb
@@ -1,0 +1,1 @@
+Sorry, nested forms for has-many relationships are not yet supported.

--- a/app/views/fields/index/_has_many.html.erb
+++ b/app/views/fields/index/_has_many.html.erb
@@ -1,0 +1,1 @@
+<%= pluralize(has_many.data.count, has_many.attribute.to_s.humanize.downcase) %>

--- a/app/views/fields/show/_has_many.html.erb
+++ b/app/views/fields/show/_has_many.html.erb
@@ -1,0 +1,5 @@
+<%= render(
+  "table",
+  table_presenter: has_many.associated_table,
+  resources: has_many.data
+) %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,6 +5,10 @@ search:
     - "app/pages"
     - "app/views"
 
+data:
+  read:
+    - config/locales/administrate.%{locale}.yml
+
 ignore_unused:
   - activerecord.*
   - date.*

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -1,0 +1,6 @@
+en:
+  administrate:
+    actions:
+      edit: Edit
+      destroy: Destroy
+      confirm: Are you sure?

--- a/lib/base_dashboard.rb
+++ b/lib/base_dashboard.rb
@@ -1,5 +1,6 @@
 require "fields/belongs_to"
 require "fields/email"
+require "fields/has_many"
 require "fields/image"
 require "fields/string"
 
@@ -20,6 +21,7 @@ class BaseDashboard
     {
       belongs_to: Field::BelongsTo,
       email: Field::Email,
+      has_many: Field::HasMany,
       image: Field::Image,
       string: Field::String,
     }

--- a/lib/fields/has_many.rb
+++ b/lib/fields/has_many.rb
@@ -1,0 +1,20 @@
+require_relative "base"
+require "pages/table"
+
+module Field
+  class HasMany < Field::Base
+    def associated_table
+      Page::Table.new(associated_dashboard)
+    end
+
+    private
+
+    def associated_dashboard
+      Object.const_get("#{resource_class_name}Dashboard").new
+    end
+
+    def resource_class_name
+      attribute.to_s.singularize.camelcase
+    end
+  end
+end

--- a/lib/pages/base.rb
+++ b/lib/pages/base.rb
@@ -1,5 +1,9 @@
 module Page
   class Base
+    def initialize(dashboard)
+      @dashboard = dashboard
+    end
+
     def resource_name
       @resource_name ||=
         dashboard.class.to_s.scan(/(.+)Dashboard/).first.first.underscore
@@ -14,5 +18,9 @@ module Page
         field_class(attribute_name).
         new(attribute_name, value, page)
     end
+
+    protected
+
+    attr_reader :dashboard
   end
 end

--- a/lib/pages/form.rb
+++ b/lib/pages/form.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Page
   class Form < Page::Base
     def initialize(dashboard, resource)
-      @dashboard = dashboard
+      super(dashboard)
       @resource = resource
     end
 

--- a/lib/pages/show.rb
+++ b/lib/pages/show.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Page
   class Show < Page::Base
     def initialize(dashboard, resource)
-      @dashboard = dashboard
+      super(dashboard)
       @resource = resource
     end
 
@@ -18,9 +18,5 @@ module Page
         attribute_field(dashboard, resource, attr_name, :show)
       end
     end
-
-    protected
-
-    attr_reader :dashboard
   end
 end

--- a/lib/pages/table.rb
+++ b/lib/pages/table.rb
@@ -1,13 +1,9 @@
 require_relative "base"
 
 module Page
-  class Index < Page::Base
-    def initialize(dashboard)
-      @dashboard = dashboard
-    end
-
+  class Table < Page::Base
     def attribute_names
-      dashboard.index_page_attributes
+      dashboard.table_attributes
     end
 
     def attributes_for(resource)
@@ -16,8 +12,8 @@ module Page
       end
     end
 
-    protected
-
-    attr_reader :dashboard
+    def to_partial_path
+      "/dashboard/table"
+    end
   end
 end

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe CustomerDashboard do
-  describe "#index_page_attributes" do
+  describe "#table_attributes" do
     it "includes the name and email" do
       dashboard = CustomerDashboard.new
 
-      expect(dashboard.index_page_attributes).to include(:name)
-      expect(dashboard.index_page_attributes).to include(:email)
+      expect(dashboard.table_attributes).to include(:name)
+      expect(dashboard.table_attributes).to include(:email)
     end
   end
 

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+feature "order index page" do
+  scenario "displays line item information" do
+    line_item = create(:line_item)
+
+    visit order_path(line_item.order)
+
+    expect(page).to have_content(line_item.unit_price)
+    expect(page).to have_content(line_item.quantity)
+    expect(page).to have_content(line_item.total_price)
+    expect(page).to have_link(line_item.product.to_s)
+  end
+
+  scenario "links to line items" do
+    line_item = create(:line_item)
+
+    visit order_path(line_item.order)
+    click_on(line_item.to_s)
+
+    expect(page).to have_header(line_item.to_s)
+  end
+end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe "customer show page" do
     expect(page).to have_content(customer.email)
   end
 
+  it "displays each of the customer's orders" do
+    customer = create(:customer)
+    orders = create_pair(:order, customer: customer)
+    orders.map.with_index(1) do |order, index|
+      create(:line_item, order: order, unit_price: 10, quantity: index)
+    end
+
+    visit customer_path(customer)
+
+    orders.each do |order|
+      expect(page).to have_link(order.to_s)
+      expect(page).to have_content(order.total_price)
+    end
+  end
+
   it "link-ifies the email" do
     customer = create(:customer)
 

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "fields/has_many"
+
+describe Field::HasMany do
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      items = double
+      field = Field::HasMany.new(:items, items, page)
+
+      path = field.to_partial_path
+
+      expect(path).to eq("/fields/#{page}/has_many")
+    end
+  end
+
+  describe "#associated_table" do
+    it "returns an index page for the dashboard of the associated attribute" do
+      orders = []
+      field = Field::HasMany.new(:orders, orders, :show)
+
+      page = field.associated_table
+
+      expect(page).to be_instance_of(Page::Table)
+    end
+  end
+end

--- a/spec/lib/pages/index_spec.rb
+++ b/spec/lib/pages/index_spec.rb
@@ -1,4 +1,0 @@
-require "pages/index"
-
-describe Page::Index do
-end

--- a/spec/lib/pages/table_spec.rb
+++ b/spec/lib/pages/table_spec.rb
@@ -1,0 +1,4 @@
+require "pages/table"
+
+describe Page::Table do
+end


### PR DESCRIPTION
Implement Field::HasMany with a table on show page
https://trello.com/c/NygJOCUM
https://trello.com/c/TERo00zt

On the `index` page, `has_many` relationships are displayed by simple
text telling how many associated objects there are.

On the `show` page, `has_many` relationships are displayed by an HTML
table, identical to the one that appears on the associated object's
`index` page.

On the `form` pages, `has_many` relationships show a message saying the
functionality is not yet implemented.
- Extracted the common table HTMl into a partial
- Extract strings to I18n
- Rename index_page_attributes -> table_attributes
- Rename `Page::Index` -> `Page::Table`
  We're now using the class to display tables both on the index page
  and on the other resource's show pages through the HasMany adapter.

Follow-up tasks:
- Implement forms for `has_many` relationships
  (needs discussion: https://trello.com/c/gjsGaU5W).
