### PR TITLE
Release v0.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: administrate
   specs:
-    administrate (0.1.0)
+    administrate (0.0.10)
       autoprefixer-rails
       datetime_picker_rails (~> 0.0.4)
       momentjs-rails (>= 2.9.0)
@@ -341,3 +341,6 @@ DEPENDENCIES
   unicorn
   web-console (>= 2.1.3)
   webmock
+
+BUNDLED WITH
+   1.10.6

--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,19 +1,19 @@
-New in 0.1.0:
+New in 0.0.10:
 
-* Improvement: Don't display redundant attributes for belongs_to relationships,
-  such as `post_id` or `post_type`.
-* Bug Fix: Squash several 500 errors caused by polymorphic relationships.
-* Improvement: support models that have a custom `to_param` method.
-* UI: Show whitespace in strings on `show` pages
+* Improvement: support lookup for models that have a custom `to_param` method.
 * Improvement: Truncate strings on index page,
   with an optional argument for truncation length
-* Improvement: Generate a single controller to serve all resources,
-  to reduce noise after running the install generator.
 * Improvement: Add `Administrate::Field::DateTime`
   for displaying dates, times, and datetimes.
 * Improvement: Add `Administrate::Field::Number`
   for displaying currency, integers, and floats.
   Supports options `prefix` and `decimals`.
+* Improvement: Generate a single controller to serve all resources,
+  to reduce noise after running the install generator.
+* Improvement: Don't display redundant attributes for belongs_to relationships,
+  such as `post_id` or `post_type`.
+* UI: Show whitespace in strings on `show` pages
+* Bug Fix: Squash several 500 errors caused by polymorphic relationships.
 
 New in 0.0.9:
 

--- a/administrate/lib/administrate/version.rb
+++ b/administrate/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.1.0"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
New in 0.0.10:
- Improvement: support lookup for models that have a custom `to_param` method.
- Improvement: Truncate strings on index page,
  with an optional argument for truncation length
- Improvement: Add `Administrate::Field::DateTime`
  for displaying dates, times, and datetimes.
- Improvement: Add `Administrate::Field::Number`
  for displaying currency, integers, and floats.
  Supports options `prefix` and `decimals`.
- Improvement: Generate a single controller to serve all resources,
  to reduce noise after running the install generator.
- Improvement: Don't display redundant attributes for belongs_to relationships,
  such as `post_id` or `post_type`.
- UI: Show whitespace in strings on `show` pages
- Bug Fix: Squash several 500 errors caused by polymorphic relationships.
