### PR TITLE
Limit number of has_many records on show pages

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -3,6 +3,9 @@
   * Customizable by overriding `Admin::ApplicationController#records_per_page`
   * Customizable through HTTP param `per_page`
 * Improvement: Generate resource-specific controller subclasses.
+* Improvement: Add a `limit` option to `Administrate::Field::HasMany`,
+  with a default of 5.
+  This option limits the number of items shown in the relationship table.
 * UI: Remove logo from the sidebar
 * Bug Fix: Fix an bug where `nil` in a string field would cause a 500 error.
 

--- a/administrate/app/views/fields/has_many/_show.html.erb
+++ b/administrate/app/views/fields/has_many/_show.html.erb
@@ -1,9 +1,10 @@
-<% if field.data.any? %>
+<% if field.resources.any? %>
   <%= render(
     "table",
     table_presenter: field.associated_table,
-    resources: field.data
+    resources: field.resources
   ) %>
+  <span>Showing <%= field.limit %> of <%= field.data.count %>.</span>
 <% else %>
   <%= t("administrate.fields.has_many.none") %>
 <% end %>

--- a/administrate/lib/administrate/fields/has_many.rb
+++ b/administrate/lib/administrate/fields/has_many.rb
@@ -4,16 +4,14 @@ require "administrate/page/table"
 module Administrate
   module Field
     class HasMany < Field::Base
-      def associated_table
-        Administrate::Page::Table.new(associated_dashboard)
-      end
+      DEFAULT_LIMIT = 5
 
       def self.permitted_attribute(attribute)
         { "#{attribute.to_s.singularize}_ids".to_sym => [] }
       end
 
-      def permitted_attribute
-        self.class.permitted_attribute(attribute)
+      def associated_table
+        Administrate::Page::Table.new(associated_dashboard)
       end
 
       def attribute_key
@@ -22,6 +20,18 @@ module Administrate
 
       def candidate_records
         Object.const_get(associated_class_name).all
+      end
+
+      def limit
+        options.fetch(:limit, DEFAULT_LIMIT)
+      end
+
+      def permitted_attribute
+        self.class.permitted_attribute(attribute)
+      end
+
+      def resources
+        data.limit(limit)
       end
 
       private

--- a/spec/administrate/views/fields/has_many/_show_spec.rb
+++ b/spec/administrate/views/fields/has_many/_show_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "fields/has_many/_show", type: :view do
   context "without any associated records" do
     it "displays 'None'" do
-      has_many = double(data: [])
+      has_many = double(resources: [])
 
       render(
         partial: "fields/has_many/show.html.erb",

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "administrate/fields/has_many"
 require "support/constant_helpers"
+require "support/mock_relation"
 
 describe Administrate::Field::HasMany do
   describe "#to_partial_path" do
@@ -43,6 +44,29 @@ describe Administrate::Field::HasMany do
         expect(attributes).to eq([])
       ensure
         remove_constants :FooDashboard
+      end
+    end
+  end
+
+  describe "#resources" do
+    it "limits the number of records shown" do
+      limit = Administrate::Field::HasMany::DEFAULT_LIMIT
+      resources = MockRelation.new([:a] * (limit + 1))
+
+      association = Administrate::Field::HasMany
+      field = association.new(:customers, resources, :show)
+
+      expect(field.resources).to eq([:a] * limit)
+    end
+
+    context "with `limit` option" do
+      it "limits the number of items returned" do
+        resources = MockRelation.new([:a, :b, :c])
+
+        association = Administrate::Field::HasMany.with_options(limit: 1)
+        field = association.new(:customers, resources, :show)
+
+        expect(field.resources).to eq([:a])
       end
     end
   end

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -1,0 +1,11 @@
+class MockRelation
+  def initialize(data)
+    @data = data
+  end
+
+  delegate :==, to: :@data
+
+  def limit(n)
+    @data.first(n)
+  end
+end


### PR DESCRIPTION
Problem:

Many `has_many` relationships have hundreds or thousands of associated
records. When we try to display all of these on a parent record's `show`
page, the request often times out.

Solution:

By default, only display five associated records at a time. This limit
is configurable through a `limit` option.
