### PR TITLE
Remove route helpers

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -50,7 +50,8 @@ class DashboardController < ApplicationController
     set_resource(resource_class.find(params[:id]))
 
     resource.destroy
-    redirect_to index_url, notice: notices[:destroyed]
+    flash[:notice] = notices[:destroyed]
+    redirect_to action: :index
   end
 
   private
@@ -96,10 +97,6 @@ class DashboardController < ApplicationController
 
   def instance_variable
     "@#{resource_name}"
-  end
-
-  def index_url
-    Rails.application.routes.url_helpers.public_send(:"#{resource_name}s_path")
   end
 
   def resource_title

--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -7,7 +7,7 @@
     <li>
       <%= link_to(
         resource.to_s.titleize,
-        polymorphic_path(resource),
+        resource,
         class: link_class(resource)
       ) %>
     </li>

--- a/app/views/dashboard/edit.html.erb
+++ b/app/views/dashboard/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form' %>
 
 <%= link_to 'Show', @page.resource %> |
-<%= link_to 'Back', @page.index_path %>
+<%= link_to 'Back', @page.resource_name.pluralize %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,7 +1,8 @@
 <p id="notice"><%= notice %></p>
 
 <h1><%= @page.resource_name.pluralize.titleize %></h1>
-<%= link_to "New #{@page.resource_name.titleize.downcase}", @page.new_path %>
+<%= link_to "New #{@page.resource_name.titleize.downcase}",
+  [:new, @page.resource_name] %>
 
 <table>
   <thead>
@@ -18,12 +19,12 @@
   <tbody>
     <% @resources.each do |resource| %>
       <tr>
-        <td><%= link_to resource.to_s, @page.show_path(resource) %></td>
+        <td><%= link_to resource.to_s, resource %></td>
 
         <% @page.attributes_for(resource).each do |attribute| %>
           <td><%= render attribute %></td>
         <% end %>
-        <td><%= link_to 'Edit', @page.edit_path(resource) %></td>
+        <td><%= link_to 'Edit', [:edit, resource] %></td>
         <td><%= link_to 'Destroy', resource, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>

--- a/app/views/dashboard/new.html.erb
+++ b/app/views/dashboard/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form' %>
 
-<%= link_to 'Back', @page.index_path %>
+<%= link_to 'Back', @page.resource_name.pluralize %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<%= link_to 'Edit', @page.edit_path %>
+<%= link_to 'Edit', [:edit, @page.resource] %>
 
 <h1><%= @page.page_title %></h1>
 

--- a/lib/fields/belongs_to.rb
+++ b/lib/fields/belongs_to.rb
@@ -13,15 +13,5 @@ module Field
     def candidate_records
       Object.const_get(attribute.to_s.camelcase).all
     end
-
-    private
-
-    def url_to_data
-      Rails.application.routes.url_helpers.public_send(data_path_helper, data)
-    end
-
-    def data_path_helper
-      "#{data.class.to_s.underscore}_path"
-    end
   end
 end

--- a/lib/pages/base.rb
+++ b/lib/pages/base.rb
@@ -7,13 +7,6 @@ module Page
 
     protected
 
-    def route(prefix, resource_name, resource = nil)
-      path_helper = [prefix, resource_name, "path"].compact.join("_")
-      arguments = [path_helper, resource].compact
-
-      Rails.application.routes.url_helpers.public_send(*arguments)
-    end
-
     def attribute_field(dashboard, resource, attribute_name, page)
       value = resource.public_send(attribute_name)
 

--- a/lib/pages/form.rb
+++ b/lib/pages/form.rb
@@ -19,10 +19,6 @@ module Page
       resource.to_s
     end
 
-    def index_path
-      route(nil, resource_name.pluralize)
-    end
-
     protected
 
     attr_reader :dashboard

--- a/lib/pages/index.rb
+++ b/lib/pages/index.rb
@@ -16,18 +16,6 @@ module Page
       end
     end
 
-    def edit_path(resource)
-      route(:edit, resource_name, resource)
-    end
-
-    def new_path
-      route(:new, resource_name)
-    end
-
-    def show_path(resource)
-      route(nil, resource_name, resource)
-    end
-
     protected
 
     attr_reader :dashboard

--- a/lib/pages/show.rb
+++ b/lib/pages/show.rb
@@ -7,6 +7,8 @@ module Page
       @resource = resource
     end
 
+    attr_reader :resource
+
     def page_title
       resource.to_s
     end
@@ -17,12 +19,8 @@ module Page
       end
     end
 
-    def edit_path
-      route(:edit, resource_name, resource)
-    end
-
     protected
 
-    attr_reader :dashboard, :resource
+    attr_reader :dashboard
   end
 end

--- a/spec/lib/pages/form_spec.rb
+++ b/spec/lib/pages/form_spec.rb
@@ -9,13 +9,4 @@ describe Page::Form do
       expect(page.page_title).to eq("Worf")
     end
   end
-
-  describe "#index_path" do
-    it "returns the index path" do
-      customer = Customer.new
-      page = Page::Form.new(CustomerDashboard.new, customer)
-
-      expect(page.index_path).to eq("/customers")
-    end
-  end
 end

--- a/spec/lib/pages/index_spec.rb
+++ b/spec/lib/pages/index_spec.rb
@@ -1,22 +1,4 @@
 require "pages/index"
 
 describe Page::Index do
-  describe "#edit_path" do
-    it "returns the edit path for a resource" do
-      customer = double(to_param: "1")
-      page = Page::Index.new(CustomerDashboard.new)
-
-      edit_path = page.edit_path(customer)
-
-      expect(edit_path).to eq("/customers/#{customer.to_param}/edit")
-    end
-  end
-
-  describe "#new_path" do
-    it "returns the new path for a model" do
-      page = Page::Index.new(CustomerDashboard.new)
-
-      expect(page.new_path).to eq("/customers/new")
-    end
-  end
 end

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -9,15 +9,4 @@ describe Page::Show do
       expect(page.page_title).to eq("Worf")
     end
   end
-
-  describe "#edit_path" do
-    it "returns the edit path for the displayed resource" do
-      customer = double(to_param: "1")
-      page = Page::Show.new(CustomerDashboard.new, customer)
-
-      edit_path = page.edit_path
-
-      expect(edit_path).to eq("/customers/#{customer.to_param}/edit")
-    end
-  end
 end


### PR DESCRIPTION
Since we started rendering attributes in Rails templates, we have access to `link_to`, which handles all of the routing logic for us.
