### PR TITLE
Generate dashboard controllers for resources

### DIFF
--- a/lib/generators/dashboard/dashboard_generator.rb
+++ b/lib/generators/dashboard/dashboard_generator.rb
@@ -1,8 +1,15 @@
 class DashboardGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("../templates", __FILE__)
 
-  def copy_dashboard_file
+  def create_dashboard_definition
     template "dashboard.rb.erb", "app/dashboards/#{file_name}_dashboard.rb"
+  end
+
+  def create_resource_controller
+    template(
+      "controller.rb.erb",
+      "app/controllers/admin/#{file_name.pluralize}_controller.rb"
+    )
   end
 
   private

--- a/lib/generators/dashboard/templates/controller.rb.erb
+++ b/lib/generators/dashboard/templates/controller.rb.erb
@@ -1,0 +1,12 @@
+class Admin::<%= class_name.pluralize %>Controller < Admin::DashboardController
+  # To customize the behavior of this controller,
+  # simply overwrite any of the RESTful actions. For example:
+  #
+  # def index
+  #   super
+  #   @resources = <%= class_name %>.all.paginate(10, params[:page])
+  # end
+
+  # See https://administrate-docs.herokuapp.com/customizing_controller_actions
+  # for more information
+end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -2,47 +2,70 @@ require "rails_helper"
 require "generators/dashboard/dashboard_generator"
 
 describe DashboardGenerator, :generator do
-  it "has valid syntax" do
-    dashboard = file("app/dashboards/customer_dashboard.rb")
+  describe "dashboard definition file" do
+    it "has valid syntax" do
+      dashboard = file("app/dashboards/customer_dashboard.rb")
 
-    run_generator ["customer"]
+      run_generator ["customer"]
 
-    expect(dashboard).to exist
-    expect(dashboard).to have_correct_syntax
+      expect(dashboard).to exist
+      expect(dashboard).to have_correct_syntax
+    end
+
+    it "includes standard model attributes" do
+      dashboard = file("app/dashboards/customer_dashboard.rb")
+
+      run_generator ["customer"]
+
+      expect(dashboard).to contain("id: :integer,")
+      expect(dashboard).to contain("created_at: :datetime,")
+      expect(dashboard).to contain("updated_at: :datetime,")
+    end
+
+    it "includes user-defined database columns" do
+      dashboard = file("app/dashboards/customer_dashboard.rb")
+
+      run_generator ["customer"]
+
+      expect(dashboard).to contain("name: :string,")
+      expect(dashboard).to contain("email: :string,")
+    end
+
+    it "includes has_many relationships" do
+      dashboard = file("app/dashboards/customer_dashboard.rb")
+
+      run_generator ["customer"]
+
+      expect(dashboard).to contain("orders: :has_many")
+    end
+
+    it "includes belongs_to relationships" do
+      dashboard = file("app/dashboards/order_dashboard.rb")
+
+      run_generator ["order"]
+
+      expect(dashboard).to contain("customer: :belongs_to")
+    end
   end
 
-  it "includes standard model attributes" do
-    dashboard = file("app/dashboards/customer_dashboard.rb")
+  describe "resource controller" do
+    it "has valid syntax" do
+      controller = file("app/controllers/admin/customers_controller.rb")
 
-    run_generator ["customer"]
+      run_generator ["customer"]
 
-    expect(dashboard).to contain("id: :integer,")
-    expect(dashboard).to contain("created_at: :datetime,")
-    expect(dashboard).to contain("updated_at: :datetime,")
-  end
+      expect(controller).to exist
+      expect(controller).to have_correct_syntax
+    end
 
-  it "includes user-defined database columns" do
-    dashboard = file("app/dashboards/customer_dashboard.rb")
+    it "subclasses DashboardController" do
+      controller = file("app/controllers/admin/customers_controller.rb")
 
-    run_generator ["customer"]
+      run_generator ["customer"]
 
-    expect(dashboard).to contain("name: :string,")
-    expect(dashboard).to contain("email: :string,")
-  end
-
-  it "includes has_many relationships" do
-    dashboard = file("app/dashboards/customer_dashboard.rb")
-
-    run_generator ["customer"]
-
-    expect(dashboard).to contain("orders: :has_many")
-  end
-
-  it "includes belongs_to relationships" do
-    dashboard = file("app/dashboards/order_dashboard.rb")
-
-    run_generator ["order"]
-
-    expect(dashboard).to contain("customer: :belongs_to")
+      expect(controller).to contain(
+        "class Admin::CustomersController < Admin::DashboardController"
+      )
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #29 

**Note: you'll definitely want to [ignore whitespace in the diff](https://github.com/thoughtbot/administrate-demo/pull/30/files?w=1).**

Based on conversation around dynamically defining classes, it seems safer to just generate resource dashboard controllers for each resource.

They'll all live in a single folder, ready for customization with helpful comments and a link to the documentation.
