### PR TITLE
Standardize field label typography

### DIFF
--- a/administrate/app/assets/stylesheets/administrate/_typography.scss
+++ b/administrate/app/assets/stylesheets/administrate/_typography.scss
@@ -1,0 +1,7 @@
+.attribute-label {
+  color: $grey-4;
+  font-size: $small-font-size;
+  font-weight: $normal-font-weight;
+  letter-spacing: 0.0357em;
+  text-transform: uppercase;
+}

--- a/administrate/app/assets/stylesheets/administrate/application.scss
+++ b/administrate/app/assets/stylesheets/administrate/application.scss
@@ -13,5 +13,6 @@
 @import "layout";
 @import "sidebar";
 @import "show";
+@import "typography";
 
 @import "components/components";

--- a/administrate/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/_tables.scss
@@ -6,13 +6,8 @@ table {
 
 th {
   border-bottom: $dark-border;
-  color: $grey-4;
-  font-size: $small-font-size;
-  font-weight: $normal-font-weight;
-  letter-spacing: 0.0357em;
   padding: $small-spacing 0;
   text-align: left;
-  text-transform: uppercase;
 }
 
 td {

--- a/administrate/app/views/administrate/application/_table.html.erb
+++ b/administrate/app/views/administrate/application/_table.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <% table_presenter.attribute_names.each do |attr_name| %>
-        <th><%= attr_name.to_s.titleize %></th>
+        <th class="attribute-label"><%= attr_name.to_s.titleize %></th>
       <% end %>
       <th colspan="2"></th>
     </tr>

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -5,7 +5,7 @@
 
 <dl>
   <% @page.attributes.each do |attribute| %>
-    <dt><%= attribute.name.titleize %></dt>
+    <dt class="attribute-label"><%= attribute.name.titleize %></dt>
     <dd><%= render_field attribute %></dd>
   <% end %>
 </dl>


### PR DESCRIPTION
Previously, the index and show pages had different typography for field labels.

Tags: #design

Index page:

![administrate](https://cloud.githubusercontent.com/assets/829576/9613454/4fd4ca2a-50a0-11e5-99b3-4fd69e670d46.png)

Show page:

![administrate](https://cloud.githubusercontent.com/assets/829576/9613489/78a80c1e-50a0-11e5-8c7f-2c72b829cfdb.png)
