### PR TITLE
Improve flash performance and formatting

### DIFF
--- a/administrate/app/assets/stylesheets/administrate/base/_variables.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/_variables.scss
@@ -38,7 +38,7 @@ $dark-blue: #293f53;
 $blue: #2a94d6;
 $light-blue: #4eb1cb;
 $light-red: #c77067;
-$light-yellow: #f3ae4e;
+$light-yellow: #f0cd66;
 $light-green: #4ab471;
 
 $form-field-background-color: #fff;

--- a/administrate/app/assets/stylesheets/administrate/base/extends/_flashes.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/extends/_flashes.scss
@@ -11,28 +11,24 @@
   }
 }
 
-%flash-base {
-  font-weight: bold;
-  margin-bottom: $base-spacing / 2;
+.flash {
+  border-radius: $base-border-radius;
+  margin-top: $base-spacing;
   padding: $base-spacing / 2;
-}
 
-%flash-alert {
-  @extend %flash-base;
-  @include flash($alert-color);
-}
+  &--alert {
+    @include flash($alert-color);
+  }
 
-%flash-error {
-  @extend %flash-base;
-  @include flash($error-color);
-}
+  &--error {
+    @include flash($error-color);
+  }
 
-%flash-notice {
-  @extend %flash-base;
-  @include flash($notice-color);
-}
+  &--notice {
+    @include flash($notice-color);
+  }
 
-%flash-success {
-  @extend %flash-base;
-  @include flash($success-color);
+  &--success {
+    @include flash($success-color);
+  }
 }

--- a/administrate/app/views/administrate/application/_flashes.html.erb
+++ b/administrate/app/views/administrate/application/_flashes.html.erb
@@ -1,7 +1,7 @@
 <% if flash.any? %>
-  <div id="flash">
+  <div id="flashes">
     <% flash.each do |key, value| -%>
-      <div class="flash-<%= key %>"><%= value %></div>
+      <div class="flash flash--<%= key %>"><%= value %></div>
     <% end -%>
   </div>
 <% end %>

--- a/administrate/lib/generators/administrate/install/templates/application_controller.rb
+++ b/administrate/lib/generators/administrate/install/templates/application_controller.rb
@@ -14,7 +14,7 @@ class Admin::ApplicationController < Administrate::ApplicationController
   def index
     super
 
-    flash[:alert] =
+    flash.now[:alert] =
       "For performance, Administrate limits the index page to show 20 items.
       Customize this action to update/remove the limit,
       or implement the pagination library of your choice."

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -14,7 +14,7 @@ class Admin::ApplicationController < Administrate::ApplicationController
   def index
     super
 
-    flash[:alert] =
+    flash.now[:alert] =
       "For performance, Administrate limits the index page to show 20 items.
       Customize this action to update/remove the limit,
       or implement the pagination library of your choice."

--- a/spec/support/have_flash_matcher.rb
+++ b/spec/support/have_flash_matcher.rb
@@ -1,5 +1,5 @@
 module Features
   def have_flash(text)
-    have_css(".flash-notice", text: text)
+    have_css(".flash--notice", text: text)
   end
 end


### PR DESCRIPTION
Why?
- Flashes were being set using the `flash[:alert] =` syntax, which
  saves the flash for the next request the user makes (used during
  redirects, etc).
- When users visited the index page and then clicked through to another
  page, they would still see the index page's flash from the previous
  request.

This commit switches to the `flash.now[:alert] =` syntax, which only
sets the flash for the current request.

Also, switch flashes to use [BEM syntax](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/).

Tags: #ruby #design
