### PR TITLE
Make generated code more explicit for clarity

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,5 +1,7 @@
 * Bug Fix: Fix asset precompilation issue for `datetime_picker_rails` gem.
 * Improvement: Add a generator for copying field views to host application
+* Improvement: Generated dashboards are more explicit,
+  and more clearly define the API.
 * Improvement: Add a generator for creating custom field types
 * Improvement: Add generators for copying view templates into host application
 * UI: Give form and show pages more consistent label styles

--- a/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/administrate/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -19,6 +19,7 @@ module Administrate
 
       DEFAULT_FIELD_TYPE = "Field::String"
       TABLE_ATTRIBUTE_LIMIT = 4
+      READ_ONLY_ATTRIBUTES = %w[id created_at updated_at]
 
       source_root File.expand_path("../templates", __FILE__)
 
@@ -37,6 +38,10 @@ module Administrate
 
       def attributes
         klass.reflections.keys + klass.attribute_names - redundant_attributes
+      end
+
+      def form_attributes
+        attributes - READ_ONLY_ATTRIBUTES
       end
 
       def redundant_attributes

--- a/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/administrate/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -1,12 +1,6 @@
 require "administrate/base_dashboard"
 
 class <%= class_name %>Dashboard < Administrate::BaseDashboard
-  READ_ONLY_ATTRIBUTES = [
-    :id,
-    :created_at,
-    :updated_at,
-  ]
-
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -23,8 +17,14 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's index page.
   #
   # By default, it's limited to four items to reduce clutter on index pages.
-  # Feel free to remove the limit or customize the returned array.
-  TABLE_ATTRIBUTES = ATTRIBUTE_TYPES.keys.first(<%= TABLE_ATTRIBUTE_LIMIT %>)
+  # Feel free to add, remove, or rearrange items.
+  TABLE_ATTRIBUTES = [
+<%=
+  attributes.first(TABLE_ATTRIBUTE_LIMIT).map do |attr|
+    "    :#{attr},"
+  end.join("\n")
+%>
+  ]
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
@@ -33,5 +33,11 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
+  FORM_ATTRIBUTES = [
+<%=
+  form_attributes.map do |attr|
+    "    :#{attr},"
+  end.join("\n")
+%>
+  ]
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -314,6 +314,31 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         Administrate::Generators::DashboardGenerator::TABLE_ATTRIBUTE_LIMIT
       end
     end
+
+    describe "FORM_ATTRIBUTES" do
+      it "does not include read-only attributes" do
+        begin
+          ActiveRecord::Schema.define do
+            create_table :foos do |t|
+              t.string :name
+              t.timestamps
+            end
+          end
+
+          class Foo < ActiveRecord::Base
+            reset_column_information
+          end
+
+          run_generator ["foo"]
+          load file("app/dashboards/foo_dashboard.rb")
+          attrs = FooDashboard::FORM_ATTRIBUTES
+
+          expect(attrs).to match_array([:name])
+        ensure
+          remove_constants :Foo, :FooDashboard
+        end
+      end
+    end
   end
 
   describe "resource controller" do


### PR DESCRIPTION
Changes:
- Use explicit ruby arrays for `TABLE_ATTRIBUTES`
  and `FORM_ATTRIBUTES`
- Remove the generated `READ_ONLY_ATTRIBUTES`, which was not used by
  Administrate and may have been confusing.
## Before

``` ruby
require "administrate/base_dashboard"

class ProductDashboard < Administrate::BaseDashboard
  READ_ONLY_ATTRIBUTES = [
    :id,
    :created_at,
    :updated_at,
  ]

  # ATTRIBUTE_TYPES
  # a hash that describes the type of each of the model's fields.
  #
  # Each different type represents an Administrate::Field object,
  # which determines how the attribute is displayed
  # on pages throughout the dashboard.
  ATTRIBUTE_TYPES = {
    id: Field::Number,
    name: Field::String,
    price: Field::Number.with_options(decimals: 2),
    description: Field::String,
    image_url: Field::String,
    created_at: Field::DateTime,
    updated_at: Field::DateTime,
    slug: Field::String,
  }

  # TABLE_ATTRIBUTES
  # an array of attributes that will be displayed on the model's index page.
  #
  # By default, it's limited to four items to reduce clutter on index pages.
  # Feel free to remove the limit or customize the returned array.
  TABLE_ATTRIBUTES = ATTRIBUTE_TYPES.keys.first(4)

  # SHOW_PAGE_ATTRIBUTES
  # an array of attributes that will be displayed on the model's show page.
  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys

  # FORM_ATTRIBUTES
  # an array of attributes that will be displayed
  # on the model's form (`new` and `edit`) pages.
  FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
end
```
## After

``` ruby
require "administrate/base_dashboard"

class ProductDashboard < Administrate::BaseDashboard
  # ATTRIBUTE_TYPES
  # a hash that describes the type of each of the model's fields.
  #
  # Each different type represents an Administrate::Field object,
  # which determines how the attribute is displayed
  # on pages throughout the dashboard.
  ATTRIBUTE_TYPES = {
    id: Field::Number,
    name: Field::String,
    price: Field::Number.with_options(decimals: 2),
    description: Field::String,
    image_url: Field::String,
    created_at: Field::DateTime,
    updated_at: Field::DateTime,
    slug: Field::String,
  }

  # TABLE_ATTRIBUTES
  # an array of attributes that will be displayed on the model's index page.
  #
  # By default, it's limited to four items to reduce clutter on index pages.
  # Feel free to add, remove, or rearrange items.
  TABLE_ATTRIBUTES = [
    :id,
    :name,
    :price,
    :description,
  ]

  # SHOW_PAGE_ATTRIBUTES
  # an array of attributes that will be displayed on the model's show page.
  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys

  # FORM_ATTRIBUTES
  # an array of attributes that will be displayed
  # on the model's form (`new` and `edit`) pages.
  FORM_ATTRIBUTES = [
    :name,
    :price,
    :description,
    :image_url,
    :slug,
  ]
end
```
