### PR TITLE
Truncate strings on the index page

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -4,7 +4,9 @@ New in 0.1.0:
   such as `post_id` or `post_type`.
 * Bug Fix: Squash several 500 errors caused by polymorphic relationships.
 * Improvement: support models that have a custom `to_param` method.
-* UI: Improve formatting of strings on `index` and `show` pages
+* UI: Show whitespace in strings on `show` pages
+* Improvement: Truncate strings on index page,
+  with an optional argument for truncation length
 * Improvement: Generate a single controller to serve all resources,
   to reduce noise after running the install generator.
 * Improvement: Add `Administrate::Field::DateTime`

--- a/administrate/app/views/fields/string/_index.html.erb
+++ b/administrate/app/views/fields/string/_index.html.erb
@@ -1,1 +1,1 @@
-<%= field.data %>
+<%= field.truncate %>

--- a/administrate/lib/administrate/fields/string.rb
+++ b/administrate/lib/administrate/fields/string.rb
@@ -3,6 +3,15 @@ require_relative "base"
 module Administrate
   module Field
     class String < Field::Base
+      def truncate
+        data[0...truncation_length]
+      end
+
+      private
+
+      def truncation_length
+        options.fetch(:truncate, 50)
+      end
     end
   end
 end

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -17,4 +17,30 @@ describe Administrate::Field::String do
   end
 
   it { should_permit_param(:foo, for_attribute: :foo) }
+
+  describe "#truncate" do
+    it "defaults to displaying up to 50 characters" do
+      short = Administrate::Field::String.new(:title, lorem(30), :show)
+      long = Administrate::Field::String.new(:description, lorem(60), :show)
+
+      expect(short.truncate).to eq(lorem(30))
+      expect(long.truncate).to eq(lorem(50))
+    end
+
+    context "with a `truncate` option" do
+      it "shortens to the given length" do
+        string = string_with_options(lorem(30), truncate: 20)
+
+        expect(string.truncate).to eq(lorem(20))
+      end
+    end
+  end
+
+  def string_with_options(string, options)
+    Administrate::Field::String.new(:string, string, :page, options)
+  end
+
+  def lorem(n)
+    "a" * n
+  end
 end


### PR DESCRIPTION
Problem: Strings were being super long on the index page, and expanding
the table past the right side of the browser window.

https://trello.com/c/0217s76j

Solution: truncate the strings.

Developers can specify a custom truncation length by passing in a truncate option:

``` ruby
ATTRIBUTE_TYPES = [
  title: Field::String.with_options(truncate: 20),
  description: Field::String, # by default, truncated to 50 characters
]
```
- [x] update the CHANGELOG
