### PR TITLE
Prefix HTML title with page title

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -2,6 +2,7 @@
 * UI: Give form and show pages more consistent label styles
 * Bug Fix: Remove erroneous "Showing 5 of 1" messages
   from has_many relationships on the `show` page.
+* Improvement: Add sensible dynamic titles to the dashboard pages.
 
 New in 0.0.12:
 

--- a/administrate/app/views/administrate/application/edit.html.erb
+++ b/administrate/app/views/administrate/application/edit.html.erb
@@ -1,5 +1,7 @@
+<% content_for(:title) { "Edit #{@page.page_title}" } %>
+
 <header class="header">
-  <h1 class="header-heading">Edit <%= @page.page_title %></h1>
+  <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to "Show #{@page.resource}", [Administrate::NAMESPACE, @page.resource], class: "button" %>
 </header>
 

--- a/administrate/app/views/administrate/application/index.html.erb
+++ b/administrate/app/views/administrate/application/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title) { @page.resource_name.pluralize.titleize } %>
+
 <% content_for(:search) do %>
   <form class="search">
     <span class="search__icon">
@@ -17,7 +19,7 @@
 <% end %>
 
 <header class="header">
-  <h1 class="header-heading"><%= @page.resource_name.pluralize.titleize %></h1>
+  <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to(
     "New #{@page.resource_name.titleize.downcase}",
     [:new, Administrate::NAMESPACE, @page.resource_name],

--- a/administrate/app/views/administrate/application/new.html.erb
+++ b/administrate/app/views/administrate/application/new.html.erb
@@ -1,5 +1,7 @@
+<% content_for(:title) { "New #{@page.resource_name.titleize}" } %>
+
 <header class="header">
-  <h1 class="header-heading">New <%= @page.resource_name.titleize %></h1>
+  <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to 'Back', @page.resource_name.pluralize, class: "button" %>
 </header>
 

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -1,5 +1,7 @@
+<% content_for(:title) { @page.page_title } %>
+
 <header class="header">
-  <h1 class="header-heading"><%= @page.page_title %></h1>
+  <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to(
     "Edit",
     [:edit, Administrate::NAMESPACE, @page.resource],

--- a/administrate/app/views/layouts/administrate/application.html.erb
+++ b/administrate/app/views/layouts/administrate/application.html.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
-  <title>Administrate</title>
+  <title><%= content_for(:title) %> | <%= Rails.application.class.parent_name.titlecase %></title>
   <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Lato:300,400,900", media: "all" %>
   <%= stylesheet_link_tag "administrate/application", media: "all" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
We generate the HTML title from the page heading and the application
name which is pulled from `titles.application` in the localization
files.
