### PR TITLE
Copy sample.env to .env in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  pre:
+    - cp .sample.env .env


### PR DESCRIPTION
This is preferable to setting environment variables manually through the
CircleCI web interface, because it requires us to keep .sample.env
updated with any values needed to make the specs pass.
