### PR TITLE
Use partials, not methods, to display attributes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/views/adapters/form/_belongs_to.html.erb
+++ b/app/views/adapters/form/_belongs_to.html.erb
@@ -1,0 +1,7 @@
+<%= f.label belongs_to.permitted_attribute %>
+<%= f.collection_select(
+  belongs_to.permitted_attribute,
+  belongs_to.candidate_records,
+  :id,
+  :to_s
+) %>

--- a/app/views/adapters/form/_email.html.erb
+++ b/app/views/adapters/form/_email.html.erb
@@ -1,0 +1,2 @@
+<%= f.label email.attribute %>
+<%= f.email_field email.attribute %>

--- a/app/views/adapters/form/_image.html.erb
+++ b/app/views/adapters/form/_image.html.erb
@@ -1,0 +1,2 @@
+<%= f.label image.attribute %>
+<%= f.text_field image.attribute %>

--- a/app/views/adapters/form/_string.html.erb
+++ b/app/views/adapters/form/_string.html.erb
@@ -1,0 +1,2 @@
+<%= f.label string.attribute %>
+<%= f.text_field string.attribute %>

--- a/app/views/adapters/index/_belongs_to.html.erb
+++ b/app/views/adapters/index/_belongs_to.html.erb
@@ -1,0 +1,1 @@
+<%= link_to belongs_to.data, belongs_to.data %>

--- a/app/views/adapters/index/_email.html.erb
+++ b/app/views/adapters/index/_email.html.erb
@@ -1,0 +1,1 @@
+<%= mail_to email.data %>

--- a/app/views/adapters/index/_image.html.erb
+++ b/app/views/adapters/index/_image.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag image.data %>

--- a/app/views/adapters/index/_string.html.erb
+++ b/app/views/adapters/index/_string.html.erb
@@ -1,0 +1,1 @@
+<%= string.data %>

--- a/app/views/adapters/show/_belongs_to.html.erb
+++ b/app/views/adapters/show/_belongs_to.html.erb
@@ -1,0 +1,1 @@
+<%= link_to belongs_to.data, belongs_to.data %>

--- a/app/views/adapters/show/_email.html.erb
+++ b/app/views/adapters/show/_email.html.erb
@@ -1,0 +1,1 @@
+<%= mail_to email.data %>

--- a/app/views/adapters/show/_image.html.erb
+++ b/app/views/adapters/show/_image.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag image.data %>

--- a/app/views/adapters/show/_string.html.erb
+++ b/app/views/adapters/show/_string.html.erb
@@ -1,0 +1,1 @@
+<%= string.data %>

--- a/app/views/dashboard/_form.html.erb
+++ b/app/views/dashboard/_form.html.erb
@@ -15,10 +15,9 @@
   <% end %>
 
   <div class="form-inputs">
-    <% @presenter.attribute_names.each do |attr_name| -%>
+    <% @presenter.attributes.each do |attribute| -%>
       <div class="field">
-        <%= @presenter.render_form_label(f, attr_name) %><br>
-        <%= @presenter.render_form_field(f, attr_name) %>
+        <%= render attribute, f: f %>
       </div>
     <% end -%>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -20,8 +20,8 @@
       <tr>
         <td><%= link_to resource.to_s, @presenter.show_path(resource) %></td>
 
-        <% @presenter.attribute_names.each do |attr_name| %>
-          <td><%= @presenter.render_attribute(resource, attr_name) %></td>
+        <% @presenter.attributes_for(resource).each do |attribute| %>
+          <td><%= render attribute %></td>
         <% end %>
         <td><%= link_to 'Edit', @presenter.edit_path(resource) %></td>
         <td><%= link_to 'Destroy', resource, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -5,8 +5,8 @@
 <h1><%= @presenter.page_title %></h1>
 
 <dl>
-  <% @presenter.attributes.each do |attr_name, attr_value| %>
-    <dt><%= attr_name.to_s.titleize %></dt>
-    <dd><%= attr_value %></dd>
+  <% @presenter.attributes.each do |attribute| %>
+    <dt><%= attribute.name.titleize %></dt>
+    <dd><%= render attribute %></dd>
   <% end %>
 </dl>

--- a/lib/adapters/base_adapter.rb
+++ b/lib/adapters/base_adapter.rb
@@ -1,29 +1,21 @@
 class BaseAdapter
-  def initialize(data)
+  def initialize(attribute, data, page)
+    @attribute = attribute
     @data = data
