### PR TITLE
Don't add namespaced models to dashboard manifest

### DIFF
--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -27,9 +27,13 @@ module Administrate
       private
 
       def dashboard_resources
-        database_models.map do |model_class|
-          model_class.to_s.pluralize.underscore
+        valid_dashboard_models.map do |model|
+          model.to_s.pluralize.underscore
         end
+      end
+
+      def valid_dashboard_models
+        database_models.reject { |model| model.to_s.include?("::") }
       end
 
       def database_models

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -43,6 +43,15 @@ describe Administrate::Generators::InstallGenerator, :generator do
       end
       expect(manifest).not_to contain("Delayed::Backend::ActiveRecord::Job")
     end
+
+    it "skips namespaced models with a warning" do
+      provide_existing_routes_file
+      manifest = file("app/dashboards/dashboard_manifest.rb")
+
+      run_generator
+
+      expect(manifest).not_to contain("delayed/backend/active_record/jobs")
+    end
   end
 
   describe "config/routes.rb" do


### PR DESCRIPTION
Currently, namespaced models are unsupported.
Eventually, this should change - it would require the dashboard manifest
to return something other than a list of symbols.
