### PR TITLE
Require lib files on engine load, not per-request

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,6 @@
+* Bug Fix: Improve development environment;
+  developers can now edit Administrate-related files
+  without needing to restart their server afterwards.
 * Improvement: Stop flash from index page from persisting across requests
 * UI: Use a light background
 * UI: Improve element spacing on index page

--- a/administrate/app/controllers/administrate/application_controller.rb
+++ b/administrate/app/controllers/administrate/application_controller.rb
@@ -1,9 +1,3 @@
-require "administrate/namespace"
-require "administrate/page/form"
-require "administrate/page/table"
-require "administrate/page/show"
-require "administrate/resource_resolver"
-
 module Administrate
   class ApplicationController < ActionController::Base
     def index

--- a/administrate/lib/administrate/engine.rb
+++ b/administrate/lib/administrate/engine.rb
@@ -2,6 +2,12 @@ require "neat"
 require "normalize-rails"
 require "selectize-rails"
 
+require "administrate/namespace"
+require "administrate/page/form"
+require "administrate/page/show"
+require "administrate/page/table"
+require "administrate/resource_resolver"
+
 module Administrate
   class Engine < ::Rails::Engine
     isolate_namespace Administrate


### PR DESCRIPTION
Why?

After changing `app/controllers/admin/application_controller` or other
controllers that required Administrate, the app would throw an error
on the following request.

```
NameError in Admin::ApplicationController#show
uninitialized constant Administrate::ResourceResolver
```

For some reason I'm not sure of, moving the `require` statements into
the rails engine file takes care of the problem. The engine is required
from `lib/administrate.rb`, which I assume is required by Bundler at the
start of the process.

Developers can now edit classes without invalidating the loaded classes.

Tags: #ruby
