### PR TITLE
Revert "single controller for all resources"

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,4 @@
+* Improvement: Generate resource-specific controller subclasses.
 * UI: Remove logo from the sidebar
 * Bug Fix: Fix an bug where `nil` in a string field would cause a 500 error.
 
@@ -12,6 +13,8 @@ New in 0.0.10:
 * Improvement: support lookup for models that have a custom `to_param` method.
 * Improvement: Truncate strings on index page,
   with an optional argument for truncation length
+* Improvement: Generate a single controller to serve all resources,
+  to reduce noise after running the install generator.
 * Improvement: Add `Administrate::Field::DateTime`
   for displaying dates, times, and datetimes.
 * Improvement: Add `Administrate::Field::Number`

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -25,6 +25,13 @@ module Administrate
         template "dashboard.rb.erb", "app/dashboards/#{file_name}_dashboard.rb"
       end
 
+      def create_resource_controller
+        template(
+          "controller.rb.erb",
+          "app/controllers/admin/#{file_name.pluralize}_controller.rb",
+        )
+      end
+
       private
 
       def attributes

--- a/administrate/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/administrate/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,0 +1,19 @@
+module Admin
+  class <%= class_name.pluralize %>Controller < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # simply overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = <%= class_name %>.all.paginate(10, params[:page])
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   <%= class_name %>.find_by!(slug: param)
+    # end
+
+    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/administrate/lib/generators/administrate/install/templates/routes.rb
+++ b/administrate/lib/generators/administrate/install/templates/routes.rb
@@ -1,15 +1,7 @@
 namespace :admin do
-    DashboardManifest::DASHBOARDS.each do |resource_class|
-      resources(
-        resource_class,
-        controller: :application,
-        resource_class: resource_class,
-      )
+    DashboardManifest::DASHBOARDS.each do |dashboard_resource|
+      resources dashboard_resource
     end
 
-    root(
-      action: :index,
-      controller: :application,
-      resource_class: DashboardManifest::ROOT_DASHBOARD,
-    )
+    root controller: DashboardManifest::ROOT_DASHBOARD, action: :index
   end

--- a/app/controllers/admin/line_items_controller.rb
+++ b/app/controllers/admin/line_items_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class LineItemsController < Admin::ApplicationController
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class OrdersController < Admin::ApplicationController
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,9 @@
 Rails.application.routes.draw do
   namespace :admin do
-    resources :customers
-    resources :products
-
-    DashboardManifest::DASHBOARDS.each do |resource_class|
-      resources(
-        resource_class,
-        controller: :application,
-        resource_class: resource_class,
-      )
+    DashboardManifest::DASHBOARDS.each do |dashboard_resource|
+      resources dashboard_resource
     end
 
-    root(
-      action: :index,
-      controller: :application,
-      resource_class: DashboardManifest::ROOT_DASHBOARD,
-    )
+    root controller: DashboardManifest::ROOT_DASHBOARD, action: :index
   end
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -315,4 +315,31 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       end
     end
   end
+
+  describe "resource controller" do
+    it "has valid syntax" do
+      controller = file("app/controllers/admin/customers_controller.rb")
+
+      run_generator ["customer"]
+
+      expect(controller).to exist
+      expect(controller).to have_correct_syntax
+    end
+
+    it "subclasses Admin::ApplicationController" do
+      begin
+        ActiveRecord::Schema.define { create_table :foos }
+        class Foo < ActiveRecord::Base; end
+
+        run_generator ["foo"]
+        load file("app/controllers/admin/foos_controller.rb")
+
+        expect(Admin::FoosController.ancestors).
+          to include(Admin::ApplicationController)
+      ensure
+        remove_constants :Foo
+        Admin.send(:remove_const, :FoosController)
+      end
+    end
+  end
 end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -56,37 +56,28 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
   describe "config/routes.rb" do
     it "inserts an admin namespace with dashboard resources" do
-      begin
-        stub_generator_dependencies
+      stub_generator_dependencies
+      routes = file("config/routes.rb")
 
-        clear_routes
-        run_generator
-        load file("config/routes.rb")
+      run_generator
 
-        routes = Rails.application.routes.routes.named_routes
-        customers_controller = routes["admin_customers"].defaults[:controller]
-        expect(customers_controller).to eq("admin/application")
-      ensure
-        reset_routes
-      end
+      expect(routes).to have_correct_syntax
+      expect(routes).to contain("namespace :admin do")
+      expect(routes).to contain(
+        "DashboardManifest::DASHBOARDS.each do |dashboard_resource|",
+      )
+      expect(routes).to contain("resources dashboard_resource")
     end
 
     it "creates a root route for the admin namespace" do
-      begin
-        stub_generator_dependencies
+      stub_generator_dependencies
+      routes = file("config/routes.rb")
 
-        clear_routes
-        run_generator
-        load file("config/routes.rb")
+      run_generator
 
-        routes = Rails.application.routes.routes.named_routes
-        root_info = routes["admin_root"].defaults
-        expect(root_info[:controller]).to eq("admin/application")
-        expect(root_info[:resource_class]).
-          to eq(DashboardManifest::ROOT_DASHBOARD)
-      ensure
-        reset_routes
-      end
+      expect(routes).to contain(
+        "root controller: DashboardManifest::ROOT_DASHBOARD, action: :index",
+      )
     end
   end
 
@@ -106,14 +97,5 @@ describe Administrate::Generators::InstallGenerator, :generator do
   def stub_generator_dependencies
     provide_existing_routes_file
     allow(Rails::Generators).to receive(:invoke)
-  end
-
-  def reset_routes
-    clear_routes
-    load Rails.root.to_s + "/config/routes.rb"
-  end
-
-  def clear_routes
-    Rails.application.routes.clear!
   end
 end


### PR DESCRIPTION
This reverts commit 267edf27a79e85ac226c0f281e33eeee2eef5715.

There are two ways to handle the controller layer for Administrate:
1. Generate a single controller, `Admin::ApplicationController`, and route the RESTful actions for all resource types through it.  Let users subclass the controller to create resource-specific behavior.
2. Generate `Admin::ApplicationController`, which contains all of the default `RESTful` logic, as well as empty subclasses for each resource type. If users want to customize controller actions in the future, this saves them a generator step.

We originally went with option 2, before switching to option 1 in 267edf2.

That switch came in the wake of adding Administrate to Hound.  We decided to change to a single controller to reduce the diff noise from the administrate:install generator.

Recently, we've started adding Administrate to Upcase.  Upcase is a more complex application, and needs more customization off the bat.  After attempting several customizations, it's clear that it would be much cleaner/easier to customize if the relevant controller subclasses had been pre-generated.

Some examples of customizations we've needed to make are:
- defining custom resource finders (e.g. to look up a product by a slug)
- overriding a view for a single resource type (Rails needs the subclass chain to look up the correct view to render)

This change also makes routing significantly cleaner, letting us use the `resources` method without additional arguments.

Many of these problems could be solved by taking option 1, and writing very good documentation & controller/view generators, but as an MVP I believe it's cleaner and clearer for developers to explicitly define the controller subclasses up front.