-  end
-
-  def render_show
-    data
-  end
-
-  def render_index
-    data
-  end
-
-  def render_form_field(form, attribute)
-    form.text_field(attribute)
-  end
-
-  def render_form_label(form, attribute)
-    form.label attribute
+    @page = page
   end
 
   def self.permitted_attribute(attr)
     attr
   end
 
-  protected
+  def name
+    attribute.to_s
+  end
 
-  attr_reader :data
+  def to_partial_path
+    "/adapters/#{page}/#{adapter_name}"
+  end
+
+  attr_reader :attribute, :data, :page
 end

--- a/lib/adapters/belongs_to_adapter.rb
+++ b/lib/adapters/belongs_to_adapter.rb
@@ -1,38 +1,23 @@
 require_relative "base_adapter"
-require "action_controller/base"
 
 class BelongsToAdapter < BaseAdapter
-  include Rails.application.routes.url_helpers
-
-  def render_show
-    ActionController::Base.helpers.link_to data.to_s, url_to_data
-  end
-
-  def render_index
-    render_show
-  end
-
-  def render_form_field(form, attribute)
-    options = attribute_class(attribute).all.map do |option|
-      [option.to_s, option.id]
-    end
-
-    form.select("#{attribute}_id", options)
-  end
-
-  def render_form_label(form, attribute)
-    form.label "#{attribute}_id"
-  end
-
   def self.permitted_attribute(attr)
     :"#{attr}_id"
   end
 
-  private
-
-  def attribute_class(attribute)
-    Object.const_get(attribute.to_s.camelcase)
+  def adapter_name
+    :belongs_to
   end
+
+  def permitted_attribute
+    self.class.permitted_attribute(attribute)
+  end
+
+  def candidate_records
+    Object.const_get(attribute.to_s.camelcase).all
+  end
+
+  private
 
   def url_to_data
     Rails.application.routes.url_helpers.public_send(data_path_helper, data)

--- a/lib/adapters/email_adapter.rb
+++ b/lib/adapters/email_adapter.rb
@@ -2,7 +2,7 @@ require "action_controller/base"
 require_relative "base_adapter"
 
 class EmailAdapter < BaseAdapter
-  def render_show
-    ActionController::Base.helpers.mail_to(data)
+  def adapter_name
+    :email
   end
 end

--- a/lib/adapters/image_adapter.rb
+++ b/lib/adapters/image_adapter.rb
@@ -1,11 +1,7 @@
 require_relative "./base_adapter"
 
 class ImageAdapter < BaseAdapter
-  def render_index
-    render_show
-  end
-
-  def render_show
-    ActionController::Base.helpers.image_tag(data)
+  def adapter_name
+    :image
   end
 end

--- a/lib/adapters/string_adapter.rb
+++ b/lib/adapters/string_adapter.rb
@@ -1,4 +1,7 @@
 require_relative "base_adapter"
 
 class StringAdapter < BaseAdapter
+  def adapter_name
+    :string
+  end
 end

--- a/lib/base_dashboard.rb
+++ b/lib/base_dashboard.rb
@@ -17,6 +17,7 @@ class BaseDashboard
     {
       belongs_to: BelongsToAdapter,
       email: EmailAdapter,
+      image: ImageAdapter,
       string: StringAdapter,
     }
   end

--- a/lib/presenters/base_presenter.rb
+++ b/lib/presenters/base_presenter.rb
@@ -18,11 +18,11 @@ class BasePresenter
     Rails.application.routes.url_helpers.public_send(*arguments)
   end
 
-  def adapter(dashboard, resource, attribute_name)
+  def adapter(dashboard, resource, attribute_name, page)
     adapter_name = dashboard.attribute_adapters[attribute_name]
     value = resource.public_send(attribute_name)
 
-    adapter_registry.fetch(adapter_name).new(value)
+    adapter_registry.fetch(adapter_name).new(attribute_name, value, page)
   end
 
   def adapter_registry

--- a/lib/presenters/form_presenter.rb
+++ b/lib/presenters/form_presenter.rb
@@ -8,8 +8,10 @@ class FormPresenter < BasePresenter
 
   attr_reader :resource
 
-  def attribute_names
-    dashboard.form_attributes
+  def attributes
+    dashboard.form_attributes.map do |attribute|
+      adapter(dashboard, resource, attribute, :form)
+    end
   end
 
   def page_title
@@ -18,14 +20,6 @@ class FormPresenter < BasePresenter
 
   def index_path
     route(nil, resource_name.pluralize)
-  end
-
-  def render_form_label(form, attribute)
-    adapter(dashboard, resource, attribute).render_form_label(form, attribute)
-  end
-
-  def render_form_field(form, attribute)
-    adapter(dashboard, resource, attribute).render_form_field(form, attribute)
   end
 
   protected

