### PR TITLE
Add support for Time, Date, and DateTime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ PATH
   specs:
     administrate (0.1.0)
       autoprefixer-rails
+      datetime_picker_rails (~> 0.0.4)
+      momentjs-rails (>= 2.9.0)
       neat (~> 1.1)
       normalize-rails (~> 3.0)
       rails (~> 4.2)
@@ -61,15 +63,15 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.0)
-    autoprefixer-rails (5.2.1.3)
+    autoprefixer-rails (6.0.0)
       execjs
       json
     awesome_print (1.6.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bourbon (4.2.3)
+    bourbon (4.2.4)
       sass (~> 3.4)
-      thor
+      thor (~> 0.19)
     builder (3.2.2)
     bundler-audit (0.3.1)
       bundler (~> 1.2)
@@ -99,6 +101,8 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.4.0)
+    datetime_picker_rails (0.0.4)
+      momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     delayed_job (4.0.6)
@@ -163,6 +167,8 @@ GEM
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
+    momentjs-rails (2.10.3)
+      railties (>= 3.1)
     multi_json (1.11.1)
     neat (1.7.2)
       bourbon (>= 4.0)

--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,7 @@
 New in 0.1.0:
 
+* Improvement: Add `Administrate::Field::DateTime`
+  for displaying dates, times, and datetimes.
 * Improvement: Add `Administrate::Field::Number`
   for displaying currency, integers, and floats.
   Supports options `prefix` and `decimals`.

--- a/administrate/administrate.gemspec
+++ b/administrate/administrate.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency "normalize-rails", "~> 3.0"
   s.add_dependency "rails", "~> 4.2"
   s.add_dependency "selectize-rails", "~> 0.6"
+  s.add_dependency "momentjs-rails", ">= 2.9.0"
+  s.add_dependency "datetime_picker_rails", "~> 0.0.4"
   s.add_dependency "autoprefixer-rails"
 
   s.description = <<-DESCRIPTION

--- a/administrate/app/assets/javascripts/administrate/application.js
+++ b/administrate/app/assets/javascripts/administrate/application.js
@@ -1,4 +1,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require selectize
+//= require moment
+//= require datetime_picker
 //= require_tree .

--- a/administrate/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/administrate/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,0 +1,3 @@
+$(function () {
+  $(".datetimepicker").datetimepicker({ format: "DD/MM/YYYY hh:mm:ss A" });
+});

--- a/administrate/app/assets/stylesheets/administrate/application.scss
+++ b/administrate/app/assets/stylesheets/administrate/application.scss
@@ -6,6 +6,7 @@
 @import "neat";
 
 @import "selectize";
+@import "datetime_picker";
 
 @import "mixins/mixins";
 @import "base/base";

--- a/administrate/app/assets/stylesheets/administrate/components/_components.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_components.scss
@@ -1,4 +1,5 @@
 @import "cells";
 @import "form";
+@import "date_time_picker";
 @import "header";
 @import "table";

--- a/administrate/app/assets/stylesheets/administrate/components/_date_time_picker.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_date_time_picker.scss
@@ -1,0 +1,3 @@
+.form-field {
+  position: relative;
+}

--- a/administrate/app/views/fields/date_time/_form.html.erb
+++ b/administrate/app/views/fields/date_time/_form.html.erb
@@ -1,0 +1,2 @@
+<%= f.label field.attribute %>
+<%= f.text_field field.attribute, class: "datetimepicker" %>

--- a/administrate/app/views/fields/date_time/_index.html.erb
+++ b/administrate/app/views/fields/date_time/_index.html.erb
@@ -1,0 +1,3 @@
+<% if field.data %>
+  <%= l field.data.to_date %>
+<% end %>

--- a/administrate/app/views/fields/date_time/_show.html.erb
+++ b/administrate/app/views/fields/date_time/_show.html.erb
@@ -1,0 +1,3 @@
+<% if field.data %>
+  <%= l field.data %>
+<% end %>

--- a/administrate/lib/administrate/base_dashboard.rb
+++ b/administrate/lib/administrate/base_dashboard.rb
@@ -1,4 +1,5 @@
 require "administrate/fields/belongs_to"
+require "administrate/fields/date_time"
 require "administrate/fields/email"
 require "administrate/fields/has_many"
 require "administrate/fields/has_one"

--- a/administrate/lib/administrate/engine.rb
+++ b/administrate/lib/administrate/engine.rb
@@ -1,6 +1,8 @@
 require "neat"
 require "normalize-rails"
 require "selectize-rails"
