### PR TITLE
Add a generator for field partials

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,4 +1,5 @@
 * Bug Fix: Fix asset precompilation issue for `datetime_picker_rails` gem.
+* Improvement: Add a generator for copying field views to host application
 * Improvement: Add a generator for creating custom field types
 * Improvement: Add generators for copying view templates into host application
 * UI: Give form and show pages more consistent label styles

--- a/administrate/lib/generators/administrate/views/field_generator.rb
+++ b/administrate/lib/generators/administrate/views/field_generator.rb
@@ -1,0 +1,36 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class FieldGenerator < Administrate::ViewGenerator
+        def self.template_source_path
+          File.expand_path(
+            "../../../../../app/views/fields/",
+            __FILE__,
+          )
+        end
+
+        source_root template_source_path
+
+        def copy_partials
+          copy_field_partial(:index)
+          copy_field_partial(:show)
+          copy_field_partial(:form)
+        end
+
+        private
+
+        def copy_field_partial(partial_name)
+          resource_path = args.first.try(:underscore)
+          template_file = "#{resource_path}/_#{partial_name}.html.erb"
+
+          copy_file(
+            template_file,
+            "app/views/fields/#{template_file}",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/views/field_generator_spec.rb
+++ b/spec/generators/views/field_generator_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "generators/administrate/views/field_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::FieldGenerator, :generator do
+  context "for an existing field type" do
+    describe "administrate:views:field field_name" do
+      it "copies the `_show` partial into the app/views/fields directory" do
+        expected_contents = contents_for_field_template(:string, :show)
+
+        run_generator ["string"]
+        contents = File.read(file("app/views/fields/string/_show.html.erb"))
+
+        expect(contents).to eq(expected_contents)
+      end
+
+      it "copies the `_form` partial into the app/views/fields directory" do
+        expected_contents = contents_for_field_template(:string, :form)
+
+        run_generator ["string"]
+        contents = File.read(file("app/views/fields/string/_form.html.erb"))
+
+        expect(contents).to eq(expected_contents)
+      end
+
+      it "copies the `_index` partial into the app/views/fields directory" do
+        expected_contents = contents_for_field_template(:string, :index)
+
+        run_generator ["string"]
+        contents = File.read(file("app/views/fields/string/_index.html.erb"))
+
+        expect(contents).to eq(expected_contents)
+      end
+    end
+  end
+
+  def contents_for_field_template(field_name, partial_name)
+    File.read(
+      "administrate/app/views/fields/#{field_name}/_#{partial_name}.html.erb",
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/wadhSHmo

Problem:

If a developer wants to change how a certain type of attribute
appears in the admin dashboards, they need to overwrite specific views.

At the moment, this requires them to dig into Administrate's source code
to find the current implementation,
and then copy that into the appropriate directory in their own app.

Solution:

Add a generator to automate the partial generation process.
Generator API is as defined at
https://administrate-docs.herokuapp.com/customizing_attribute_partials
