### PR TITLE
Let devs set field options from dashboard classes

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,8 @@
+* Change: use field classes for `attribute_types` instead of symbols.
+  The new interface adds the `.with_options` class method,
+  which allows developers to specify options that will be applied
+  when the field object is initialized.
+
 New in 0.0.6:
 
 * Improvement: Add an outline to links on their focus state

--- a/administrate/lib/administrate/base_dashboard.rb
+++ b/administrate/lib/administrate/base_dashboard.rb
@@ -6,31 +6,12 @@ require "administrate/fields/string"
 
 module Administrate
   class BaseDashboard
+    include Administrate
+
     def permitted_attributes
       form_attributes.map do |attr|
-        field_class(attr).permitted_attribute(attr)
+        attribute_types[attr].permitted_attribute(attr)
       end.uniq
-    end
-
-    def field_class(attr)
-      field_registry.fetch(attribute_types[attr])
-    end
-
-    private
-
-    def field_registry
-      {
-        belongs_to: Administrate::Field::BelongsTo,
-        boolean: Administrate::Field::String,
-        datetime: Administrate::Field::String,
-        email: Administrate::Field::Email,
-        float: Administrate::Field::String,
-        has_many: Administrate::Field::HasMany,
-        image: Administrate::Field::Image,
-        integer: Administrate::Field::String,
-        string: Administrate::Field::String,
-        text: Administrate::Field::String,
-      }
     end
   end
 end

--- a/administrate/lib/administrate/fields/base.rb
+++ b/administrate/lib/administrate/fields/base.rb
@@ -1,10 +1,17 @@
+require_relative "deferred"
+
 module Administrate
   module Field
     class Base
-      def initialize(attribute, data, page)
+      def self.with_options(options = {})
+        Deferred.new(self, options)
+      end
+
+      def initialize(attribute, data, page, options = {})
         @attribute = attribute
         @data = data
         @page = page
+        @options = options
       end
 
       def self.permitted_attribute(attr)

--- a/administrate/lib/administrate/fields/deferred.rb
+++ b/administrate/lib/administrate/fields/deferred.rb
@@ -1,0 +1,14 @@
+module Administrate
+  module Field
+    class Deferred
+      def initialize(klass, options = {})
+        @klass = klass
+        @options = options
+      end
+
+      def new(*args)
+        @klass.new(*args, @options)
+      end
+    end
+  end
+end

--- a/administrate/lib/administrate/page/base.rb
+++ b/administrate/lib/administrate/page/base.rb
@@ -16,7 +16,7 @@ module Administrate
         value = resource.public_send(attribute_name)
 
         dashboard.
-          field_class(attribute_name).
+          attribute_types[attribute_name].
           new(attribute_name, value, page)
       end
 

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -25,16 +25,23 @@ module Administrate
       end
 
       def field_type(attribute)
-        klass.type_for_attribute(attribute).type ||
+        if klass.type_for_attribute(attribute).type
+          default_field_type
+        else
           association_type(attribute)
+        end
+      end
+
+      def default_field_type
+        "Field::String"
       end
 
       def association_type(attribute)
         reflection = klass.reflections[attribute.to_s]
         if reflection.collection?
-          :has_many
+          "Field::HasMany"
         else
-          :belongs_to
+          "Field::BelongsTo"
         end
       end
 

