### PR TITLE
Only show has_many count when applicable

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,7 @@
-* UI: Give form and show pages more consistent label styles
 * Improvement: Add generators for copying view templates into host application
+* UI: Give form and show pages more consistent label styles
+* Bug Fix: Remove erroneous "Showing 5 of 1" messages
+  from has_many relationships on the `show` page.
 
 New in 0.0.12:
 

--- a/administrate/app/views/fields/has_many/_show.html.erb
+++ b/administrate/app/views/fields/has_many/_show.html.erb
@@ -4,7 +4,17 @@
     table_presenter: field.associated_table,
     resources: field.resources
   ) %>
-  <span>Showing <%= field.limit %> of <%= field.data.count %>.</span>
+
+  <% if field.more_than_limit? %>
+    <span>
+      <%= t(
+        'administrate.fields.has_many.more',
+        count: field.limit,
+        total_count: field.data.count,
+      ) %>
+    </span>
+  <% end %>
+
 <% else %>
   <%= t("administrate.fields.has_many.none") %>
 <% end %>

--- a/administrate/config/locales/administrate.en.yml
+++ b/administrate/config/locales/administrate.en.yml
@@ -1,19 +1,21 @@
+---
 en:
   administrate:
     actions:
-      show: Show
-      edit: Edit
-      destroy: Destroy
       confirm: Are you sure?
-    fields:
-      has_many:
-        none: None
-      polymorphic:
-        not_supported: "Polymorphic relationship forms are not supported yet. Sorry!"
+      destroy: Destroy
+      edit: Edit
+      show: Show
     controller:
       create:
         success: "%{resource} was successfully created."
-      update:
-        success: "%{resource} was successfully updated."
       destroy:
         success: "%{resource} was successfully destroyed."
+      update:
+        success: "%{resource} was successfully updated."
+    fields:
+      has_many:
+        more: Showing %{count} of %{total_count}
+        none: None
+      polymorphic:
+        not_supported: Polymorphic relationship forms are not supported yet. Sorry!

--- a/administrate/lib/administrate/fields/has_many.rb
+++ b/administrate/lib/administrate/fields/has_many.rb
@@ -34,6 +34,10 @@ module Administrate
         data.limit(limit)
       end
 
+      def more_than_limit?
+        data.count > limit
+      end
+
       private
 
       def associated_dashboard

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -48,6 +48,28 @@ describe Administrate::Field::HasMany do
     end
   end
 
+  describe "#more_than_limit?" do
+    it "returns true if record count > limit" do
+      limit = Administrate::Field::HasMany::DEFAULT_LIMIT
+      resources = MockRelation.new([:a] * (limit + 1))
+
+      association = Administrate::Field::HasMany
+      field = association.new(:customers, resources, :show)
+
+      expect(field.more_than_limit?).to eq(true)
+    end
+
+    it "returns false if record count <= limit" do
+      limit = Administrate::Field::HasMany::DEFAULT_LIMIT
+      resources = MockRelation.new([:a] * limit)
+
+      association = Administrate::Field::HasMany
+      field = association.new(:customers, resources, :show)
+
+      expect(field.more_than_limit?).to eq(false)
+    end
+  end
+
   describe "#resources" do
     it "limits the number of records shown" do
       limit = Administrate::Field::HasMany::DEFAULT_LIMIT

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -3,7 +3,7 @@ class MockRelation
     @data = data
   end
 
-  delegate :==, to: :@data
+  delegate :==, :count, to: :@data
 
   def limit(n)
     @data.first(n)


### PR DESCRIPTION
Problem:

When a record `has_many` other records,
and there's only one resource in the association,
the show page for the record would display
"Showing 5 of 1."

https://trello.com/c/4KqAiTAN

Solution:

Only show the show message
when the page is not already displaying all of them.
