### PR TITLE
Propose refactor for resource resolution (WIP)

### DIFF
--- a/administrate/lib/administrate/resource_resolver.rb
+++ b/administrate/lib/administrate/resource_resolver.rb
@@ -1,0 +1,41 @@
+require "administrate/namespace"
+
+module Administrate
+  class ResourceResolver
+    def initialize(controller_path)
+      @controller_path = controller_path
+    end
+
+    def dashboard_class
+      Object.const_get(resource_class_name + "Dashboard")
+    end
+
+    def resource_class
+      Object.const_get(resource_class_name)
+    end
+
+    def resource_name
+      model_path_parts.map(&:underscore).join("__").to_sym
+    end
+
+    def resource_title
+      model_path_parts.join(" ")
+    end
+
+    private
+
+    def resource_class_name
+      model_path_parts.join("::")
+    end
+
+    def model_path_parts
+      controller_path_parts.map(&:camelize)
+    end
+
+    def controller_path_parts
+      controller_path.singularize.split("/") - [Administrate::NAMESPACE.to_s]
+    end
+
+    attr_reader :controller_path
+  end
+end

--- a/spec/lib/administrate/resource_resolver_spec.rb
+++ b/spec/lib/administrate/resource_resolver_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+require "administrate/resource_resolver"
+
+describe Administrate::ResourceResolver do
+  # Fixture classes
+  class UserDashboard
+  end
+
+  class User
+  end
+
+  module Blog
+    class Post
+    end
+
+    class PostDashboard
+    end
+  end
+
+  describe "#resource_class" do
+    it "handles global-namepsace models" do
+      resolver = Administrate::ResourceResolver.new("admin/users")
+
+      expect(resolver.resource_class).to eq(User)
+    end
+
+    it "handles namespaced models" do
+      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+
+      expect(resolver.resource_class).to eq(Blog::Post)
+    end
+  end
+
+  describe "#dashboard_class" do
+    it "handles global-namepsace models" do
+      resolver = Administrate::ResourceResolver.new("admin/users")
+
+      expect(resolver.dashboard_class).to eq(UserDashboard)
+    end
+
+    it "handles namespaced models" do
+      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+
+      expect(resolver.dashboard_class).to eq(Blog::PostDashboard)
+    end
+  end
+
+  describe "#resource_title" do
+    it "handles global-namepsace models" do
+      resolver = Administrate::ResourceResolver.new("admin/users")
+
+      expect(resolver.resource_title).to eq("User")
+    end
+
+    it "handles namespaced models" do
+      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+
+      expect(resolver.resource_title).to eq("Blog Post")
+    end
+  end
+
+  describe "#resource_name" do
+    it "handles global-namepsace models" do
+      resolver = Administrate::ResourceResolver.new("admin/users")
+
+      expect(resolver.resource_name).to eq(:user)
+    end
+
+    it "handles namespaced models" do
+      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+
+      expect(resolver.resource_name).to eq(:blog__post)
+    end
+  end
+end


### PR DESCRIPTION
There are quite a few private methods that do some work translating the
concept of "this controller" to a name, a title, a class, etc.

In attempting to implement dashboards for some namespaced models I ran
into some limitations with the current code. I made an attempt below to
pull together the private methods that fall into the scope of what I
would call a "resource resolver" (or maybe a "resource factory"?).
Delegating to an object that returned the type of information, or objects,
that we want from the controller's path sounds like a reasonable
abstraction.

The base administrate application controller would ideally and
eventually delegate the updated methods to
`ResourceResolver.new(controller_path)`.

The changed methods below are to illustrate a collection of base use
cases and how they would end up looking.