--- a/lib/presenters/index_presenter.rb
+++ b/lib/presenters/index_presenter.rb
@@ -11,16 +11,18 @@ class IndexPresenter < BasePresenter
     dashboard.index_page_attributes
   end
 
+  def attributes_for(resource)
+    attribute_names.map do |attr_name|
+      adapter(dashboard, resource, attr_name, :index)
+    end
+  end
+
   def edit_path(resource)
     route(:edit, resource_name, resource)
   end
 
   def new_path
     route(:new, resource_name)
-  end
-
-  def render_attribute(resource, attribute_name)
-    attribute_html(resource, attribute_name)
   end
 
   def show_path(resource)
@@ -30,8 +32,4 @@ class IndexPresenter < BasePresenter
   protected
 
   attr_reader :dashboard
-
-  def attribute_html(resource, attribute_name)
-    adapter(dashboard, resource, attribute_name).render_index
-  end
 end

--- a/lib/presenters/show_presenter.rb
+++ b/lib/presenters/show_presenter.rb
@@ -11,15 +11,9 @@ class ShowPresenter < BasePresenter
   end
 
   def attributes
-    Hash[
-      dashboard.show_page_attributes.map do |attr_name|
-        [attr_name, render_attribute(attr_name)]
-      end
-    ]
-  end
-
-  def render_attribute(attribute_name)
-    adapter(dashboard, resource, attribute_name).render_show
+    dashboard.show_page_attributes.map do |attr_name|
+      adapter(dashboard, resource, attr_name, :show)
+    end
   end
 
   def edit_path

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -14,7 +14,7 @@ describe "order index page" do
     order = create(:order)
 
     visit orders_path
-    click_on(order.customer.name)
+    click_on(order.customer.to_s)
 
     expect(page).to have_header(order.customer.name)
   end

--- a/spec/lib/adapters/belongs_to_adapter_spec.rb
+++ b/spec/lib/adapters/belongs_to_adapter_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+require "adapters/belongs_to_adapter"
+
+describe BelongsToAdapter do
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      owner = double
+      adapter = BelongsToAdapter.new(:owner, owner, page)
+
+      path = adapter.to_partial_path
+
+      expect(path).to eq("/adapters/#{page}/belongs_to")
+    end
+  end
+end

--- a/spec/lib/adapters/email_adapter_spec.rb
+++ b/spec/lib/adapters/email_adapter_spec.rb
@@ -1,33 +1,15 @@
 require "spec_helper"
 require "adapters/email_adapter"
 
-RSpec.describe EmailAdapter do
-  it "renders the email with a link for the show page" do
-    email = "hello@example.com"
+describe EmailAdapter do
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      adapter = EmailAdapter.new(:email, "foo@example.com", page)
 
-    adapter = EmailAdapter.new(email)
-    rendered = adapter.render_show
+      path = adapter.to_partial_path
 
-    expect(rendered).to eq "<a href=\"mailto:#{email}\">#{email}</a>"
-  end
-
-  it "renders the email for the index page" do
-    email = "hello@example.com"
-
-    adapter = EmailAdapter.new(email)
-    rendered = adapter.render_index
-
-    expect(rendered).to eq email
-  end
-
-  it "renders an input form for the edit page" do
-    email = "hello@example.com"
-    form_object_double = double(text_field: email)
-
-    adapter = EmailAdapter.new(email)
-    rendered = adapter.render_form_field(form_object_double, :attribute)
-
-    expect(rendered).to eq email
-    expect(form_object_double).to have_received(:text_field).with(:attribute)
+      expect(path).to eq("/adapters/#{page}/email")
+    end
   end
 end

--- a/spec/lib/adapters/image_adapter_spec.rb
+++ b/spec/lib/adapters/image_adapter_spec.rb
@@ -1,41 +1,15 @@
 require "spec_helper"
 require "adapters/image_adapter"
 
-RSpec.describe ImageAdapter do
-  describe "#render_show" do
-    it "renders an image tag" do
-      image = "http://placekitten.com/200/200"
-      alt = "200"
+describe ImageAdapter do
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      adapter = ImageAdapter.new(:image, "http://placekitten.com/200/300", page)
 
-      adapter = ImageAdapter.new(image)
-      rendered = adapter.render_show
+      path = adapter.to_partial_path
 
