### PR TITLE
Remove redundant "Show" link from tables

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,8 @@
+New in 0.0.4:
+
+* Interface: remove the "Show" link from tables - it was redundant because
+  clicking on the row itself took the user to the same place.
+
 New in 0.0.3:
 
 * Improvement: the `administrate:install` generator now runs

--- a/administrate/app/views/administrate/application/_table.html.erb
+++ b/administrate/app/views/administrate/application/_table.html.erb
@@ -4,7 +4,7 @@
       <% table_presenter.attribute_names.each do |attr_name| %>
         <th><%= attr_name.to_s.titleize %></th>
       <% end %>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 
@@ -16,14 +16,10 @@
           data-url="<%= polymorphic_path([Administrate::NAMESPACE, resource]) -%>"
           >
         <% table_presenter.attributes_for(resource).each do |attribute| %>
-          <td><%= render_field attribute %></td>
+          <td class="field-<%= attribute.html_class %>">
+            <%= render_field attribute %>
+          </td>
         <% end %>
-
-        <td><%= link_to(
-          t("administrate.actions.show"),
-          [Administrate::NAMESPACE, resource],
-          class: "action-show",
-        ) %></td>
 
         <td><%= link_to(
           t("administrate.actions.edit"),

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -11,11 +11,11 @@ describe "customer index page" do
     expect(page).to have_content(customer.email)
   end
 
-  it "links to the customer show page" do
+  it "links to the customer show page", :js do
     customer = create(:customer)
 
     visit admin_customers_path
-    find(index_row_css_for(customer)).click
+    click_row_for(customer)
 
     expect(page).to have_header(customer.to_s)
     expect(page).to have_content(customer.name)

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "line item index page" do
     expect(page).to have_content(line_item.product.to_s)
   end
 
-  it "links to the line item show page" do
+  it "links to the line item show page", :js do
     line_item = create(:line_item)
 
     visit admin_line_items_path
-    find(index_row_css_for(line_item)).click
+    click_row_for(line_item)
 
     expect(page).to have_header(line_item.to_s)
     expect(page).to have_content(line_item.to_s)

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -19,11 +19,11 @@ describe "order index page" do
     expect(page).to have_header(order.customer.name)
   end
 
-  it "links to the order show page" do
+  it "links to the order show page", :js do
     order = create(:order)
 
     visit admin_orders_path
-    find(index_row_css_for(order)).click
+    click_row_for(order)
 
     expect(page).to have_header(order.to_s)
     expect(page).to have_link(order.customer.name)

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -11,11 +11,11 @@ feature "order index page" do
     expect(page).to have_content(line_item.total_price)
   end
 
-  scenario "links to line items" do
+  scenario "links to line items", :js do
     line_item = create(:line_item)
 
     visit admin_order_path(line_item.order)
-    find(index_row_css_for(line_item)).click
+    click_row_for(line_item)
 
     expect(page).to have_header(line_item.to_s)
   end

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "product index page" do
     expect(page).to have_content(product.description)
   end
 
-  it "links to the product show page" do
+  it "links to the product show page", :js do
     product = create(:product)
 
     visit admin_products_path
-    find(index_row_css_for(product)).click
+    click_row_for(product)
 
     expect(current_path).to eq(admin_product_path(product))
     expect(page).to have_content(product.name)

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe "customer show page" do
     end
   end
 
-  it "links to the customer's orders" do
+  it "links to the customer's orders", :js do
     customer = create(:customer)
     order = create(:order, customer: customer)
 
     visit admin_customer_path(customer)
 
-    find(index_row_css_for(order)).click
+    click_row_for(order)
 
     expect(page).to have_header(order.to_s)
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,10 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+
+  config.before(js: true) do
+    page.driver.block_unknown_urls
+  end
 end
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -1,9 +1,13 @@
 module Features
-  def index_row_css_for(model)
-    "tr[data-url='#{url_for(model)}'] .action-show"
+  def click_row_for(model)
+    all(index_row_css_for(model)).first.click
   end
 
   private
+
+  def index_row_css_for(model)
+    "tr[data-url='#{url_for(model)}'] .field-string"
+  end
 
   def url_for(model)
     "/" + [


### PR DESCRIPTION
We have a snippet of javascript that makes table rows clickable,
and links each table rows to the resource show page.

Because of this, the "show" link is redundant.
The "show" link was originally added over concerns about accessibility.
However, according to a survey of screen readers and browsers,
javascript is nearly ubiquitous.
We don't need to worry about browsers that don't have it enabled.

More information at:
http://webaim.org/projects/screenreadersurvey5/#javascript
