### PR TITLE
Don't require developers to define resource controllers

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -1,5 +1,2 @@
 class CustomersController < DashboardController
-  def resource_name
-    :customer
-  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -58,7 +58,7 @@ class DashboardController < ApplicationController
 
   helper_method :link_class
   def link_class(resource)
-    if params[:controller] == resource.to_s
+    if resource_name.to_s.pluralize == resource.to_s
       :active
     end
   end
@@ -109,5 +109,9 @@ class DashboardController < ApplicationController
       updated: "#{resource_title} was successfully updated.",
       destroyed: "#{resource_title} was successfully destroyed.",
     }
+  end
+
+  def resource_name
+    controller_name.singularize.to_sym
   end
 end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,5 +1,2 @@
 class LineItemsController < DashboardController
-  def resource_name
-    :line_item
-  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,2 @@
 class OrdersController < DashboardController
-  def resource_name
-    :order
-  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,2 @@
 class ProductsController < DashboardController
-  def resource_name
-    :product
-  end
 end


### PR DESCRIPTION
All of the controller logic for displaying resources lives in [`DashboardController`](https://github.com/thoughtbot/administrate-demo/blob/master/app/controllers/dashboard_controller.rb).

Before this PR, in order to set up the routes for a resource, developers had to create empty `DashboardController` subclasses that looked like this:

``` ruby
class CustomersController < DashboardController
end
```

Instead, this PR overrides `Object.const_missing` to automagically define missing `...Controller` classes as subclasses of `DashboardController`. That way, developers only need to create `DashboardController` subclasses if they want to override the controller's actions.

This solution requires overriding `Object.const_get`, which I'm not super thrilled about. An alternative would be to always create the empty resource controllers through a rails generator, but I think it would be annoying for a developer to have a bunch of empty controller classes laying around.
