### PR TITLE
Limit index pages to showing 20 items

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,7 @@
+* Improvement: Limit index pages to showing 20 items by default.
+  Developers can customize the action to update or remove the limit,
+  or to implement pagination with the system of their choice.
+
 New in 0.0.5:
 
 * Compatibility: Administrate relies on the `&-suffix` feature of SASS,

--- a/administrate/lib/generators/administrate/install/templates/application_controller.rb
+++ b/administrate/lib/generators/administrate/install/templates/application_controller.rb
@@ -10,4 +10,14 @@ class Admin::ApplicationController < Administrate::ApplicationController
   def authenticate_admin
     # TODO Add authentication logic here.
   end
+
+  def index
+    super
+
+    flash[:alert] =
+      "For performance, Administrate limits the index page to show 20 items.
+      Customize this action to update/remove the limit,
+      or implement the pagination library of your choice."
+    @resources = @resources.limit(20)
+  end
 end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -10,4 +10,14 @@ class Admin::ApplicationController < Administrate::ApplicationController
   def authenticate_admin
     # TODO Add authentication logic here.
   end
+
+  def index
+    super
+
+    flash[:alert] =
+      "For performance, Administrate limits the index page to show 20 items.
+      Customize this action to update/remove the limit,
+      or implement the pagination library of your choice."
+    @resources = @resources.limit(20)
+  end
 end


### PR DESCRIPTION
This helps with performance on index pages, until the dev can get
pagination set up themselves.

We display a flash alert to the user so they know they need to implement
pagination or remove the limit to see all of the records.

Why?

https://trello.com/c/GRZTyr56
### ToDo:
- [x] Add a changelog entry
