### PR TITLE
Display "none" when there are no has_many records

### DIFF
--- a/administrate/app/views/fields/show/_has_many.html.erb
+++ b/administrate/app/views/fields/show/_has_many.html.erb
@@ -1,5 +1,9 @@
-<%= render(
-  "table",
-  table_presenter: has_many.associated_table,
-  resources: has_many.data
-) %>
+<% if has_many.data.any? %>
+  <%= render(
+    "table",
+    table_presenter: has_many.associated_table,
+    resources: has_many.data
+  ) %>
+<% else %>
+  <%= t("administrate.fields.has_many.none") %>
+<% end %>

--- a/administrate/config/locales/administrate.en.yml
+++ b/administrate/config/locales/administrate.en.yml
@@ -5,3 +5,6 @@ en:
       edit: Edit
       destroy: Destroy
       confirm: Are you sure?
+    fields:
+      has_many:
+        none: None

--- a/spec/administrate/views/fields/show/_has_many_spec.rb
+++ b/spec/administrate/views/fields/show/_has_many_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe "fields/show/_has_many", type: :view do
+  context "without any associated records" do
+    it "displays 'None'" do
+      has_many = double(data: [])
+
+      render(
+        partial: "fields/show/has_many.html.erb",
+        locals: { has_many: has_many },
+      )
+
+      expect(rendered.strip).to eq(t("administrate.fields.has_many.none"))
+    end
+  end
+end


### PR DESCRIPTION
When there are no records in a has_many relationship,
display "None" instead of an empty table on the parent record's show
page.
- Add a view spec for the field. We'll eventually have a lot of fields,
  so it will be helpful to be able to test them in isolation.

https://trello.com/c/koWauH3v