--- a/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -10,7 +10,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   def attribute_types
     {<% attributes.each do |attr| %>
-      <%= attr %>: :<%= field_type(attr) %>,<% end %>
+      <%= attr %>: <%= field_type(attr) %>,<% end %>
     }
   end
 

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -3,12 +3,12 @@ require "administrate/base_dashboard"
 class CustomerDashboard < Administrate::BaseDashboard
   def attribute_types
     {
-      created_at: :datetime,
-      email: :email,
-      lifetime_value: :string,
-      name: :string,
-      orders: :has_many,
-      updated_at: :datetime,
+      created_at: Field::String,
+      email: Field::Email,
+      lifetime_value: Field::String,
+      name: Field::String,
+      orders: Field::HasMany,
+      updated_at: Field::String,
     }
   end
 

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -15,11 +15,11 @@ class LineItemDashboard < Administrate::BaseDashboard
 
   def attribute_types
     {
-      order: :belongs_to,
-      product: :belongs_to,
-      quantity: :string,
-      total_price: :string,
-      unit_price: :string,
+      order: Field::BelongsTo,
+      product: Field::BelongsTo,
+      quantity: Field::String,
+      total_price: Field::String,
+      unit_price: Field::String,
     }
   end
 

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -3,15 +3,15 @@ require "administrate/base_dashboard"
 class OrderDashboard < Administrate::BaseDashboard
   def attribute_types
     {
-      id: :string,
-      address_line_one: :string,
-      address_line_two: :string,
-      address_city: :string,
-      address_state: :string,
-      address_zip: :string,
-      customer: :belongs_to,
-      line_items: :has_many,
-      total_price: :string,
+      id: Field::String,
+      address_line_one: Field::String,
+      address_line_two: Field::String,
+      address_city: Field::String,
+      address_state: Field::String,
+      address_zip: Field::String,
+      customer: Field::BelongsTo,
+      line_items: Field::HasMany,
+      total_price: Field::String,
     }
   end
 

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -3,10 +3,10 @@ require "administrate/base_dashboard"
 class ProductDashboard < Administrate::BaseDashboard
   def attribute_types
     {
-      description: :string,
-      image_url: :image,
-      name: :string,
-      price: :string,
+      description: Field::String,
+      image_url: Field::Image,
+      name: Field::String,
+      price: Field::String,
     }
   end
 

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -14,9 +14,11 @@ describe CustomerDashboard do
     it "maps each attribute to an attribute field" do
       dashboard = CustomerDashboard.new
 
-      expect(dashboard.attribute_types[:name]).to eq(:string)
-      expect(dashboard.attribute_types[:email]).to eq(:email)
-      expect(dashboard.attribute_types[:lifetime_value]).to eq(:string)
+      fields = dashboard.attribute_types
+
+      expect(fields[:name]).to eq(Administrate::Field::String)
+      expect(fields[:email]).to eq(Administrate::Field::Email)
+      expect(fields[:lifetime_value]).to eq(Administrate::Field::String)
     end
   end
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -18,9 +18,9 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         run_generator ["customer"]
 
-        expect(dashboard).to contain("id: :integer,")
-        expect(dashboard).to contain("created_at: :datetime,")
-        expect(dashboard).to contain("updated_at: :datetime,")
+        expect(dashboard).to contain("id: Field::String,")
+        expect(dashboard).to contain("created_at: Field::String,")
+        expect(dashboard).to contain("updated_at: Field::String,")
       end
 
       it "includes user-defined database columns" do
@@ -28,8 +28,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         run_generator ["customer"]
 
-        expect(dashboard).to contain("name: :string,")
-        expect(dashboard).to contain("email: :string,")
+        expect(dashboard).to contain("name: Field::String,")
+        expect(dashboard).to contain("email: Field::String,")
       end
 
       it "includes has_many relationships" do
@@ -37,7 +37,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         run_generator ["customer"]
 
-        expect(dashboard).to contain("orders: :has_many")
+        expect(dashboard).to contain("orders: Field::HasMany")
       end
 
       it "includes belongs_to relationships" do
@@ -45,7 +45,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         run_generator ["order"]
 
-        expect(dashboard).to contain("customer: :belongs_to")
+        expect(dashboard).to contain("customer: Field::BelongsTo")
       end
     end
 


### PR DESCRIPTION
This is a prerequisite for extending the belongs_to and has_many
fields to take options such as alternate table names, etc.

Other potential uses could be to specify the number of decimal places to
show a floating-point number to, or whether or not to truncate a string.

Cards that depend on this commit:
https://trello.com/c/kypYTxFt
https://trello.com/c/GDw9Luy3
### ToDo:
- [x] Add a changelog entry