+require "momentjs-rails"
+require "datetime_picker_rails"
 
 require "administrate/namespace"
 require "administrate/page/form"

--- a/administrate/lib/administrate/fields/date_time.rb
+++ b/administrate/lib/administrate/fields/date_time.rb
@@ -1,0 +1,6 @@
+module Administrate
+  module Field
+    class DateTime < Base
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -4,8 +4,11 @@ module Administrate
   module Generators
     class DashboardGenerator < Rails::Generators::NamedBase
       ATTRIBUTE_TYPE_MAPPING = {
-        integer: "Field::Number",
+        date: "Field::DateTime",
+        datetime: "Field::DateTime",
         float: "Field::Number",
+        integer: "Field::Number",
+        time: "Field::DateTime",
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {

--- a/app/dashboards/customer_dashboard.rb
+++ b/app/dashboards/customer_dashboard.rb
@@ -11,12 +11,12 @@ class CustomerDashboard < Administrate::BaseDashboard
   ]
 
   ATTRIBUTE_TYPES = {
-    created_at: Field::String,
+    created_at: Field::DateTime,
     email: Field::Email,
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
     orders: Field::HasMany,
-    updated_at: Field::String,
+    updated_at: Field::DateTime,
   }
 
   TABLE_ATTRIBUTES = ATTRIBUTES

--- a/app/dashboards/line_item_dashboard.rb
+++ b/app/dashboards/line_item_dashboard.rb
@@ -9,6 +9,8 @@ class LineItemDashboard < Administrate::BaseDashboard
   ]
 
   ATTRIBUTE_TYPES = {
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
     order: Field::BelongsTo,
     product: Field::BelongsTo,
     quantity: Field::Number,

--- a/app/dashboards/order_dashboard.rb
+++ b/app/dashboards/order_dashboard.rb
@@ -1,20 +1,10 @@
 require "administrate/base_dashboard"
 
 class OrderDashboard < Administrate::BaseDashboard
-  ATTRIBUTES = [
-    :id,
-    :address_line_one,
-    :address_line_two,
-    :address_city,
-    :address_state,
-    :address_zip,
-    :customer,
-    :line_items,
-    :total_price,
-  ]
-
   ATTRIBUTE_TYPES = {
     id: Field::Number,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
     address_line_one: Field::String,
     address_line_two: Field::String,
     address_city: Field::String,
@@ -23,9 +13,17 @@ class OrderDashboard < Administrate::BaseDashboard
     customer: Field::BelongsTo,
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    shipped_at: Field::DateTime,
   }
 
-  TABLE_ATTRIBUTES = ATTRIBUTES
-  FORM_ATTRIBUTES = ATTRIBUTES - [:id, :total_price]
-  SHOW_PAGE_ATTRIBUTES = ATTRIBUTES
+  READ_ONLY_ATTRIBUTES = [
+    :id,
+    :total_price,
+    :created_at,
+    :updated_at,
+  ]
+
+  TABLE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+  FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
+  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
 end

--- a/app/dashboards/product_dashboard.rb
+++ b/app/dashboards/product_dashboard.rb
@@ -9,6 +9,8 @@ class ProductDashboard < Administrate::BaseDashboard
   ]
 
   ATTRIBUTE_TYPES = {
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
     description: Field::String,
     image_url: Field::Image,
     name: Field::String,

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,9 @@ Rails.application.config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w(
+  bootstrap/glyphicons-halflings-regular.eot
+  bootstrap/glyphicons-halflings-regular.woff
+  bootstrap/glyphicons-halflings-regular.ttf
+  bootstrap/glyphicons-halflings-regular.svg
+)

--- a/db/migrate/20150903215027_add_shipped_at_to_orders.rb
+++ b/db/migrate/20150903215027_add_shipped_at_to_orders.rb
@@ -1,0 +1,5 @@
+class AddShippedAtToOrders < ActiveRecord::Migration
+  def change
+    add_column :orders, :shipped_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150417044505) do
+ActiveRecord::Schema.define(version: 20150903215027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20150417044505) do
     t.string   "address_zip"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
+    t.datetime "shipped_at"
   end
 
   add_index "orders", ["customer_id"], name: "index_orders_on_customer_id", using: :btree

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -55,4 +55,35 @@ describe "order form" do
       field.find("option", text: associated_model.to_s)
     end
   end