-      expect(rendered).to eq "<img src=\"#{image}\" alt=\"#{alt}\" />"
-    end
-  end
-
-  describe "#render_index" do
-    it "renders an image tag" do
-      image = "http://placekitten.com/200/200"
-      alt = "200"
-
-      adapter = ImageAdapter.new(image)
-      rendered = adapter.render_index
-
-      expect(rendered).to eq "<img src=\"#{image}\" alt=\"#{alt}\" />"
-    end
-  end
-
-  describe "#render_form" do
-    it "renders a text field" do
-      image = "http://placekitten.com/200/200"
-      form_object_double = double(text_field: image)
-
-      adapter = ImageAdapter.new(image)
-      rendered = adapter.render_form_field(form_object_double, :attribute)
-
-      expect(rendered).to eq image
-      expect(form_object_double).to have_received(:text_field).with(:attribute)
+      expect(path).to eq("/adapters/#{page}/image")
     end
   end
 end

--- a/spec/lib/adapters/string_adapter_spec.rb
+++ b/spec/lib/adapters/string_adapter_spec.rb
@@ -1,33 +1,15 @@
 require "spec_helper"
 require "adapters/string_adapter"
 
-RSpec.describe StringAdapter do
-  it "renders the string for the show page" do
-    string = "hello"
+describe StringAdapter do
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      adapter = StringAdapter.new(:string, "hello", page)
 
-    adapter = StringAdapter.new(string)
-    rendered = adapter.render_show
+      path = adapter.to_partial_path
 
-    expect(rendered).to eq string
-  end
-
-  it "renders the string for the index page" do
-    string = "hello"
-
-    adapter = StringAdapter.new(string)
-    rendered = adapter.render_index
-
-    expect(rendered).to eq string
-  end
-
-  it "renders an input form for the edit page" do
-    string = "hello"
-    form_object_double = double(text_field: string)
-
-    adapter = StringAdapter.new(string)
-    rendered = adapter.render_form_field(form_object_double, :attribute)
-
-    expect(rendered).to eq string
-    expect(form_object_double).to have_received(:text_field).with(:attribute)
+      expect(path).to eq("/adapters/#{page}/string")
+    end
   end
 end

--- a/spec/lib/presenters/form_presenter_spec.rb
+++ b/spec/lib/presenters/form_presenter_spec.rb
@@ -11,18 +11,6 @@ RSpec.describe FormPresenter do
     end
   end
 
-  describe "#attribute_names" do
-    it "returns attributes defined by the dashboard" do
-      customer = build(:customer, name: "Worf")
-      presenter = FormPresenter.new(CustomerDashboard.new, customer)
-
-      expect(presenter.attribute_names).to eq([
-        :name,
-        :email,
-      ])
-    end
-  end
-
   describe "#index_path" do
     it "returns the index path" do
       customer = Customer.new

--- a/spec/lib/presenters/show_presenter_spec.rb
+++ b/spec/lib/presenters/show_presenter_spec.rb
@@ -3,36 +3,12 @@ require "presenters/show_presenter"
 
 RSpec.describe ShowPresenter do
   describe "#page_title" do
-    it "is the resource's key attribute" do
-      customer = build(:customer, name: "Worf")
+    it "is the stringified resource" do
+      customer = build(:customer)
+      allow(customer).to receive(:to_s).and_return("Worf")
       presenter = ShowPresenter.new(CustomerDashboard.new, customer)
 
       expect(presenter.page_title).to eq("Worf")
-    end
-  end
-
-  describe "#attributes" do
-    it "returns attributes defined by the dashboard" do
-      customer = build(:customer, name: "Worf")
-      allow(customer).to receive(:lifetime_value).and_return(10)
-      presenter = ShowPresenter.new(CustomerDashboard.new, customer)
-
-      expect(presenter.attributes).to eq(
-        email: EmailAdapter.new(customer.email).render_show,
-        lifetime_value: customer.lifetime_value,
-      )
-    end
-  end
-
-  describe "#render_attribute" do
-    it "renders the attribute" do
-      email = "worf@enterprise.uss"
-      customer = build(:customer, email: email)
-      presenter = ShowPresenter.new(CustomerDashboard.new, customer)
-
-      rendered = presenter.render_attribute(:email)
-
-      expect(rendered).to eq(EmailAdapter.new(email).render_show)
     end
   end
 


### PR DESCRIPTION
Extract the following methods from all adapter classes:
- #render_show
- #render_index
- #render_form_label
- #render_form_field

And add a `_show`, `_index`, and `_form` partial for each adapter.
The partials live in `app/views/adapters/(adapter_name)`.

Inspired by https://robots.thoughtbot.com/rendering-collections-in-rails
and discussion on https://github.com/thoughtbot/administrate-demo/pull/16
