### PR TITLE
Limit tables to four columns by default

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,8 @@
 * Improvement: Add an outline to links on their focus state
   to improve accessibility through keyboard navigation.
+* Improvement: Limit index pages
+  to displaying four columns of attributes by default,
+  to reduce clutter and overflow in the first-run experience.
 * Improvement: Limit index pages to showing 20 items by default.
   Developers can customize the action to update or remove the limit,
   or to implement pagination with the system of their choice.

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -3,6 +3,8 @@ require "rails/generators/named_base"
 module Administrate
   module Generators
     class DashboardGenerator < Rails::Generators::NamedBase
+      TABLE_ATTRIBUTE_LIMIT = 4
+
       source_root File.expand_path("../templates", __FILE__)
 
       def create_dashboard_definition

--- a/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -16,8 +16,11 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
 
   # This method returns an array of attributes
   # that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to remove the limit or customize the returned array.
   def table_attributes
-    attributes
+    attributes.first(<%= TABLE_ATTRIBUTE_LIMIT %>)
   end
 
   # This method returns an array of attributes

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -12,39 +12,55 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       expect(dashboard).to have_correct_syntax
     end
 
-    it "includes standard model attributes" do
-      dashboard = file("app/dashboards/customer_dashboard.rb")
+    describe "#attribute_types" do
+      it "includes standard model attributes" do
+        dashboard = file("app/dashboards/customer_dashboard.rb")
 
-      run_generator ["customer"]
+        run_generator ["customer"]
 
-      expect(dashboard).to contain("id: :integer,")
-      expect(dashboard).to contain("created_at: :datetime,")
-      expect(dashboard).to contain("updated_at: :datetime,")
+        expect(dashboard).to contain("id: :integer,")
+        expect(dashboard).to contain("created_at: :datetime,")
+        expect(dashboard).to contain("updated_at: :datetime,")
+      end
+
+      it "includes user-defined database columns" do
+        dashboard = file("app/dashboards/customer_dashboard.rb")
+
+        run_generator ["customer"]
+
+        expect(dashboard).to contain("name: :string,")
+        expect(dashboard).to contain("email: :string,")
+      end
+
+      it "includes has_many relationships" do
+        dashboard = file("app/dashboards/customer_dashboard.rb")
+
+        run_generator ["customer"]
+
+        expect(dashboard).to contain("orders: :has_many")
+      end
+
+      it "includes belongs_to relationships" do
+        dashboard = file("app/dashboards/order_dashboard.rb")
+
+        run_generator ["order"]
+
+        expect(dashboard).to contain("customer: :belongs_to")
+      end
     end
 
-    it "includes user-defined database columns" do
-      dashboard = file("app/dashboards/customer_dashboard.rb")
+    describe "#table_attributes" do
+      it "is limited to a reasonable number of items" do
+        dashboard = file("app/dashboards/customer_dashboard.rb")
+        limit =
+          Administrate::Generators::DashboardGenerator::TABLE_ATTRIBUTE_LIMIT
 
-      run_generator ["customer"]
+        run_generator ["customer"]
 
-      expect(dashboard).to contain("name: :string,")
-      expect(dashboard).to contain("email: :string,")
-    end
-
-    it "includes has_many relationships" do
-      dashboard = file("app/dashboards/customer_dashboard.rb")
-
-      run_generator ["customer"]
-
-      expect(dashboard).to contain("orders: :has_many")
-    end
-
-    it "includes belongs_to relationships" do
-      dashboard = file("app/dashboards/order_dashboard.rb")
-
-      run_generator ["order"]
-
-      expect(dashboard).to contain("customer: :belongs_to")
+        expect(dashboard).to contain(
+          "def table_attributes\n    attributes.first(#{limit})"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Limit index pages to displaying four columns of attributes by default,
to reduce clutter and overflow in the first-run experience.

https://trello.com/c/LiGlposh
