### PR TITLE
Add comments to page views and field partials

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -6,6 +6,8 @@
 * Documentation: Update README with a better description of the repo.
 * Improvement: Add generators for copying view templates into host application
 * UI: Give form and show pages more consistent label styles
+* Documentation: Add comments to all template files
+  describing what variables will be available
 * Bug Fix: Remove erroneous "Showing 5 of 1" messages
   from has_many relationships on the `show` page.
 * Improvement: Add sensible dynamic titles to the dashboard pages.

--- a/administrate/app/views/administrate/application/_flashes.html.erb
+++ b/administrate/app/views/administrate/application/_flashes.html.erb
@@ -1,3 +1,16 @@
+<%#
+# Flash Partial
+
+This partial renders flash messages on every page.
+
+## Relevant Helpers:
+
+- `flash`:
+  Returns a hash,
+  where the keys are the type of flash (alert, error, notice, etc)
+  and the values are the message to be displayed.
+%>
+
 <% if flash.any? %>
   <div id="flashes">
     <% flash.each do |key, value| -%>

--- a/administrate/app/views/administrate/application/_form.html.erb
+++ b/administrate/app/views/administrate/application/_form.html.erb
@@ -1,3 +1,19 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Instance variables:
+
+- `@page`:
+  Instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
 <%= form_for([Administrate::NAMESPACE, @page.resource], class: "form") do |f| %>
   <% if @page.resource.errors.any? %>
     <div id="error_explanation">

--- a/administrate/app/views/administrate/application/_javascript.html.erb
+++ b/administrate/app/views/administrate/application/_javascript.html.erb
@@ -1,3 +1,12 @@
+<%#
+# Javascript Partial
+
+This partial imports the necessary javascript on each page.
+By default, it includes the application JS,
+but each page can define additional JS sources
+by providing a `content_for(:javascript)` block.
+%>
+
 <%= javascript_include_tag "administrate/application" %>
 
 <%= yield :javascript %>

--- a/administrate/app/views/administrate/application/_sidebar.html.erb
+++ b/administrate/app/views/administrate/application/_sidebar.html.erb
@@ -1,3 +1,12 @@
+<%#
+# Sidebar
+
+This partial is used to display the sidebar in Administrate.
+By default, the sidebar contains navigation links
+for all resources in the admin dashboard,
+as defined by the DashboardManifest.
+%>
+
 <ul class="sidebar__list">
   <% DashboardManifest::DASHBOARDS.each do |resource| %>
     <li>

--- a/administrate/app/views/administrate/application/_table.html.erb
+++ b/administrate/app/views/administrate/application/_table.html.erb
@@ -1,3 +1,23 @@
+<%#
+# Table
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `table_presenter`:
+  An instance of [Administrate::Page::Table][1].
+  The table presenter uses `ResourceDashboard::TABLE_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Table
+%>
+
 <table>
   <thead>
     <tr>

--- a/administrate/app/views/administrate/application/edit.html.erb
+++ b/administrate/app/views/administrate/application/edit.html.erb
@@ -1,3 +1,20 @@
+<%#
+# Edit
+
+This view is the template for the edit page.
+
+It displays a header, and renders the `_form` partial to do the heavy lifting.
+
+## Instance variables:
+
+- `@page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
 <% content_for(:title) { "Edit #{@page.page_title}" } %>
 
 <header class="header">

