### PR TITLE
Fix crash when displaying `nil` numbers

### DIFF
--- a/administrate/lib/administrate/fields/number.rb
+++ b/administrate/lib/administrate/fields/number.rb
@@ -4,7 +4,11 @@ module Administrate
   module Field
     class Number < Field::Base
       def to_s
-        format_string % data
+        if data.nil?
+          "-"
+        else
+          format_string % data
+        end
       end
 
       private

--- a/spec/administrate/views/fields/has_many/_show_spec.rb
+++ b/spec/administrate/views/fields/has_many/_show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "fields/show/_has_many", type: :view do
+describe "fields/has_many/_show", type: :view do
   context "without any associated records" do
     it "displays 'None'" do
       has_many = double(data: [])

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -15,9 +15,11 @@ describe Administrate::Field::Number do
 
       expect(path).to eq("/fields/number/#{page}")
     end
+  end
 
-    it { should_permit_param(:foo, for_attribute: :foo) }
+  it { should_permit_param(:foo, for_attribute: :foo) }
 
+  describe "#to_s" do
     it "defaults to displaying no decimal points" do
       int = Administrate::Field::Number.new(:quantity, 3, :show)
       float = Administrate::Field::Number.new(:quantity, 3.1415926, :show)
@@ -49,6 +51,14 @@ describe Administrate::Field::Number do
         number = number_with_options(12, decimals: 2)
 
         expect(number.to_s).to eq("12.00")
+      end
+    end
+
+    context "when data is nil" do
+      it "returns a dash" do
+        number = Administrate::Field::Number.new(:number, nil, :page)
+
+        expect(number.to_s).to eq("-")
       end
     end
 


### PR DESCRIPTION
Problem: When a number field is nil (doesn't have a value), the index
and show pages that display the field throw an error, which appears to
the user as a 500 internal server error.

![image](https://cloud.githubusercontent.com/assets/829576/9827644/04909b2e-5899-11e5-9d0d-80544d3cee35.png)

https://trello.com/c/plIMUtZd

Solution: Handle `nil` values specifically in `Number` fields, by
displaying a "-" to represent them.

Tags: #ruby
