### PR TITLE
Fix name collision for `FooDashboard` in specs

### DIFF
--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -182,8 +182,4 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       )
     end
   end
-
-  def remove_constants(*constants)
-    constants.each { |const| Object.send(:remove_const, const) }
-  end
 end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "administrate/fields/has_many"
+require "support/constant_helpers"
 
 describe Administrate::Field::HasMany do
   describe "#to_partial_path" do
@@ -27,17 +28,22 @@ describe Administrate::Field::HasMany do
 
   describe "class_name option" do
     it "determines what dashboard is used to present the association" do
-      FooDashboard = Class.new
-      dashboard_double = double(table_attributes: [])
-      allow(FooDashboard).to receive(:new).and_return(dashboard_double)
+      begin
+        FooDashboard = Class.new
+        dashboard_double = double(table_attributes: [])
+        allow(FooDashboard).to receive(:new).and_return(dashboard_double)
 
-      association = Administrate::Field::HasMany.with_options(class_name: "Foo")
-      field = association.new(:customers, [], :show)
-      table = field.associated_table
-      attributes = table.attribute_names
+        association = Administrate::Field::HasMany.
+          with_options(class_name: "Foo")
+        field = association.new(:customers, [], :show)
+        table = field.associated_table
+        attributes = table.attribute_names
 
-      expect(dashboard_double).to have_received(:table_attributes)
-      expect(attributes).to eq([])
+        expect(dashboard_double).to have_received(:table_attributes)
+        expect(attributes).to eq([])
+      ensure
+        remove_constants :FooDashboard
+      end
     end
   end
 end

--- a/spec/support/constant_helpers.rb
+++ b/spec/support/constant_helpers.rb
@@ -1,0 +1,9 @@
+module ConstantHelpers
+  def remove_constants(*constants)
+    constants.each { |const| Object.send(:remove_const, const) }
+  end
+end
+
+RSpec.configure do |config|
+  config.include ConstantHelpers
+end


### PR DESCRIPTION
A spec in `spec/lib/fields/has_many_spec.rb` was defining a constant
`FooDashboard`, but not cleaning it up when it finished. This caused
a generator spec that created a `FooDashboard` to fail, when it detected
a mismatched superclass between the two definitions.

It's best to ignore whitespace while looking at this diff:
https://github.com/thoughtbot/administrate/pull/61/files?w=1
