### PR TITLE
Detect class_name for has_many :through w/ :source

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,4 +1,6 @@
 * Improvement: Support `has_one` relationships
+* Improvement: Support `has_many :through` associations
+  with a custom `source` option.
 * Improvement: Support `has_many` associations
   with a custom `class_name` option.
 * Change: use field classes for `attribute_types` instead of symbols.

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -52,22 +52,18 @@ module Administrate
       end
 
       def has_many_options_string(reflection)
-        options = reflection.options.slice(*allowed_has_many_options)
-
-        if options.any?
-          ".with_options(#{hash_to_string(options)})"
+        if reflection.class_name != reflection.name.to_s.classify
+          options_string(class_name: reflection.class_name)
         else
           ""
         end
       end
 
-      def allowed_has_many_options
-        [
-          :class_name,
-        ]
+      def options_string(options)
+        ".with_options(#{inspect_hash_as_ruby(options)})"
       end
 
-      def hash_to_string(hash)
+      def inspect_hash_as_ruby(hash)
         hash.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
       end
     end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -53,6 +53,50 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         )
       end
 
+      it "determines a class_name from `through` and `source` options" do
+        begin
+          ActiveRecord::Schema.define do
+            create_table :people
+            create_table :concerts
+            create_table(:numbers) { |t| t.references :ticket }
+
+            create_table :tickets do |t|
+              t.references :concert
+              t.references :attendee
+            end
+          end
+
+          class Concert < ActiveRecord::Base
+            has_many :tickets
+            has_many :attendees, through: :tickets, source: :person
+            has_many :venues, through: :tickets
+            has_many :numbers, through: :tickets
+          end
+
+          class Ticket < ActiveRecord::Base
+            belongs_to :concert
+            belongs_to :person
+            belongs_to :venue
+            has_many :numbers
+          end
+
+          class Number; end
+          class Person < ActiveRecord::Base; end
+
+          dashboard = file("app/dashboards/concert_dashboard.rb")
+
+          run_generator ["concert"]
+
+          expect(dashboard).to contain(
+            'attendees: Field::HasMany.with_options(class_name: "Person"),',
+          )
+          expect(dashboard).to contain("venues: Field::HasMany,")
+          expect(dashboard).to contain("numbers: Field::HasMany,")
+        ensure
+          remove_constants :Concert, :Ticket, :Number, :Person
+        end
+      end
+
       it "includes belongs_to relationships" do
         dashboard = file("app/dashboards/order_dashboard.rb")
 
@@ -62,27 +106,31 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       end
 
       it "detects has_one relationships" do
-        ActiveRecord::Schema.define do
-          create_table :accounts, force: true
+        begin
+          ActiveRecord::Schema.define do
+            create_table :accounts
 
-          create_table :profiles, force: true do |t|
-            t.references :account
+            create_table :profiles do |t|
+              t.references :account
+            end
           end
+
+          class Account < ActiveRecord::Base
+            has_one :profile
+          end
+
+          class Ticket < ActiveRecord::Base
+            belongs_to :account
+          end
+
+          dashboard = file("app/dashboards/account_dashboard.rb")
+
+          run_generator ["account"]
+
+          expect(dashboard).to contain("profile: Field::HasOne")
+        ensure
+          remove_constants :Account, :Ticket
         end
-
-        class Account < ActiveRecord::Base
-          has_one :profile
-        end
-
-        class Ticket < ActiveRecord::Base
-          belongs_to :account
-        end
-
-        dashboard = file("app/dashboards/account_dashboard.rb")
-
-        run_generator ["account"]
-
-        expect(dashboard).to contain("profile: Field::HasOne")
       end
     end
 
@@ -120,5 +168,9 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         "class Admin::CustomersController < Admin::ApplicationController",
       )
     end
+  end
+
+  def remove_constants(*constants)
+    constants.each { |const| Object.send(:remove_const, const) }
   end
 end


### PR DESCRIPTION
Previously, Administrate would try to look up the incorrect dashboard
class for  has_many :through relationships with a `source` option
because it wasn't taking that option into account.

Also, include tests to make sure we don't set the class_name option
unless it's needed

The class_name option was being set incorrectly for `has_many :through`
without a `:source` option, and for `has_many :through -> has_many`
nested relationships

https://trello.com/c/GDw9Luy3
