### PR TITLE
[generator] don't show decimals for integer fields

### DIFF
--- a/administrate/lib/administrate/fields/number.rb
+++ b/administrate/lib/administrate/fields/number.rb
@@ -18,7 +18,7 @@ module Administrate
       end
 
       def decimals
-        options.fetch(:decimals, 2)
+        options.fetch(:decimals, 0)
       end
     end
   end

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -7,6 +7,11 @@ module Administrate
         integer: "Field::Number",
         float: "Field::Number",
       }
+
+      ATTRIBUTE_OPTIONS_MAPPING = {
+        float: { decimals: 2 },
+      }
+
       DEFAULT_FIELD_TYPE = "Field::String"
       TABLE_ATTRIBUTE_LIMIT = 4
 
@@ -33,7 +38,8 @@ module Administrate
         type = klass.column_types[attribute.to_s].type
 
         if type
-          ATTRIBUTE_TYPE_MAPPING.fetch(type, DEFAULT_FIELD_TYPE)
+          ATTRIBUTE_TYPE_MAPPING.fetch(type, DEFAULT_FIELD_TYPE) +
+            options_string(ATTRIBUTE_OPTIONS_MAPPING.fetch(type, {}))
         else
           association_type(attribute)
         end
@@ -63,7 +69,11 @@ module Administrate
       end
 
       def options_string(options)
-        ".with_options(#{inspect_hash_as_ruby(options)})"
+        if options.any?
+          ".with_options(#{inspect_hash_as_ruby(options)})"
+        else
+          ""
+        end
       end
 
       def inspect_hash_as_ruby(hash)

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -13,7 +13,7 @@ class CustomerDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     created_at: Field::String,
     email: Field::Email,
-    lifetime_value: Field::Number.with_options(prefix: "$"),
+    lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
     orders: Field::HasMany,
     updated_at: Field::String,

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -11,9 +11,9 @@ class LineItemDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     order: Field::BelongsTo,
     product: Field::BelongsTo,
-    quantity: Field::Number.with_options(decimals: 0),
-    total_price: Field::Number.with_options(prefix: "$"),
-    unit_price: Field::Number.with_options(prefix: "$"),
+    quantity: Field::Number,
+    total_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    unit_price: Field::Number.with_options(prefix: "$", decimals: 2),
   }
 
   TABLE_ATTRIBUTES = ATTRIBUTES + [:total_price]

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -22,7 +22,7 @@ class OrderDashboard < Administrate::BaseDashboard
     address_zip: Field::String,
     customer: Field::BelongsTo,
     line_items: Field::HasMany,
-    total_price: Field::Number.with_options(prefix: "$"),
+    total_price: Field::Number.with_options(prefix: "$", decimals: 2),
   }
 
   TABLE_ATTRIBUTES = ATTRIBUTES

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -12,7 +12,7 @@ class ProductDashboard < Administrate::BaseDashboard
     description: Field::String,
     image_url: Field::Image,
     name: Field::String,
-    price: Field::Number.with_options(prefix: "$"),
+    price: Field::Number.with_options(prefix: "$", decimals: 2),
   }
 
   TABLE_ATTRIBUTES = ATTRIBUTES

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -12,14 +12,15 @@ describe CustomerDashboard do
 
   describe "#attribute_types" do
     it "maps each attribute to an attribute field" do
+      Field = Administrate::Field
       dashboard = CustomerDashboard.new
 
       fields = dashboard.attribute_types
 
-      expect(fields[:name]).to eq(Administrate::Field::String)
-      expect(fields[:email]).to eq(Administrate::Field::Email)
+      expect(fields[:name]).to eq(Field::String)
+      expect(fields[:email]).to eq(Field::Email)
       expect(fields[:lifetime_value]).
-        to eq(Administrate::Field::Number.with_options(prefix: "$"))
+        to eq(Field::Number.with_options(prefix: "$", decimals: 2))
     end
   end
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -83,8 +83,10 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           load file("app/dashboards/inventory_item_dashboard.rb")
           attrs = InventoryItemDashboard::ATTRIBUTE_TYPES
 
-          expect(attrs[:quantity]).to eq(Administrate::Field::Number)
-          expect(attrs[:price]).to eq(Administrate::Field::Number)
+          expect(attrs[:price]).
+            to eq(Administrate::Field::Number.with_options(decimals: 2))
+          expect(attrs[:quantity]).
+            to eq(Administrate::Field::Number)
         ensure
           remove_constants :InventoryItem, :InventoryItemDashboard
         end

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -18,19 +18,19 @@ describe Administrate::Field::Number do
 
     it { should_permit_param(:foo, for_attribute: :foo) }
 
-    it "defaults to displaying two decimal points" do
+    it "defaults to displaying no decimal points" do
       int = Administrate::Field::Number.new(:quantity, 3, :show)
       float = Administrate::Field::Number.new(:quantity, 3.1415926, :show)
 
-      expect(int.to_s).to eq("3.00")
-      expect(float.to_s).to eq("3.14")
+      expect(int.to_s).to eq("3")
+      expect(float.to_s).to eq("3")
     end
 
     context "with `prefix` option" do
       it "displays the given prefix" do
         number = number_with_options(13, prefix: "$")
 
-        expect(number.to_s).to eq("$13.00")
+        expect(number.to_s).to eq("$13")
       end
     end
 


### PR DESCRIPTION
Why?

Previously, generators default to showing two decimal places
for all numbers unless a `decimals` option is set.
It was confusing to see integers displayed with decimals.

Changes:
- If a field is a float, explicitly set the number of decimals to
  display (2).
- If a field is an integer, don't set the number of decimals.
- Change `Field::Number` to not display any decimals unless the option
  is set.

Tags: #ruby
