### PR TITLE
Create a dashbard generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "ammeter"
   gem "capybara-webkit", ">= 1.2.0"
   gem "database_cleaner"
   gem "formulaic"

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -3,10 +3,12 @@ require "base_dashboard"
 class CustomerDashboard < BaseDashboard
   def attribute_types
     {
+      created_at: :datetime,
       email: :email,
       lifetime_value: :string,
       name: :string,
       orders: :has_many,
+      updated_at: :datetime,
     }
   end
 
@@ -33,6 +35,8 @@ class CustomerDashboard < BaseDashboard
       :email,
       :lifetime_value,
       :orders,
+      :created_at,
+      :updated_at,
     ]
   end
 end

--- a/lib/base_dashboard.rb
+++ b/lib/base_dashboard.rb
@@ -20,9 +20,11 @@ class BaseDashboard
   def field_registry
     {
       belongs_to: Field::BelongsTo,
+      datetime: Field::String,
       email: Field::Email,
       has_many: Field::HasMany,
       image: Field::Image,
+      integer: Field::String,
       string: Field::String,
     }
   end

--- a/lib/generators/dashboard/USAGE
+++ b/lib/generators/dashboard/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generates a Dashboard object for a model,
+    pulling the attributes from database columns.
+
+Example:
+    rails generate dashboard FooBar
+
+    This will create:
+        app/dashboards/foo_bar_dashboard.rb

--- a/lib/generators/dashboard/dashboard_generator.rb
+++ b/lib/generators/dashboard/dashboard_generator.rb
@@ -1,0 +1,34 @@
+class DashboardGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("../templates", __FILE__)
+
+  def copy_dashboard_file
+    template "dashboard.rb.erb", "app/dashboards/#{file_name}_dashboard.rb"
+  end
+
+  private
+
+  def attributes
+    klass.attribute_names + klass.reflections.keys
+  end
+
+  def field_type(attribute)
+    klass.type_for_attribute(attribute).type ||
+      association_type(attribute)
+  end
+
+  def association_type(attribute)
+    reflection = klass.reflections[attribute.to_s]
+    if reflection.collection?
+      :has_many
+    elsif reflection.belongs_to?
+      :belongs_to
+    else
+      throw "Unknown association type: #{reflection.inspect}\n" +
+        "Please open an issue on the Administrate repo."
+    end
+  end
+
+  def klass
+    @klass ||= Object.const_get(class_name)
+  end
+end

--- a/lib/generators/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/dashboard/templates/dashboard.rb.erb
@@ -1,0 +1,50 @@
+require "base_dashboard"
+
+class <%= class_name %>Dashboard < BaseDashboard
+
+  # This method returns a hash
+  # that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  def attribute_types
+    {<% attributes.each do |attr| %>
+      <%= attr %>: :<%= field_type(attr) %>,<% end %>
+    }
+  end
+
+  # This method returns an array of attributes
+  # that will be displayed on the model's index page.
+  def index_page_attributes
+    attributes
+  end
+
+  # This method returns an array of attributes
+  # that will be displayed on the model's show page
+  def show_page_attributes
+    attributes
+  end
+
+  # This method returns an array of attributes
+  # that will be displayed on the model's form pages (`new` and `edit`)
+  def form_attributes
+    attributes - read_only_attributes
+  end
+
+  private
+
+  def attributes
+    [<% attributes.each do |attribute| %>
+      :<%= attribute %>,<% end %>
+    ]
+  end
+
+  def read_only_attributes
+    [
+      :id,
+      :created_at,
+      :updated_at,
+    ]
+  end
+end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "generators/dashboard/dashboard_generator"
+
+describe DashboardGenerator, :generator do
+  it "has valid syntax" do
+    dashboard = file("app/dashboards/customer_dashboard.rb")
+
+    run_generator ["customer"]
+
+    expect(dashboard).to exist
+    expect(dashboard).to have_correct_syntax
+  end
+
+  it "includes standard model attributes" do
+    dashboard = file("app/dashboards/customer_dashboard.rb")
+
+    run_generator ["customer"]
+
+    expect(dashboard).to contain("id: :integer,")
+    expect(dashboard).to contain("created_at: :datetime,")
+    expect(dashboard).to contain("updated_at: :datetime,")
+  end
+
+  it "includes user-defined database columns" do
+    dashboard = file("app/dashboards/customer_dashboard.rb")
+
+    run_generator ["customer"]
+
+    expect(dashboard).to contain("name: :string,")
+    expect(dashboard).to contain("email: :string,")
+  end
+
+  it "includes has_many relationships" do
+    dashboard = file("app/dashboards/customer_dashboard.rb")
+
+    run_generator ["customer"]
+
+    expect(dashboard).to contain("orders: :has_many")
+  end
+
+  it "includes belongs_to relationships" do
+    dashboard = file("app/dashboards/order_dashboard.rb")
+
+    run_generator ["order"]
+
+    expect(dashboard).to contain("customer: :belongs_to")
+  end
+end


### PR DESCRIPTION
The generator pulls column names and types from the database,
using the methods `#column_names` and `column_types`.
- Fill in missing mappings to `BaseDashboard#field_registry`.

References:
http://edgeguides.rubyonrails.org/generators.html
https://github.com/ryanb/nifty-generators

When the user runs `rails generate dashboard order`,
they get a file `app/dashboards/order_dashboard.rb` with the contents:

``` ruby
require "base_dashboard"

class OrderDashboard < BaseDashboard

  # This method returns a hash
  # that describes the type of each of the model's fields.
  #
  # Each different type represents an Administrate::Field object,
  # which determines how the attribute is displayed
  # on pages throughout the dashboard.
  def attribute_types
    {
      id: :integer,
      customer_id: :integer,
      address_line_one: :string,
      address_line_two: :string,
      address_city: :string,
      address_state: :string,
      address_zip: :string,
      created_at: :datetime,
      updated_at: :datetime,
      customer: :belongs_to,
      line_items: :has_many,
    }
  end

  # This method returns an array of attributes
  # that will be displayed on the model's index page.
  def index_page_attributes
    attributes
  end

  # This method returns an array of attributes
  # that will be displayed on the model's show page
  def show_page_attributes
    attributes
  end

  # This method returns an array of attributes
  # that will be displayed on the model's form pages (`new` and `edit`)
  def form_attributes
    attributes - read_only_attributes
  end

  private

  def attributes
    [
      :id,
      :customer_id,
      :address_line_one,
      :address_line_two,
      :address_city,
      :address_state,
      :address_zip,
      :created_at,
      :updated_at,
      :customer,
      :line_items,
    ]
  end

  def read_only_attributes
    [
      :id,
      :created_at,
      :updated_at,
    ]
  end
end
```

https://trello.com/c/My9ldlzZ
