### PR TITLE
Add support for polymorphic relationships

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,8 @@
 New in 0.1.0:
 
+* Improvement: Don't display redundant attributes for belongs_to relationships,
+  such as `post_id` or `post_type`.
+* Bug Fix: Squash several 500 errors caused by polymorphic relationships.
 * Improvement: support models that have a custom `to_param` method.
 * UI: Improve formatting of strings on `index` and `show` pages
 * Improvement: Generate a single controller to serve all resources,

--- a/administrate/app/views/fields/polymorphic/_form.html.erb
+++ b/administrate/app/views/fields/polymorphic/_form.html.erb
@@ -1,0 +1,3 @@
+<%= f.label field.name %>
+
+<%= t("administrate.fields.polymorphic.not_supported") %>

--- a/administrate/app/views/fields/polymorphic/_index.html.erb
+++ b/administrate/app/views/fields/polymorphic/_index.html.erb
@@ -1,0 +1,6 @@
+<% if field.data %>
+  <%= link_to(
+    field.data.to_s,
+    polymorphic_path([:admin, field.data])
+  ) %>
+<% end %>

--- a/administrate/app/views/fields/polymorphic/_show.html.erb
+++ b/administrate/app/views/fields/polymorphic/_show.html.erb
@@ -1,0 +1,6 @@
+<% if field.data %>
+  <%= link_to(
+    field.data.to_s,
+    polymorphic_path([:admin, field.data])
+  ) %>
+<% end %>

--- a/administrate/config/locales/administrate.en.yml
+++ b/administrate/config/locales/administrate.en.yml
@@ -8,6 +8,8 @@ en:
     fields:
       has_many:
         none: None
+      polymorphic:
+        not_supported: "Polymorphic relationship forms are not supported yet. Sorry!"
     controller:
       create:
         success: "%{resource} was successfully created."

--- a/administrate/lib/administrate/base_dashboard.rb
+++ b/administrate/lib/administrate/base_dashboard.rb
@@ -5,6 +5,7 @@ require "administrate/fields/has_many"
 require "administrate/fields/has_one"
 require "administrate/fields/image"
 require "administrate/fields/number"
+require "administrate/fields/polymorphic"
 require "administrate/fields/string"
 
 module Administrate

--- a/administrate/lib/administrate/fields/polymorphic.rb
+++ b/administrate/lib/administrate/fields/polymorphic.rb
@@ -1,0 +1,8 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class Polymorphic < Base
+    end
+  end
+end

--- a/administrate/lib/administrate/page/base.rb
+++ b/administrate/lib/administrate/page/base.rb
@@ -13,14 +13,18 @@ module Administrate
       protected
 
       def attribute_field(dashboard, resource, attribute_name, page)
-        value = resource.public_send(attribute_name)
+        value = get_attribute_value(resource, attribute_name)
 
         dashboard.
           attribute_types[attribute_name].
           new(attribute_name, value, page)
       end
 
-      protected
+      def get_attribute_value(resource, attribute_name)
+        resource.public_send(attribute_name)
+      rescue NameError
+        nil
+      end
 
       attr_reader :dashboard
     end

--- a/spec/administrate/views/fields/polymorphic/_form_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_form_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "fields/polymorphic/_form", type: :view do
+  it "displays the field name" do
+    polymorphic = double(name: "Commentable")
+
+    render(
+      partial: "fields/polymorphic/form.html.erb",
+      locals: { field: polymorphic, f: form_builder },
+    )
+
+    expect(rendered.strip).to include("Commentable")
+  end
+
+  it "does not display a form" do
+    polymorphic = double(name: "Commentable")
+
+    render(
+      partial: "fields/polymorphic/form.html.erb",
+      locals: { field: polymorphic, f: form_builder },
+    )
+
+    expect(rendered).
+      to include(t("administrate.fields.polymorphic.not_supported"))
+  end
+
+  def form_builder
+    double("Form Builder", label: "Commentable")
+  end
+end

--- a/spec/administrate/views/fields/polymorphic/_index_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_index_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "fields/polymorphic/_index", type: :view do
+  context "without an associated records" do
+    it "displays nothing" do
+      polymorphic = double(data: nil)
+
+      render(
+        partial: "fields/polymorphic/index.html.erb",
+        locals: { field: polymorphic },
+      )
+
+      expect(rendered.strip).to eq("")
+    end
+  end
+
+  context "with an associated record" do
+    it "renders a link to the record" do
+      product = create(:product)
+      polymorphic = double(data: product)
+      product_path = polymorphic_path([:admin, product])
+
+      render(
+        partial: "fields/polymorphic/index.html.erb",
+        locals: { field: polymorphic },
+      )
+
+      expect(rendered.strip).to eq("<a href=\"#{product_path}\">#{product}</a>")
+    end
+  end
+end

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "fields/polymorphic/_show", type: :view do
+  context "without an associated records" do
+    it "displays nothing" do
+      polymorphic = double(data: nil)
+
+      render(
+        partial: "fields/polymorphic/show.html.erb",
+        locals: { field: polymorphic },
+      )
+
+      expect(rendered.strip).to eq("")
+    end
+  end
+
+  context "with an associated record" do
+    it "renders a link to the record" do
+      product = create(:product)
+      polymorphic = double(data: product)
+      product_path = polymorphic_path([:admin, product])
+
+      render(
+        partial: "fields/polymorphic/show.html.erb",
+        locals: { field: polymorphic },
+      )
+
+      expect(rendered.strip).to eq("<a href=\"#{product_path}\">#{product}</a>")
+    end
+  end
+end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "administrate/fields/polymorphic"
+require "support/field_matchers"
+
+describe Administrate::Field::Polymorphic do
+  include FieldMatchers
+
+  describe "#to_partial_path" do
+    it "returns a partial based on the page being rendered" do
+      page = :show
+      field = Administrate::Field::Polymorphic.new(:foo, "hello", page)
+
+      path = field.to_partial_path
+
+      expect(path).to eq("/fields/polymorphic/#{page}")
+    end
+  end
+
+  it { should_permit_param(:foo, for_attribute: :foo) }
+end


### PR DESCRIPTION
# Problem:

Until now, polymorphic relationships were being treated as standard `belongs_to` relationships. When Administrate inferred the incorrect class name for models, it resulted in a 500 error. This was most commonly seen on the form page.

In addition, when a polymorphic relationship has a non-existant class, the dashboard was throwing errors. This was the case on Upcase, where there are several dangling references from the `Classification` model to the removed `Article` model.

More information on https://trello.com/c/dMUeObDx
# Solution:
- Detect polymorphic belongs_to relationships in the dashboard generator
- Add `Administrate::Field::PolymorphicBelongsTo`
- Rescue errors when associated object lookup fails
- Add a stopgap "not supported" message to polymorphic forms for the moment. Trello card for completing it: https://trello.com/c/D9qnFx10

Related:
- Update Changelog

Tags: #ruby
