### PR TITLE
Fix whitespace problem for strings on show page

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -9,6 +9,7 @@
   with a default of 5.
   This option limits the number of items shown in the relationship table.
 * UI: Remove logo from the sidebar
+* UI: Fix alignment issue with string fields on show pages
 * Bug Fix: Fix an bug where `nil` in a string field would cause a 500 error.
 
 New in 0.0.11:

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -10,8 +10,8 @@
 <dl>
   <% @page.attributes.each do |attribute| %>
     <dt class="attribute-label"><%= attribute.name.titleize %></dt>
-    <dd class="attribute-data--<%=attribute.html_class%>">
-      <%= render_field attribute %>
-    </dd>
+
+    <dd class="attribute-data--<%=attribute.html_class%>"
+        ><%= render_field attribute %></dd>
   <% end %>
 </dl>


### PR DESCRIPTION
Problem:

Because we're using CSS to preserve whitespace for strings on the show
page, the extra spaces in the HTML markup were throwing off the
alignment of the text.

Solution:

Remove extra whitespace around data on the show page.

Before:
![administrate](https://cloud.githubusercontent.com/assets/829576/10115146/dc56f646-63b3-11e5-8298-5e71e1115f11.png)

After:
![administrate](https://cloud.githubusercontent.com/assets/829576/10115151/f6f80e36-63b3-11e5-924d-fc9d4d6672ce.png)
