### PR TITLE
Support custom class names for `belongs_to`

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,6 @@
+* Improvement: support a `class_name` option in `belongs_to` relationships.
+  The class name is now detected by the dashboard generator.
+
 New in 0.0.10:
 
 * Improvement: support lookup for models that have a custom `to_param` method.

--- a/administrate/lib/administrate/fields/belongs_to.rb
+++ b/administrate/lib/administrate/fields/belongs_to.rb
@@ -12,7 +12,13 @@ module Administrate
       end
 
       def candidate_records
-        Object.const_get(attribute.to_s.camelcase).all
+        Object.const_get(associated_class_name).all
+      end
+
+      private
+
+      def associated_class_name
+        options.fetch(:class_name, attribute.to_s.camelcase)
       end
     end
   end

--- a/administrate/lib/administrate/fields/has_many.rb
+++ b/administrate/lib/administrate/fields/has_many.rb
@@ -21,17 +21,17 @@ module Administrate
       end
 
       def candidate_records
-        Object.const_get(resource_class_name).all
+        Object.const_get(associated_class_name).all
       end
 
       private
 
       def associated_dashboard
-        Object.const_get("#{resource_class_name}Dashboard").new
+        Object.const_get("#{associated_class_name}Dashboard").new
       end
 
-      def resource_class_name
-        options[:class_name] || attribute.to_s.singularize.camelcase
+      def associated_class_name
+        options.fetch(:class_name, attribute.to_s.singularize.camelcase)
       end
     end
   end

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -61,11 +61,11 @@ module Administrate
         if relationship.has_one?
           "Field::HasOne"
         elsif relationship.collection?
-          "Field::HasMany" + has_many_options_string(relationship)
+          "Field::HasMany" + relationship_options_string(relationship)
         elsif relationship.polymorphic?
           "Field::Polymorphic"
         else
-          "Field::BelongsTo"
+          "Field::BelongsTo" + relationship_options_string(relationship)
         end
       end
 
@@ -73,7 +73,7 @@ module Administrate
         @klass ||= Object.const_get(class_name)
       end
 
-      def has_many_options_string(relationship)
+      def relationship_options_string(relationship)
         if relationship.class_name != relationship.name.to_s.classify
           options_string(class_name: relationship.class_name)
         else

--- a/spec/lib/administrate/resource_resolver_spec.rb
+++ b/spec/lib/administrate/resource_resolver_spec.rb
@@ -1,47 +1,53 @@
 require "spec_helper"
+require "support/constant_helpers"
 require "administrate/resource_resolver"
 
 describe Administrate::ResourceResolver do
-  # Fixture classes
-  class UserDashboard
-  end
-
-  class User
-  end
-
-  module Blog
-    class Post
-    end
-
-    class PostDashboard
-    end
-  end
-
   describe "#resource_class" do
     it "handles global-namepsace models" do
-      resolver = Administrate::ResourceResolver.new("admin/users")
+      begin
+        class User; end
+        resolver = Administrate::ResourceResolver.new("admin/users")
 
-      expect(resolver.resource_class).to eq(User)
+        expect(resolver.resource_class).to eq(User)
+      ensure
+        remove_constants :User
+      end
     end
 
     it "handles namespaced models" do
-      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+      begin
+        module Blog; class Post; end; end
+        resolver = Administrate::ResourceResolver.new("admin/blog/posts")
 
-      expect(resolver.resource_class).to eq(Blog::Post)
+        expect(resolver.resource_class).to eq(Blog::Post)
+      ensure
+        remove_constants :Blog
+      end
     end
   end
 
   describe "#dashboard_class" do
     it "handles global-namepsace models" do
-      resolver = Administrate::ResourceResolver.new("admin/users")
+      begin
+        class UserDashboard; end
+        resolver = Administrate::ResourceResolver.new("admin/users")
 
-      expect(resolver.dashboard_class).to eq(UserDashboard)
+        expect(resolver.dashboard_class).to eq(UserDashboard)
+      ensure
+        remove_constants :UserDashboard
+      end
     end
 
     it "handles namespaced models" do
-      resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+      begin
+        module Blog; class PostDashboard; end; end
+        resolver = Administrate::ResourceResolver.new("admin/blog/posts")
 
-      expect(resolver.dashboard_class).to eq(Blog::PostDashboard)
+        expect(resolver.dashboard_class).to eq(Blog::PostDashboard)
+      ensure
+        remove_constants :Blog
+      end
     end
   end
 

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "administrate/fields/belongs_to"
+require "support/constant_helpers"
 
 describe Administrate::Field::BelongsTo do
   describe "#to_partial_path" do
@@ -11,6 +12,25 @@ describe Administrate::Field::BelongsTo do
       path = field.to_partial_path
 
       expect(path).to eq("/fields/belongs_to/#{page}")
+    end
+  end
+
+  describe "class_name option" do
+    it "determines what dashboard is used to present the association" do
+      begin
+        Foo = Class.new
+        allow(Foo).to receive(:all).and_return([])
+
+        association = Administrate::Field::BelongsTo.
+          with_options(class_name: "Foo")
+        field = association.new(:customers, [], :show)
+        candidates = field.candidate_records
+
+        expect(Foo).to have_received(:all)
+        expect(candidates).to eq([])
+      ensure
+        remove_constants :Foo
+      end
     end
   end
 end


### PR DESCRIPTION
Problem:

When a `belongs_to` relationship was defined with a custom `class_name`,
Administrate wouldn't pick up on the option and would try to fetch the
object using the relationship name. This resulted in 500 errors, most
commonly on form pages.

See https://trello.com/c/hkZynxwL

Solution:

Let the user pass a `class_name` option to the Administrate
field to override the default class lookup.

The solution is essentially what we did for `has_many` relationships
back in 092d55f20e.
