### PR TITLE
Support looking up models by custom param

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,6 @@
 New in 0.1.0:
 
+* Improvement: support models that have a custom `to_param` method.
 * UI: Improve formatting of strings on `index` and `show` pages
 * Improvement: Generate a single controller to serve all resources,
   to reduce noise after running the install generator.

--- a/administrate/app/controllers/administrate/application_controller.rb
+++ b/administrate/app/controllers/administrate/application_controller.rb
@@ -75,8 +75,12 @@ module Administrate
     end
 
     def set_resource(resource = nil)
-      resource ||= resolver.resource_class.find(params[:id])
+      resource ||= find_resource(params[:id])
       instance_variable_set(instance_variable, resource)
+    end
+
+    def find_resource(param)
+      resolver.resource_class.find(param)
     end
 
     def resource

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class ProductsController < Admin::ApplicationController
+    private
+
+    def find_resource(param)
+      Product.find_by!(slug: param)
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,4 +7,13 @@ class Product < ActiveRecord::Base
   def to_s
     name
   end
+
+  def name=(value)
+    self.slug = value.to_s.parameterize
+    super(value)
+  end
+
+  def to_param
+    slug
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :admin do
     resources :customers
+    resources :products
 
     DashboardManifest::DASHBOARDS.each do |resource_class|
       resources(

--- a/db/migrate/20150914175022_add_slug_to_products.rb
+++ b/db/migrate/20150914175022_add_slug_to_products.rb
@@ -1,0 +1,17 @@
+class AddSlugToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :slug, :string, null: true
+
+    products = select_all("select id, name from products")
+    products.each do |product|
+      update(<<-SQL)
+        UPDATE products
+          SET slug='#{product['name'].parameterize}'
+          WHERE id=#{product['id']}
+      SQL
+    end
+
+    change_column_null :products, :slug, false
+    add_index :products, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150903215027) do
+ActiveRecord::Schema.define(version: 20150914175022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,10 @@ ActiveRecord::Schema.define(version: 20150903215027) do
     t.string   "image_url"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "slug",        null: false
   end
+
+  add_index "products", ["slug"], name: "index_products_on_slug", unique: true, using: :btree
 
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
   end
 
   factory :product do
-    name "Monopoly"
+    sequence(:name) { |n| "Monopoly #{n}" }
     price 10.50
     description "A cutthroat game of financial conquest"
     image_url \


### PR DESCRIPTION
Problem:
When a model overrides `#to_param` to have more meaningful URLs,
Administrate was still trying to look the objects up by their `id`s
instead of by whatever attribute the `param` was representing.

Solution:
- Extract a `find_resource` method in dashboard controllers
- Devs can override the method to look up resources using custom logic

Side Effects:
- Add a custom to_param to Product model for testing

See https://trello.com/c/ew5pA2G5

Tags: #ruby
