### PR TITLE
Create class_name option on has_many fields

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,5 @@
+* Improvement: Support `has_many` associations
+  with a custom `class_name` option.
 * Change: use field classes for `attribute_types` instead of symbols.
   The new interface adds the `.with_options` class method,
   which allows developers to specify options that will be applied

--- a/administrate/lib/administrate/fields/has_many.rb
+++ b/administrate/lib/administrate/fields/has_many.rb
@@ -31,7 +31,7 @@ module Administrate
       end
 
       def resource_class_name
-        attribute.to_s.singularize.camelcase
+        @options[:class_name] || attribute.to_s.singularize.camelcase
       end
     end
   end

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -39,7 +39,7 @@ module Administrate
       def association_type(attribute)
         reflection = klass.reflections[attribute.to_s]
         if reflection.collection?
-          "Field::HasMany"
+          "Field::HasMany" + has_many_options_string(reflection)
         else
           "Field::BelongsTo"
         end
@@ -47,6 +47,26 @@ module Administrate
 
       def klass
         @klass ||= Object.const_get(class_name)
+      end
+
+      def has_many_options_string(reflection)
+        options = reflection.options.slice(*allowed_has_many_options)
+
+        if options.any?
+          ".with_options(#{hash_to_string(options)})"
+        else
+          ""
+        end
+      end
+
+      def allowed_has_many_options
+        [
+          :class_name,
+        ]
+      end
+
+      def hash_to_string(hash)
+        hash.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
       end
     end
   end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -40,6 +40,19 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         expect(dashboard).to contain("orders: Field::HasMany")
       end
 
+      it "looks for class_name options on has_many fields" do
+        class Customer < ActiveRecord::Base
+          has_many :purchases, class_name: "Order", foreign_key: "purchase_id"
+        end
+        dashboard = file("app/dashboards/customer_dashboard.rb")
+
+        run_generator ["customer"]
+
+        expect(dashboard).to contain(
+          'purchases: Field::HasMany.with_options(class_name: "Order")',
+        )
+      end
+
       it "includes belongs_to relationships" do
         dashboard = file("app/dashboards/order_dashboard.rb")
 
@@ -58,7 +71,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         run_generator ["customer"]
 
         expect(dashboard).to contain(
-          "def table_attributes\n    attributes.first(#{limit})"
+          "def table_attributes\n    attributes.first(#{limit})",
         )
       end
     end
@@ -80,7 +93,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       run_generator ["customer"]
 
       expect(controller).to contain(
-        "class Admin::CustomersController < Admin::ApplicationController"
+        "class Admin::CustomersController < Admin::ApplicationController",
       )
     end
   end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -24,4 +24,20 @@ describe Administrate::Field::HasMany do
       expect(page).to be_instance_of(Administrate::Page::Table)
     end
   end
+
+  describe "class_name option" do
+    it "determines what dashboard is used to present the association" do
+      FooDashboard = Class.new
+      dashboard_double = double(table_attributes: [])
+      allow(FooDashboard).to receive(:new).and_return(dashboard_double)
+
+      association = Administrate::Field::HasMany.with_options(class_name: "Foo")
+      field = association.new(:customers, [], :show)
+      table = field.associated_table
+      attributes = table.attribute_names
+
+      expect(dashboard_double).to have_received(:table_attributes)
+      expect(attributes).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Upcase has the following code:

``` ruby
class Mentor < ActiveRecord::Base
  # ...
  has_many :mentees, class_name: 'User', foreign_key: 'mentor_id'
  # ...
end
```

Before this commit, Administrate incorrectly tries to look up a `MenteeDashboard` instead of a `UserDashboard` to figure out how to display the association table.

This commit allows developers to specify the `class_name` that will be used to look up the proper dashboard for a has_many association.

The option is used like this:

``` ruby
  def attribute_types
    {
      # ...
      mentees: Field::HasMany.with_options(class_name: "User"),
      # ...
    }
  end
```

Background: https://trello.com/c/kypYTxFt
