### PR TITLE
Move Rack::Timeout to production & staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "neat", "~> 1.7.0"
 gem "newrelic_rpm"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
-gem "rack-timeout"
 gem "rails", "4.2.0"
 gem "recipient_interceptor"
 gem "refills"
@@ -54,5 +53,6 @@ group :test do
 end
 
 group :staging, :production do
+  gem "rack-timeout"
   gem "rails_stdout_logging"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,3 +77,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end
+
+Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i


### PR DESCRIPTION
This will help us avoid occasional timeouts during CI testing

See https://github.com/thoughtbot/suspenders/pull/542
