### PR TITLE
Add a Field and partials to support `has_one` relationships

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,4 @@
+* Improvement: Support `has_one` relationships
 * Improvement: Support `has_many` associations
   with a custom `class_name` option.
 * Change: use field classes for `attribute_types` instead of symbols.

--- a/administrate/app/views/fields/form/_has_one.html.erb
+++ b/administrate/app/views/fields/form/_has_one.html.erb
@@ -1,0 +1,7 @@
+<%= f.label has_one.permitted_attribute %>
+<%= f.collection_select(
+  has_one.permitted_attribute,
+  has_one.candidate_records,
+  :id,
+  :to_s,
+) %>

--- a/administrate/app/views/fields/index/_has_one.html.erb
+++ b/administrate/app/views/fields/index/_has_one.html.erb
@@ -1,0 +1,3 @@
+<% if has_one.data %>
+  <%= link_to has_one.data, [Administrate::NAMESPACE, has_one.data] %>
+<% end %>

--- a/administrate/app/views/fields/show/_has_one.html.erb
+++ b/administrate/app/views/fields/show/_has_one.html.erb
@@ -1,0 +1,3 @@
+<% if has_one.data %>
+  <%= link_to has_one.data, [Administrate::NAMESPACE, has_one.data] %>
+<% end %>

--- a/administrate/lib/administrate/base_dashboard.rb
+++ b/administrate/lib/administrate/base_dashboard.rb
@@ -1,6 +1,7 @@
 require "administrate/fields/belongs_to"
 require "administrate/fields/email"
 require "administrate/fields/has_many"
+require "administrate/fields/has_one"
 require "administrate/fields/image"
 require "administrate/fields/string"
 

--- a/administrate/lib/administrate/fields/has_one.rb
+++ b/administrate/lib/administrate/fields/has_one.rb
@@ -1,0 +1,11 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class HasOne < BelongsTo
+      def self.permitted_attribute(attr)
+        attr
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -38,7 +38,9 @@ module Administrate
 
       def association_type(attribute)
         reflection = klass.reflections[attribute.to_s]
-        if reflection.collection?
+        if reflection.has_one?
+          "Field::HasOne"
+        elsif reflection.collection?
           "Field::HasMany" + has_many_options_string(reflection)
         else
           "Field::BelongsTo"

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -60,6 +60,30 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         expect(dashboard).to contain("customer: Field::BelongsTo")
       end
+
+      it "detects has_one relationships" do
+        ActiveRecord::Schema.define do
+          create_table :accounts, force: true
+
+          create_table :profiles, force: true do |t|
+            t.references :account
+          end
+        end
+
+        class Account < ActiveRecord::Base
+          has_one :profile
+        end
+
+        class Ticket < ActiveRecord::Base
+          belongs_to :account
+        end
+
+        dashboard = file("app/dashboards/account_dashboard.rb")
+
+        run_generator ["account"]
+
+        expect(dashboard).to contain("profile: Field::HasOne")
+      end
     end
 
     describe "#table_attributes" do


### PR DESCRIPTION
Add a `Field` and partials to support `has_one` relationships.

Previously, the generators would mistakenly recognize `has_one` relationships as `belongs_to` relationships, and try to use the `belongs_to` partials to display the relationship.

This change adds support for recognizing `has_one` relationships and displaying them correctly on the page.

https://trello.com/c/vz3R8hh3
