### PR TITLE
Relax Neat dependency down to ~> 1.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: administrate
   specs:
     administrate (0.0.2)
-      neat (~> 1.7)
+      neat (~> 1.1)
       normalize-rails (~> 3.0)
       rails (~> 4.2)
 

--- a/administrate/administrate.gemspec
+++ b/administrate/administrate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 4.2"
-  s.add_dependency "neat", "~> 1.7"
+  s.add_dependency "neat", "~> 1.1"
   s.add_dependency "normalize-rails", "~> 3.0"
 
   s.description = <<-DESCRIPTION


### PR DESCRIPTION
Based on @jayroh's feedback

I tried using `~> 1.0`, but I got an error about not being able to require bourbon.
`1.0.1` worked fine, but I'm not sure how to specify that safely with semantic versioning.
