### PR TITLE
Add pagination with Kaminari

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       autoprefixer-rails
       datetime_picker_rails (~> 0.0.4)
       inline_svg (~> 0.6)
+      kaminari (~> 0.16)
       momentjs-rails (>= 2.9.0)
       neat (~> 1.1)
       normalize-rails (~> 3.0)
@@ -161,6 +162,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)

--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,4 +1,7 @@
 * Improvement: Implement searching over string and email attributes
+* Improvement: Add pagination to index views
+  * Customizable by overriding `Admin::ApplicationController#records_per_page`
+  * Customizable through HTTP param `per_page`
 * Improvement: Generate resource-specific controller subclasses.
 * UI: Remove logo from the sidebar
 * Bug Fix: Fix an bug where `nil` in a string field would cause a 500 error.

--- a/administrate/administrate.gemspec
+++ b/administrate/administrate.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "autoprefixer-rails"
   s.add_dependency "datetime_picker_rails", "~> 0.0.4"
   s.add_dependency "inline_svg", "~> 0.6"
+  s.add_dependency "kaminari", "~> 0.16"
   s.add_dependency "momentjs-rails", ">= 2.9.0"
   s.add_dependency "neat", "~> 1.1"
   s.add_dependency "normalize-rails", "~> 3.0"

--- a/administrate/app/assets/stylesheets/administrate/components/_components.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_components.scss
@@ -4,4 +4,5 @@
 @import "form";
 @import "header";
 @import "search";
+@import "pagination";
 @import "table";

--- a/administrate/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -1,0 +1,16 @@
+.pagination {
+  margin: $base-spacing 0;
+  text-align: center;
+
+  .first,
+  .prev,
+  .page,
+  .next,
+  .last {
+    margin: $small-spacing;
+  }
+
+  .current {
+    font-weight: bold;
+  }
+}

--- a/administrate/app/controllers/administrate/application_controller.rb
+++ b/administrate/app/controllers/administrate/application_controller.rb
@@ -3,6 +3,7 @@ module Administrate
     def index
       @search_term = params[:search].to_s.strip
       @resources = Administrate::Search.new(resource_resolver, @search_term).run
+      @resources = @resources.page(params[:page]).per(records_per_page)
       @page = Administrate::Page::Table.new(dashboard)
     end
 
@@ -67,6 +68,10 @@ module Administrate
       else
         :inactive
       end
+    end
+
+    def records_per_page
+      params[:per_page] || 20
     end
 
     def dashboard

--- a/administrate/app/views/administrate/application/index.html.erb
+++ b/administrate/app/views/administrate/application/index.html.erb
@@ -26,3 +26,5 @@
 </header>
 
 <%= render "table", table_presenter: @page, resources: @resources %>
+
+<%= paginate @resources %>

--- a/administrate/lib/administrate/engine.rb
+++ b/administrate/lib/administrate/engine.rb
@@ -1,5 +1,6 @@
 require "datetime_picker_rails"
 require "inline_svg"
+require "kaminari"
 require "momentjs-rails"
 require "neat"
 require "normalize-rails"

--- a/administrate/lib/generators/administrate/install/templates/application_controller.rb
+++ b/administrate/lib/generators/administrate/install/templates/application_controller.rb
@@ -1,4 +1,4 @@
-# All Administrate controllers inherit from this `ApplicationController`,
+# All Administrate controllers inherit from this `Admin::ApplicationController`,
 # making it the ideal place to put authentication logic or other
 # before_filters.
 #
@@ -11,13 +11,9 @@ class Admin::ApplicationController < Administrate::ApplicationController
     # TODO Add authentication logic here.
   end
 
-  def index
-    super
-
-    flash.now[:alert] =
-      "For performance, Administrate limits the index page to show 20 items.
-      Customize this action to update/remove the limit,
-      or implement the pagination library of your choice."
-    @resources = @resources.limit(20)
-  end
+  # Override this value to specify the number of elements to display at a time
+  # on index pages. Defaults to 20.
+  # def records_per_page
+  #   params[:per_page] || 20
+  # end
 end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -11,12 +11,9 @@ class Admin::ApplicationController < Administrate::ApplicationController
     # TODO Add authentication logic here.
   end
 
-  def index
-    super
-
-    if @resources.count > 20
-      flash.now[:alert] = "Showing 20 of #{@resources.count} items."
-      @resources = @resources.limit(20)
-    end
-  end
+  # Override this value to specify the number of elements to display at a time
+  # on index pages. Defaults to 20.
+  # def records_per_page
+  #   params[:per_page] || 20
+  # end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -37,4 +37,14 @@ describe "customer index page" do
 
     expect(current_path).to eq(new_admin_customer_path)
   end
+
+  it "paginates records based on a constant" do
+    customers = create_list(:customer, 2)
+
+    visit admin_customers_path(per_page: 1)
+
+    expect(page).not_to have_content(customers.last.name)
+    click_on "Next"
+    expect(page).to have_content(customers.last.name)
+  end
 end


### PR DESCRIPTION
## Problem:

Loading all resources on the index page at a time is incredibly costly,
so until now we've been limiting the number of items to 20.
Users had no way to browse through records,
or even see the total number of records.

https://trello.com/c/xFyDXn0z/78-pagination
## Solution:
- Use [kaminari](https://github.com/amatsuda/kaminari) to handle pagination.
- Minimally style pagination links

![administrate](https://cloud.githubusercontent.com/assets/829576/10009137/1b773d06-608d-11e5-9e31-7388bb266c73.png)
- [ ] update CHANGELOG

Tags: #design, #ruby