--- a/administrate/app/views/administrate/application/index.html.erb
+++ b/administrate/app/views/administrate/application/index.html.erb
@@ -1,3 +1,26 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Instance variables:
+
+- `@page`:
+  An instance of [Administrate::Page::Table][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `@resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `@search_term`:
+  A string containing the term the user has searched for, if any.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Table
+%>
+
 <% content_for(:title) { @page.resource_name.pluralize.titleize } %>
 
 <% content_for(:search) do %>

--- a/administrate/app/views/administrate/application/new.html.erb
+++ b/administrate/app/views/administrate/application/new.html.erb
@@ -1,3 +1,20 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Instance variables:
+
+- `@page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
 <% content_for(:title) { "New #{@page.resource_name.titleize}" } %>
 
 <header class="header">

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -1,3 +1,21 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Instance variables:
+
+- `@page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
 <% content_for(:title) { @page.page_title } %>
 
 <header class="header">

--- a/administrate/app/views/fields/belongs_to/_form.html.erb
+++ b/administrate/app/views/fields/belongs_to/_form.html.erb
@@ -1,3 +1,21 @@
+<%#
+# BelongsTo Form Partial
+
+This partial renders an input element for belongs_to relationships.
+By default, the input is a collection select box
+that displays all possible records to associate with.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  Contains helper methods for displaying a collection select box.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
 <%= f.label field.permitted_attribute %>
 <%= f.collection_select(
   field.permitted_attribute,

--- a/administrate/app/views/fields/belongs_to/_index.html.erb
+++ b/administrate/app/views/fields/belongs_to/_index.html.erb
@@ -1,3 +1,20 @@
+<%#
+# BelongsTo Index Partial
+
+This partial renders a belongs_to relationship,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  A wrapper around the belongs_to relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
 <% if field.data %>
   <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
 <% end %>

--- a/administrate/app/views/fields/belongs_to/_show.html.erb
+++ b/administrate/app/views/fields/belongs_to/_show.html.erb
@@ -1,3 +1,20 @@
+<%#
+# BelongsTo Show Partial
+
+This partial renders a belongs_to relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  A wrapper around the belongs_to relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
 <% if field.data %>
   <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
 <% end %>

--- a/administrate/app/views/fields/boolean/_form.html.erb
+++ b/administrate/app/views/fields/boolean/_form.html.erb
@@ -1,2 +1,19 @@
+<%#
+# Boolean Form Partial
+
+This partial renders an input element for a boolean attribute.
+By default, the input is a checkbox.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Boolean][1].
+  A wrapper around the boolean value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Boolean
+%>
+
 <%= f.label field.attribute %>
 <%= f.check_box field.attribute %>

--- a/administrate/app/views/fields/boolean/_index.html.erb
+++ b/administrate/app/views/fields/boolean/_index.html.erb
@@ -1,1 +1,19 @@
-<%= field %>
+<%#
+# Boolean Index Partial
+
+This partial renders a boolean attribute,
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered
+as a string representation of the boolean value.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Boolean][1].
+  A wrapper around the boolean value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Boolean
+%>
+
+<%= field.to_s %>

--- a/administrate/app/views/fields/boolean/_show.html.erb
+++ b/administrate/app/views/fields/boolean/_show.html.erb
@@ -1,1 +1,19 @@
-<%= field %>
+<%#
+# Boolean Show Partial
+
+This partial renders a boolean attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered
+as a string representation of the boolean value.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Boolean][1].
+  A wrapper around the boolean value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Boolean
+%>
+
+<%= field.to_s %>

--- a/administrate/app/views/fields/date_time/_form.html.erb
+++ b/administrate/app/views/fields/date_time/_form.html.erb
@@ -1,2 +1,20 @@
+<%#
+# DateTime Form Partial
+
+This partial renders an input element for a datetime attribute.
+By default, the input is a text field that is augmented with [DateTimePicker].
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::DateTime][1].
+  A wrapper around the DateTime value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
+[DateTimePicker]: https://github.com/Eonasdan/bootstrap-datetimepicker
+%>
+
 <%= f.label field.attribute %>
 <%= f.text_field field.attribute, class: "datetimepicker" %>

--- a/administrate/app/views/fields/date_time/_index.html.erb
+++ b/administrate/app/views/fields/date_time/_index.html.erb
@@ -1,3 +1,21 @@
+<%#
+# DateTime Index Partial
+
+This partial renders a datetime attribute,
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered
+as a localized date & time string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::DateTime][1].
+  A wrapper around the DateTime value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
+%>
+
 <% if field.data %>
   <%= l field.data.to_date %>
 <% end %>

--- a/administrate/app/views/fields/date_time/_show.html.erb
+++ b/administrate/app/views/fields/date_time/_show.html.erb
@@ -1,3 +1,21 @@
+<%#
+# DateTime Show Partial
+
+This partial renders a datetime attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered
+as a localized date & time string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::DateTime][1].
+  A wrapper around the DateTime value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
+%>
+
 <% if field.data %>
   <%= l field.data %>
 <% end %>

--- a/administrate/app/views/fields/email/_form.html.erb
+++ b/administrate/app/views/fields/email/_form.html.erb
@@ -1,2 +1,19 @@
+<%#
+# Email Form Partial
+
+This partial renders an input element for email addresses.
+By default, the input is a text box.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Email][1].
+  A wrapper around the email pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Email
+%>
+
 <%= f.label field.attribute %>
 <%= f.email_field field.attribute %>

--- a/administrate/app/views/fields/email/_index.html.erb
+++ b/administrate/app/views/fields/email/_index.html.erb
@@ -1,1 +1,18 @@
+<%#
+# Email Index Partial
+
+This partial renders an email address,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered as a `mailto` link.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Email][1].
+  A wrapper around the email pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Email
+%>
+
 <%= mail_to field.data %>

--- a/administrate/app/views/fields/email/_show.html.erb
+++ b/administrate/app/views/fields/email/_show.html.erb
@@ -1,1 +1,18 @@
+<%#
+# Email Show Partial
+
+This partial renders an email address,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered as a `mailto` link.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Email][1].
+  A wrapper around the email pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Email
+%>
+
 <%= mail_to field.data %>

--- a/administrate/app/views/fields/has_many/_form.html.erb
+++ b/administrate/app/views/fields/has_many/_form.html.erb
@@ -1,3 +1,24 @@
+<%#
+# HasMany Form Partial
+
+This partial renders an input element for belongs_to relationships.
+By default, the input is a collection select box
+that displays all possible records to associate with.
+The collection select box supports multiple inputs,
+and is augmented with [Selectize].
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::HasMany][1].
+  Contains helper methods for displaying a collection select box.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
+[Selectize]: http://brianreavis.github.io/selectize.js
+%>
+
 <%= f.label field.attribute_key %>
 
 <%= f.collection_select(

--- a/administrate/app/views/fields/has_many/_index.html.erb
+++ b/administrate/app/views/fields/has_many/_index.html.erb
@@ -1,1 +1,19 @@
+<%#
+# HasMany Index Partial
+
+This partial renders a has_many relationship,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered
+as a count of how many objects are associated through the relationship.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::HasMany][1].
+  A wrapper around the has_many relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
+%>
+
 <%= pluralize(field.data.count, field.attribute.to_s.humanize.downcase) %>

--- a/administrate/app/views/fields/has_many/_show.html.erb
+++ b/administrate/app/views/fields/has_many/_show.html.erb
@@ -1,3 +1,23 @@
+<%#
+# HasMany Show Partial
+
+This partial renders a has_many relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered
+as a table of the first few associated resources.
+The columns of the table are taken
+from the associated resource class's dashboard.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::HasMany][1].
+  Contains methods to help display a table of associated resources.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
+%>
+
 <% if field.resources.any? %>
   <%= render(
     "table",

--- a/administrate/app/views/fields/has_one/_form.html.erb
+++ b/administrate/app/views/fields/has_one/_form.html.erb
@@ -1,2 +1,22 @@
+<%#
+# HasOne Form Partial
+
+This partial renders an input element for has_one relationships.
+
+At the moment, has_one form fields are not supported,
+so this partial renders a message to that effect.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::HasOne][1].
+  A wrapper around the has_one relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
+%>
+
 <%= f.label field.permitted_attribute %>
-HasOne relationship forms are not supported yet. Sorry!
+
+<%= t("administrate.fields.has_one.not_supported") %>

--- a/administrate/app/views/fields/has_one/_index.html.erb
+++ b/administrate/app/views/fields/has_one/_index.html.erb
@@ -1,3 +1,20 @@
+<%#
+# HasOne Index Partial
+
+This partial renders a has_one relationship,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::HasOne][1].
+  A wrapper around the has_one relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
+%>
+
 <% if field.data %>
   <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
 <% end %>

--- a/administrate/app/views/fields/has_one/_show.html.erb
+++ b/administrate/app/views/fields/has_one/_show.html.erb
@@ -1,3 +1,20 @@
+<%#
+# HasOne Show Partial
+
+This partial renders a has_one relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::HasOne][1].
+  A wrapper around the has_one relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
+%>
+
 <% if field.data %>
   <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
 <% end %>

--- a/administrate/app/views/fields/image/_form.html.erb
+++ b/administrate/app/views/fields/image/_form.html.erb
@@ -1,2 +1,19 @@
+<%#
+# Image Form Partial
+
+This partial renders an input element for image attributes.
+By default, the input is a text field for the image's URL.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Image][1].
+  A wrapper around the image url pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
+%>
+
 <%= f.label field.attribute %>
 <%= f.text_field field.attribute %>

--- a/administrate/app/views/fields/image/_index.html.erb
+++ b/administrate/app/views/fields/image/_index.html.erb
@@ -1,1 +1,18 @@
+<%#
+# Image Index Partial
+
+This partial renders an image attribute
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered as an image tag.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Image][1].
+  A wrapper around the image url pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
+%>
+
 <%= image_tag field.data %>

--- a/administrate/app/views/fields/image/_show.html.erb
+++ b/administrate/app/views/fields/image/_show.html.erb
@@ -1,1 +1,18 @@
+<%#
+# Image Show Partial
+
+This partial renders an image attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered as an image tag.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Image][1].
+  A wrapper around the image url pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
+%>
+
 <%= image_tag field.data %>

--- a/administrate/app/views/fields/number/_form.html.erb
+++ b/administrate/app/views/fields/number/_form.html.erb
@@ -1,2 +1,19 @@
+<%#
+# Number Form Partial
+
+This partial renders an input element for number attributes.
+By default, the input is a text field.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Number][1].
+  A wrapper around the number pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Number
+%>
+
 <%= f.label field.attribute %>
 <%= f.text_field field.attribute %>

--- a/administrate/app/views/fields/number/_index.html.erb
+++ b/administrate/app/views/fields/number/_index.html.erb
@@ -1,1 +1,19 @@
-<%= field %>
+<%#
+# Number Index Partial
+
+This partial renders a number attribute,
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered
+using the formatting options given in the resource's dashboard.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Number][1].
+  A wrapper around the number pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Number
+%>
+
+<%= field.to_s %>

--- a/administrate/app/views/fields/number/_show.html.erb
+++ b/administrate/app/views/fields/number/_show.html.erb
@@ -1,1 +1,19 @@
-<%= field %>
+<%#
+# Number Show Partial
+
+This partial renders a number attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered
+using the formatting options given in the resource's dashboard.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Number][1].
+  A wrapper around the number pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Number
+%>
+
+<%= field.to_s %>

--- a/administrate/app/views/fields/polymorphic/_form.html.erb
+++ b/administrate/app/views/fields/polymorphic/_form.html.erb
@@ -1,3 +1,23 @@
+<%#
+# Polymorphic Form Partial
+
+This partial renders an input element for polymorphic relationships.
+
+At the moment, polymorphic form fields are not supported,
+so this partial renders a message to that effect.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Polymorphic][1].
+  A wrapper around the polymorphic belongs_to relationship
+  pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Polymorphic
+%>
+
 <%= f.label field.name %>
 
 <%= t("administrate.fields.polymorphic.not_supported") %>

--- a/administrate/app/views/fields/polymorphic/_index.html.erb
+++ b/administrate/app/views/fields/polymorphic/_index.html.erb
@@ -1,3 +1,21 @@
+<%#
+# Polymorphic Index Partial
+
+This partial renders a polymorphic relationship,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Polymorphic][1].
+  A wrapper around the polymorphic belongs_to relationship
+  pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Polymorphic
+%>
+
 <% if field.data %>
   <%= link_to(
     field.data.to_s,

--- a/administrate/app/views/fields/polymorphic/_show.html.erb
+++ b/administrate/app/views/fields/polymorphic/_show.html.erb
@@ -1,3 +1,21 @@
+<%#
+# Polymorphic Show Partial
+
+This partial renders a polymorphic relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Polymorphic][1].
+  A wrapper around the polymorphic belongs_to relationship
+  pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Polymorphic
+%>
+
 <% if field.data %>
   <%= link_to(
     field.data.to_s,

--- a/administrate/app/views/fields/string/_form.html.erb
+++ b/administrate/app/views/fields/string/_form.html.erb
@@ -1,2 +1,19 @@
+<%#
+# String Form Partial
+
+This partial renders an input element for a string attribute.
+By default, the input is a text field.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::String][1].
+  A wrapper around the String pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
+%>
+
 <%= f.label field.attribute %>
 <%= f.text_field field.attribute %>

--- a/administrate/app/views/fields/string/_index.html.erb
+++ b/administrate/app/views/fields/string/_index.html.erb
@@ -1,1 +1,18 @@
+<%#
+# String Index Partial
+
+This partial renders a string attribute
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered as a truncated string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::String][1].
+  A wrapper around the String pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
+%>
+
 <%= field.truncate %>

--- a/administrate/app/views/fields/string/_show.html.erb
+++ b/administrate/app/views/fields/string/_show.html.erb
@@ -1,1 +1,18 @@
+<%#
+# String Show Partial
+
+This partial renders a string attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered as an unformatted string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::String][1].
+  A wrapper around the String pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
+%>
+
 <%= field.data %>

--- a/administrate/app/views/layouts/administrate/application.html.erb
+++ b/administrate/app/views/layouts/administrate/application.html.erb
@@ -1,3 +1,17 @@
+<%#
+# Application Layout
+
+This view template is used as the layout
+for every page that Administrate generates.
+
+By default, it renders:
+- Sidebar for navigation
+- Content for a search bar
+  (if provided by a `content_for` block in a nested page)
+- Flashes
+- Links to stylesheets and Javascripts
+%>
+
 <!DOCTYPE html>
 <html>
 <head>

--- a/administrate/config/locales/administrate.en.yml
+++ b/administrate/config/locales/administrate.en.yml
@@ -19,3 +19,5 @@ en:
         none: None
       polymorphic:
         not_supported: Polymorphic relationship forms are not supported yet. Sorry!
+      has_one:
+        not_supported: HasOne relationship forms are not supported yet. Sorry!


### PR DESCRIPTION
https://trello.com/c/2Pan7Jmp

Problem:

When a developer generates a template in order to override it,
it is not always clear which local and instance variables are available
for them to use.

In order to get a good idea of what's going on,
they would need to open up Administrate's source code,
take a look at the controller,
and see which variables are being assigned for the view to use.

Solution:

Add comments at the top of each view
detailing which variables are in scope,
with links to further documentation about the variables.

Review checklist:
- [x] verify all rubydoc links are correct
- [x] verify comment titles (e.g. "Email Show Partial") matches up with filename
- [x] Replace TODO with links to selectize and datetimepicker
- [x] replace "contains methods for accessing the underlying attribute data"
