### PR TITLE
Fix the back button in "new" forms

### DIFF
--- a/administrate/app/views/administrate/application/new.html.erb
+++ b/administrate/app/views/administrate/application/new.html.erb
@@ -2,7 +2,7 @@
 
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
-  <%= link_to 'Back', @page.resource_name.pluralize, class: "button" %>
+  <%= link_to 'Back', :back, class: "button" %>
 </header>
 
 <%= render 'form' %>

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -37,4 +37,13 @@ RSpec.describe "line item index page" do
 
     expect(page).to have_header("New Line Item")
   end
+
+  it "links back to line items" do
+    visit admin_line_items_path
+    click_on("New line item")
+
+    click_on("Back")
+
+    expect(page).to have_header("Line Items")
+  end
 end


### PR DESCRIPTION
The back button in the new item form was not correctly working out the
return URL. Using `:back` makes it do the right thing.
