### PR TITLE
Preserve whitespace for strings on show page

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,6 @@
 New in 0.1.0:
 
+* UI: Improve formatting of strings on `index` and `show` pages
 * Improvement: Generate a single controller to serve all resources,
   to reduce noise after running the install generator.
 * Improvement: Add `Administrate::Field::DateTime`

--- a/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -1,0 +1,3 @@
+.attribute-data--string {
+  white-space: pre;
+}

--- a/administrate/app/assets/stylesheets/administrate/components/_components.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_components.scss
@@ -1,3 +1,4 @@
+@import "attributes";
 @import "cells";
 @import "form";
 @import "date_time_picker";

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -1,11 +1,17 @@
 <header class="header">
   <h1 class="header-heading"><%= @page.page_title %></h1>
-  <%= link_to 'Edit', [:edit, Administrate::NAMESPACE, @page.resource], class: "button" %>
+  <%= link_to(
+    "Edit",
+    [:edit, Administrate::NAMESPACE, @page.resource],
+    class: "button",
+  ) %>
 </header>
 
 <dl>
   <% @page.attributes.each do |attribute| %>
     <dt class="attribute-label"><%= attribute.name.titleize %></dt>
-    <dd><%= render_field attribute %></dd>
+    <dd class="attribute-data--<%=attribute.html_class%>">
+      <%= render_field attribute %>
+    </dd>
   <% end %>
 </dl>

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -1,7 +1,10 @@
 require "spec_helper"
 require "administrate/fields/string"
+require "support/field_matchers"
 
 describe Administrate::Field::String do
+  include FieldMatchers
+
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show
@@ -12,4 +15,6 @@ describe Administrate::Field::String do
       expect(path).to eq("/fields/string/#{page}")
     end
   end
+
+  it { should_permit_param(:foo, for_attribute: :foo) }
 end


### PR DESCRIPTION
Problem: Long description fields were being all mashed onto a single
line on the 'show' page, making it difficult to read.

https://trello.com/c/xueiirQV

Solution: Add a CSS class to mark the type of each attribute on the show
page, then add a rule to preserve whitespace.

Before:
![image](https://cloud.githubusercontent.com/assets/829576/9828845/964b9866-58a8-11e5-956b-9773f855d129.png)

After:
<img width="1042" alt="administrate" src="https://cloud.githubusercontent.com/assets/829576/9828842/85ffdff8-58a8-11e5-8c51-500617bff993.png">
- [ ] update the CHANGELOG

Tags: #ruby, #design
