### PR TITLE
Add `.permitted_attribute` to `Field::Deferred`

### DIFF
--- a/administrate/lib/administrate/fields/deferred.rb
+++ b/administrate/lib/administrate/fields/deferred.rb
@@ -7,8 +7,14 @@ module Administrate
       end
 
       def new(*args)
-        @klass.new(*args, @options)
+        klass.new(*args, options)
       end
+
+      delegate :permitted_attribute, to: :klass
+
+      private
+
+      attr_reader :klass, :options
     end
   end
 end

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "administrate/fields/deferred"
+require "administrate/fields/string"
+
+describe Administrate::Field::Deferred do
+  describe "#permitted_attribute" do
+    it "delegates to the backing class" do
+      deferred = Administrate::Field::Deferred.new(Administrate::Field::String)
+      allow(Administrate::Field::String).to receive(:permitted_attribute)
+
+      deferred.permitted_attribute(:foo)
+
+      expect(Administrate::Field::String).
+        to have_received(:permitted_attribute).with(:foo)
+    end
+  end
+end


### PR DESCRIPTION
Why:
- Administrate was giving error messages when users try to update a
  field that has options.

This change addresses the need by delegating from `Field::Deferred` to
the backing `Field` class.

Tags: #ruby