+
+  describe "datetime field" do
+    pending "correctly parses dates" do
+      order = create(:order)
+
+      visit edit_admin_order_path(order)
+      fill_in("Shipped at", with: "09/03/2015 7:18 AM")
+      click_on "Update Order"
+
+      expect(page).to have_content("Thu, Sep 3, 2015 at 07:18:00 AM")
+    end
+
+    it "responds to the date/time picker date format", :js do
+      order = create(:order)
+
+      visit edit_admin_order_path(order)
+      select_from_datepicker(Time.new(2015, 01, 02, 03, 04, 05))
+      click_on "Update Order"
+
+      expect(page).to have_content("Fri, Jan 2, 2015 at 03:04:05 AM")
+    end
+
+    def select_from_datepicker(time)
+      time_string = time.to_s[0..-7]
+
+      page.execute_script(<<-JS)
+        var date = moment("#{time_string}", "YYYY-MM-DD hh:mm:ss");
+        $(".datetimepicker").data("DateTimePicker").date(date);
+      JS
+    end
+  end
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -28,8 +28,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           attrs = FooDashboard::ATTRIBUTE_TYPES
 
           expect(attrs[:id]).to eq(Administrate::Field::Number)
-          expect(attrs[:created_at]).to eq(Administrate::Field::String)
-          expect(attrs[:updated_at]).to eq(Administrate::Field::String)
+          expect(attrs[:created_at]).to eq(Administrate::Field::DateTime)
+          expect(attrs[:updated_at]).to eq(Administrate::Field::DateTime)
         ensure
           remove_constants :Foo, :FooDashboard
         end
@@ -89,6 +89,32 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             to eq(Administrate::Field::Number)
         ensure
           remove_constants :InventoryItem, :InventoryItemDashboard
+        end
+      end
+
+      it "assigns dates, times, and datetimes a type of `DateTime`" do
+        begin
+          ActiveRecord::Schema.define do
+            create_table :events do |t|
+              t.date :start_date
+              t.time :start_time
+              t.datetime :ends_at
+            end
+          end
+
+          class Event < ActiveRecord::Base
+            reset_column_information
+          end
+
+          run_generator ["event"]
+          load file("app/dashboards/event_dashboard.rb")
+          attrs = EventDashboard::ATTRIBUTE_TYPES
+
+          expect(attrs[:start_date]).to eq(Administrate::Field::DateTime)
+          expect(attrs[:start_time]).to eq(Administrate::Field::DateTime)
+          expect(attrs[:ends_at]).to eq(Administrate::Field::DateTime)
+        ensure
+          remove_constants :Event, :EventDashboard
         end
       end
 

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -1,0 +1,6 @@
+require "spec_helper"
+require "administrate/fields/date_time"
+require "support/field_matchers"
+
+describe Administrate::Field::DateTime do
+end

--- a/spec/support/constant_helpers.rb
+++ b/spec/support/constant_helpers.rb
@@ -1,6 +1,8 @@
 module ConstantHelpers
   def remove_constants(*constants)
     constants.each { |const| Object.send(:remove_const, const) }
+  rescue NameError => e
+    $stderr.puts "Warning from ConstantHelpers::remove_constants:\n\t#{e}"
   end
 end
 


### PR DESCRIPTION
https://trello.com/c/UkczYXFe/58-datetime-fields

Why?

Up until now, dates, times, and datetimes have been displayed in the app looking something like this: `2015-07-31 23:48:57 UTC`.

That's terrible.

Changes:
- Update generators to assign DateTime fields
- Add views for Field::DateTime
- Add datetime table column to Orders for testing
- Add a date/time picker to DateTime fields
  - Manually entering dates is difficult, tedious, and error-prone.

Related changes:
- Created the [datetime_picker_rails](http://github.com/graysonwright/datetime_picker_rails) gem based on [Bootstrap 3 Datepicker](http://eonasdan.github.io/bootstrap-datetimepicker/).

---

![administrate_and_developer_tools_-_http___eonasdan_github_io_bootstrap-datetimepicker_](https://cloud.githubusercontent.com/assets/829576/9676334/bd8f62de-527e-11e5-81ed-43cc11afbabf.png)

---

![administrate_and_developer_tools_-_http___eonasdan_github_io_bootstrap-datetimepicker_](https://cloud.githubusercontent.com/assets/829576/9676337/d10790c0-527e-11e5-88f6-167a683b003a.png)

---

![datetime_picker](https://cloud.githubusercontent.com/assets/829576/9676331/a018c38a-527e-11e5-9c0a-32e5f841df66.gif)

---

Tags: #ruby
