### PR TITLE
Fix scrolling bugs on lists

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -6,7 +6,8 @@
   from has_many relationships on the `show` page.
 * Improvement: Add sensible dynamic titles to the dashboard pages.
 * Improvement: Add text field type.
-* UI: Fix checkbox styling and label alignment
+* UI: Fix checkbox styling and label alignment.
+* UI: Fix scrollbar issues on list pages.
 
 New in 0.0.12:
 

--- a/administrate/app/assets/javascripts/administrate/components/_search.js
+++ b/administrate/app/assets/javascripts/administrate/components/_search.js
@@ -7,7 +7,8 @@ $(function() {
 
   $.fn.textWidth = function(text, font) {
     if (!$.fn.textWidth.fakeEl) {
-      $.fn.textWidth.fakeEl = $("<span>").appendTo(document.body);
+      $.fn.textWidth.fakeEl = $('<span style="display: none;">')
+                              .appendTo(document.body);
     }
 
     var htmlText = text || this.val() || this.text();

--- a/administrate/app/assets/stylesheets/administrate/components/_search.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_search.scss
@@ -38,7 +38,7 @@
 }
 
 .search__hint {
-  @include position(absolute, 1em null null null);
+  @include position(absolute, 1em 0 null null);
   @include transition($base-transition);
   color: $hint-grey;
   opacity: 0;


### PR DESCRIPTION
The search hint resting place was pushing it outside the right hand edge of the screen causing a horizontal scrollbar to appear when it was not required. This change aligns it the right hand edge so it doesn't add a horizontal scroll bar or interfere with the search input.

The additional `<span />` element used to measure the width of the text was causing a vertical scroll bar to get added so that's now set to `display: none;`. The measurement still works just fine in Firefox, Chrome and Safari but I've not had chance to test it in IE or Edge.

<img width="1392" alt="screen shot 2015-10-27 at 16 55 49" src="https://cloud.githubusercontent.com/assets/165531/10765749/3e5aca6c-7ccc-11e5-8ae8-1068017fdf7e.png">
<img width="1392" alt="screen shot 2015-10-27 at 16 56 07" src="https://cloud.githubusercontent.com/assets/165531/10765750/3e86ef98-7ccc-11e5-88ca-7adb9e5180c4.png">
