### PR TITLE
Fix bug displaying nil strings

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,5 @@
+* Bug Fix: Fix an bug where `nil` in a string field would cause a 500 error.
+
 New in 0.0.11:
 
 * Improvement: Add `Administrate::Field::Boolean` for displaying boolean data.

--- a/administrate/lib/administrate/fields/string.rb
+++ b/administrate/lib/administrate/fields/string.rb
@@ -4,7 +4,7 @@ module Administrate
   module Field
     class String < Field::Base
       def truncate
-        data[0...truncation_length]
+        data.to_s[0...truncation_length]
       end
 
       private

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -19,6 +19,12 @@ describe Administrate::Field::String do
   it { should_permit_param(:foo, for_attribute: :foo) }
 
   describe "#truncate" do
+    it "renders an empty string for nil" do
+      string = Administrate::Field::String.new(:description, nil, :show)
+
+      expect(string.truncate).to eq("")
+    end
+
     it "defaults to displaying up to 50 characters" do
       short = Administrate::Field::String.new(:title, lorem(30), :show)
       long = Administrate::Field::String.new(:description, lorem(60), :show)


### PR DESCRIPTION
Problem:

When a string was nil, we would get:

```
NoMethodError: undefined method `[]' for nil:NilClass
```

Solution:

Make sure we're only indexing on strings by adding a call to `to_s`.
