### PR TITLE
Align number fields to the right in tables

### DIFF
--- a/administrate/app/assets/stylesheets/administrate/application.scss
+++ b/administrate/app/assets/stylesheets/administrate/application.scss
@@ -13,6 +13,5 @@
 @import "layout";
 @import "sidebar";
 @import "show";
-@import "typography";
 
 @import "components/components";

--- a/administrate/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/administrate/app/assets/stylesheets/administrate/base/_tables.scss
@@ -3,30 +3,22 @@ table {
   width: 100%;
 }
 
+th,
+td {
+  padding: $small-spacing;
+  vertical-align: middle;
+}
+
 th {
   border-bottom: $dark-border;
-  padding-bottom: $small-spacing;
+  padding-top: 0;
   text-align: left;
 }
 
 td {
   border-bottom: $base-border;
   overflow: hidden;
-  padding: $small-spacing 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   word-wrap: normal;
-}
-
-td,
-th {
-  &:first-child {
-    padding-left: 1em;
-  }
-}
-
-tr,
-td,
-th {
-  vertical-align: middle;
 }

--- a/administrate/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_cells.scss
@@ -1,7 +1,13 @@
+.cell-label,
 .attribute-label {
   color: $grey-4;
   font-size: $small-font-size;
   font-weight: $normal-font-weight;
   letter-spacing: 0.0357em;
   text-transform: uppercase;
+}
+
+.cell-data--number,
+.cell-label--number {
+  text-align: right;
 }

--- a/administrate/app/assets/stylesheets/administrate/components/_components.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_components.scss
@@ -1,3 +1,4 @@
+@import "cells";
 @import "form";
 @import "header";
 @import "table";

--- a/administrate/app/views/administrate/application/_table.html.erb
+++ b/administrate/app/views/administrate/application/_table.html.erb
@@ -1,8 +1,10 @@
 <table>
   <thead>
     <tr>
-      <% table_presenter.attribute_names.each do |attr_name| %>
-        <th class="attribute-label"><%= attr_name.to_s.titleize %></th>
+      <% table_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label cell-label--<%= attr_type.html_class %>">
+          <%= attr_name.to_s.titleize %>
+        </th>
       <% end %>
       <th colspan="2"></th>
     </tr>
@@ -16,7 +18,7 @@
           data-url="<%= polymorphic_path([Administrate::NAMESPACE, resource]) -%>"
           >
         <% table_presenter.attributes_for(resource).each do |attribute| %>
-          <td class="field-<%= attribute.html_class %>">
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
             <%= render_field attribute %>
           </td>
         <% end %>

--- a/administrate/lib/administrate/fields/base.rb
+++ b/administrate/lib/administrate/fields/base.rb
@@ -7,6 +7,10 @@ module Administrate
         Deferred.new(self, options)
       end
 
+      def self.html_class
+        field_type.dasherize
+      end
+
       def initialize(attribute, data, page, options = {})
         @attribute = attribute
         @data = data
@@ -19,7 +23,7 @@ module Administrate
       end
 
       def html_class
-        field_name.dasherize
+        self.class.html_class
       end
 
       def name
@@ -27,7 +31,7 @@ module Administrate
       end
 
       def to_partial_path
-        "/fields/#{field_name}/#{page}"
+        "/fields/#{self.class.field_type}/#{page}"
       end
 
       attr_reader :attribute, :data, :page
@@ -36,8 +40,8 @@ module Administrate
 
       attr_reader :options
 
-      def field_name
-        self.class.to_s.split("::").last.underscore
+      def self.field_type
+        to_s.split("::").last.underscore
       end
     end
   end

--- a/administrate/lib/administrate/fields/deferred.rb
+++ b/administrate/lib/administrate/fields/deferred.rb
@@ -16,7 +16,7 @@ module Administrate
         deferred_class == other.deferred_class && options == other.options
       end
 
-      delegate :permitted_attribute, to: :deferred_class
+      delegate :html_class, :permitted_attribute, to: :deferred_class
     end
   end
 end

--- a/administrate/lib/administrate/page/table.rb
+++ b/administrate/lib/administrate/page/table.rb
@@ -13,6 +13,10 @@ module Administrate
         end
       end
 
+      def attribute_types
+        dashboard.attribute_types.slice(*attribute_names)
+      end
+
       def to_partial_path
         "/dashboard/table"
       end

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -11,7 +11,7 @@ class LineItemDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     order: Field::BelongsTo,
     product: Field::BelongsTo,
-    quantity: Field::Number,
+    quantity: Field::Number.with_options(decimals: 0),
     total_price: Field::Number.with_options(prefix: "$"),
     unit_price: Field::Number.with_options(prefix: "$"),
   }

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -12,7 +12,7 @@ module Features
   end
 
   def clickable_table_elements
-    ".field-string, .field-number"
+    ".cell-data--string, .cell-data--number"
   end
 
   def url_for(model)


### PR DESCRIPTION
Why?
- It's easiest to read numbers in a table if they're right-aligned

Changes:
- Switch table elements to BEM syntax
  - not sure if this is best practice, because the field elements are
    not all contained in a single `.field` div.
  - I like it because on index and show pages, we can reuse the classes,
    and wrap them in a `.field` div there.
- Move `html_class` from instance to class method on `Field::Base` so we
  can use the field type to align the table headers.

![administrate](https://cloud.githubusercontent.com/assets/829576/9667508/0e894f04-5231-11e5-9f12-09e42961d1fc.png)

Tags: #ruby #design
