### PR TITLE
Add generators for different resource templates

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,5 @@
+* Improvement: Add generators for copying view templates into host application
+
 New in 0.0.12:
 
 * Improvement: Implement searching over string and email attributes

--- a/administrate/lib/administrate/view_generator.rb
+++ b/administrate/lib/administrate/view_generator.rb
@@ -1,0 +1,27 @@
+require "rails/generators/base"
+
+module Administrate
+  class ViewGenerator < Rails::Generators::Base
+    private
+
+    def self.template_source_path
+      File.expand_path(
+        "../../../app/views/administrate/application",
+        __FILE__,
+      )
+    end
+
+    def copy_resource_template(template_name)
+      template_file = "#{template_name}.html.erb"
+
+      copy_file(
+        template_file,
+        "app/views/admin/#{resource_path}/#{template_file}",
+      )
+    end
+
+    def resource_path
+      args.first.try(:underscore).try(:pluralize) || "application"
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/edit_generator.rb
+++ b/administrate/lib/generators/administrate/views/edit_generator.rb
@@ -1,0 +1,16 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class EditGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_edit
+          copy_resource_template("edit")
+          copy_resource_template("_form")
+        end
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/form_generator.rb
+++ b/administrate/lib/generators/administrate/views/form_generator.rb
@@ -1,0 +1,15 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class FormGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_form
+          copy_resource_template("_form")
+        end
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/index_generator.rb
+++ b/administrate/lib/generators/administrate/views/index_generator.rb
@@ -1,0 +1,16 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class IndexGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_template
+          copy_resource_template("index")
+          copy_resource_template("_table")
+        end
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/new_generator.rb
+++ b/administrate/lib/generators/administrate/views/new_generator.rb
@@ -1,0 +1,16 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class NewGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_new
+          copy_resource_template("new")
+          copy_resource_template("_form")
+        end
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/show_generator.rb
+++ b/administrate/lib/generators/administrate/views/show_generator.rb
@@ -1,0 +1,15 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class ShowGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_template
+          copy_resource_template("show")
+        end
+      end
+    end
+  end
+end

--- a/administrate/lib/generators/administrate/views/views_generator.rb
+++ b/administrate/lib/generators/administrate/views/views_generator.rb
@@ -1,0 +1,14 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    class ViewsGenerator < Administrate::ViewGenerator
+      def copy_templates
+        Rails::Generators.invoke("administrate:views:index", [resource_path])
+        Rails::Generators.invoke("administrate:views:show", [resource_path])
+        Rails::Generators.invoke("administrate:views:new", [resource_path])
+        Rails::Generators.invoke("administrate:views:edit", [resource_path])
+      end
+    end
+  end
+end

--- a/spec/generators/views/edit_generator_spec.rb
+++ b/spec/generators/views/edit_generator_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "generators/administrate/views/edit_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::EditGenerator, :generator do
+  describe "administrate:views:edit" do
+    it "copies the edit template into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("edit")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/edit.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+
+  describe "administrate:views:edit resource" do
+    it "copies the edit template into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("edit")
+
+      run_generator ["LineItem"]
+      contents = File.read(file("app/views/admin/line_items/edit.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end

--- a/spec/generators/views/form_generator_spec.rb
+++ b/spec/generators/views/form_generator_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "generators/administrate/views/form_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::FormGenerator, :generator do
+  describe "administrate:views:form" do
+    it "copies the form partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+
+  describe "administrate:views:form resource" do
+    it "copies the form view into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end

--- a/spec/generators/views/index_generator_spec.rb
+++ b/spec/generators/views/index_generator_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "generators/administrate/views/index_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::IndexGenerator, :generator do
+  describe "administrate:views:index" do
+    it "copies the index template into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("index")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/index.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the table partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_table")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/_table.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+
+  describe "administrate:views:index resource" do
+    it "copies the index view into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("index")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/index.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the table partial into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_table")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/_table.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end

--- a/spec/generators/views/new_generator_spec.rb
+++ b/spec/generators/views/new_generator_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require "generators/administrate/views/new_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::NewGenerator, :generator do
+  describe "administrate:views:new" do
+    it "copies the new template into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("new")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/new.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+
+  describe "administrate:views:new resource" do
+    it "copies the new template into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("new")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/new.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end

--- a/spec/generators/views/show_generator_spec.rb
+++ b/spec/generators/views/show_generator_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+require "generators/administrate/views/show_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::ShowGenerator, :generator do
+  describe "administrate:views:show" do
+    it "copies the show template into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("show")
+
+      run_generator []
+      contents = File.read(file("app/views/admin/application/show.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+
+  describe "administrate:views:show resource" do
+    it "copies the show view into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("show")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/show.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "generators/administrate/views/views_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::ViewsGenerator, :generator do
+  describe "administrate:views resource" do
+    it "runs all sub-generators" do
+      allow(Rails::Generators).to receive(:invoke)
+      resource = "users"
+
+      run_generator [resource]
+
+      %w[index show new edit].each do |generator|
+        expect(Rails::Generators).to have_received(:invoke).
+          with("administrate:views:#{generator}", [resource])
+      end
+    end
+  end
+end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -9,6 +9,12 @@ module GeneratorSpecHelpers
     copy_to_generator_root("config", "routes.rb")
   end
 
+  def contents_for_application_template(view_name)
+    File.read(
+      "administrate/app/views/administrate/application/#{view_name}.html.erb",
+    )
+  end
+
   private
 
   def copy_to_generator_root(destination, template)


### PR DESCRIPTION
## Problem

In order for developers to customize views,
they need to define templates in specific paths
inside the application.

It can be difficult for developers to remember
which paths they need to place the template files into,
what the templates should be called,
and which variables are available inside each of the views.

https://trello.com/c/woiNAsJ8
## Solution

Add generators [according to the documentation](http://administrate-docs.herokuapp.com/3-page-customization.md)
for copying views from administrate's source code
into the appropriate location in the developer's code base.
## Usage
### generate views for all resources

``` bash
rails generate administrate:views:index
 # Generates app/views/administrate/application/index.html.erb
 # Generates app/views/administrate/application/_table.html.erb

rails generate administrate:views:show
 # Generates app/views/administrate/application/show.html.erb

rails generate administrate:views:edit
 # Generates app/views/administrate/application/edit.html.erb
 # Generates app/views/administrate/application/_form.html.erb

rails generate administrate:views:new
 # Generates app/views/administrate/application/new.html.erb
 # Generates app/views/administrate/application/_form.html.erb

rails generate administrate:views
 # Generates all of the above
```
### Generate views for a specific resource

``` bash
rails generate administrate:views:index User
 # Generates app/views/administrate/users/index.html.erb
 # Generates app/views/administrate/users/_table.html.erb

rails generate administrate:views:show User
 # Generates app/views/administrate/users/show.html.erb

rails generate administrate:views:edit User
 # Generates app/views/administrate/users/edit.html.erb
 # Generates app/views/administrate/users/_form.html.erb

rails generate administrate:views:new User
 # Generates app/views/administrate/users/new.html.erb
 # Generates app/views/administrate/users/_form.html.erb

rails generate administrate:views User
 # Generates all of the above
```
