### PR TITLE
Display a visual indication of focus for accessibility

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,5 @@
+* Improvement: Add an outline to links on their focus state
+  to improve accessibility through keyboard navigation.
 * Improvement: Limit index pages to showing 20 items by default.
   Developers can customize the action to update or remove the limit,
   or to implement pagination with the system of their choice.

--- a/administrate/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/_typography.scss
@@ -55,11 +55,6 @@ a {
   &:hover {
     color: $hover-link-color;
   }
-
-  &:active, &:focus {
-    color: $hover-link-color;
-    outline: none;
-  }
 }
 
 hr {


### PR DESCRIPTION
You can find a lot of discussion around this issue in https://github.com/thoughtbot/bitters/issues/172, and we're following the solution that bitters uses in https://github.com/thoughtbot/bitters/pull/174.

The short version is that removing the outline from links on their focus states breaks the application for keyboard-only users.

We're restoring the outline to restore that functionality.

https://trello.com/c/s15TslbU
