### PR TITLE
Update `uglifier` to improve security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "refills"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
 gem "title"
-gem "uglifier"
+gem "uglifier", ">= 2.7.2"
 gem "unicorn"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       rails (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicorn (4.8.3)
@@ -327,7 +327,7 @@ DEPENDENCIES
   spring-commands-rspec
   timecop
   title
-  uglifier
+  uglifier (>= 2.7.2)
   unicorn
   web-console (>= 2.1.3)
   webmock


### PR DESCRIPTION
Based on the recommendations of [bundler-audit](https://rubygems.org/gems/bundler-audit):

```
ruby-advisory-db: 227 advisories
Name: uglifier
Version: 2.7.0
Advisory: OSVDB-126747
Criticality: Unknown
URL: https://github.com/mishoo/UglifyJS2/issues/751
Title: uglifier incorrectly handles non-boolean comparisons during
minification
Solution: upgrade to >= 2.7.2

Unpatched versions found!
```
