### PR TITLE
Line up table header on show page

### DIFF
--- a/administrate/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/_tables.scss
@@ -1,12 +1,11 @@
 table {
   border-collapse: separate;
-  margin: $small-spacing 0;
   width: 100%;
 }
 
 th {
   border-bottom: $dark-border;
-  padding: $small-spacing 0;
+  padding-bottom: $small-spacing;
   text-align: left;
 }
 

--- a/administrate/app/assets/stylesheets/administrate/base/extends/_flashes.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/extends/_flashes.scss
@@ -1,6 +1,7 @@
 @mixin flash($color) {
   background: $color;
   color: darken($color, 60);
+  margin-bottom: $base-spacing;
 
   a {
     color: darken($color, 70);
@@ -13,7 +14,6 @@
 
 .flash {
   border-radius: $base-border-radius;
-  margin-top: $base-spacing;
   padding: $base-spacing / 2;
 
   &--alert {

--- a/administrate/app/assets/stylesheets/administrate/components/_header.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_header.scss
@@ -2,7 +2,7 @@
   @include display(flex);
   @include justify-content(space-between);
   @include align-items(flex-end);
-  padding: $base-spacing 0;
+  margin-bottom: $base-spacing;
 
   &-heading {
     margin-top: 0;

--- a/administrate/app/assets/stylesheets/administrate/layout.scss
+++ b/administrate/app/assets/stylesheets/administrate/layout.scss
@@ -22,5 +22,5 @@ body {
   @include card(1);
   background-color: $white;
   overflow-y: auto;
-  padding: 0 $gutter;
+  padding: $base-spacing;
 }


### PR DESCRIPTION
- Remove all padding and margins from top of table
- Add bottom padding/margins on index page elements to compensate

Tags: #design

![administrate](https://cloud.githubusercontent.com/assets/829576/9614295/d267f3e0-50a5-11e5-9a8d-b8fc0eb8b775.png)
