### PR TITLE
Refactor controller & views to use local variables

### DIFF
--- a/administrate/NEWS
+++ b/administrate/NEWS
@@ -1,3 +1,4 @@
+* Change: Render views using local variables, not instance variables.
 * Bug Fix: Fix missing `dropdown.svg` asset.
 * Change: Rename `table` -> `collection` throughout the engine.
   * API for dashboard classes now relies on `COLLECTION_ATTRIBUTES` constant

--- a/administrate/app/views/administrate/application/_form.html.erb
+++ b/administrate/app/views/administrate/application/_form.html.erb
@@ -4,26 +4,26 @@
 This partial is rendered on a resource's `new` and `edit` pages,
 and renders all form fields for a resource's editable attributes.
 
-## Instance variables:
+## Local variables:
 
-- `@page`:
-  Instance of [Administrate::Page::Form][1].
+- `page`:
+  An instance of [Administrate::Page::Form][1].
   Contains helper methods to display a form,
   and knows which attributes should be displayed in the resource's form.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([Administrate::NAMESPACE, @page.resource], class: "form") do |f| %>
-  <% if @page.resource.errors.any? %>
+<%= form_for([Administrate::NAMESPACE, page.resource], class: "form") do |f| %>
+  <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>
-        <%= pluralize(@page.resource.errors.count, "error") %>
-        prohibited this <%= @page.resource_name %> from being saved:
+        <%= pluralize(page.resource.errors.count, "error") %>
+        prohibited this <%= page.resource_name %> from being saved:
       </h2>
 
       <ul>
-        <% @page.resource.errors.full_messages.each do |message| %>
+        <% page.resource.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
       </ul>
@@ -31,7 +31,7 @@ and renders all form fields for a resource's editable attributes.
   <% end %>
 
   <div class="form-inputs">
-    <% @page.attributes.each do |attribute| -%>
+    <% page.attributes.each do |attribute| -%>
       <div class="form-field form-field--<%= attribute.html_class %>">
         <%= render_field attribute, f: f %>
       </div>

--- a/administrate/app/views/administrate/application/edit.html.erb
+++ b/administrate/app/views/administrate/application/edit.html.erb
@@ -5,9 +5,9 @@ This view is the template for the edit page.
 
 It displays a header, and renders the `_form` partial to do the heavy lifting.
 
-## Instance variables:
+## Local variables:
 
-- `@page`:
+- `page`:
   An instance of [Administrate::Page::Form][1].
   Contains helper methods to help display a form,
   and knows which attributes should be displayed in the resource's form.
@@ -15,11 +15,11 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "Edit #{@page.page_title}" } %>
+<% content_for(:title) { "Edit #{page.page_title}" } %>
 
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
-  <%= link_to "Show #{@page.resource}", [Administrate::NAMESPACE, @page.resource], class: "button" %>
+  <%= link_to "Show #{page.resource}", [Administrate::NAMESPACE, page.resource], class: "button" %>
 </header>
 
-<%= render "form" %>
+<%= render "form", page: page %>

--- a/administrate/app/views/administrate/application/index.html.erb
+++ b/administrate/app/views/administrate/application/index.html.erb
@@ -5,23 +5,23 @@ This view is the template for the index page.
 It is responsible for rendering the search bar, header and pagination.
 It renders the `_table` partial to display details about the resources.
 
-## Instance variables:
+## Local variables:
 
-- `@page`:
+- `page`:
   An instance of [Administrate::Page::Table][1].
   Contains helper methods to help display a table,
   and knows which attributes should be displayed in the resource's table.
-- `@resources`:
+- `resources`:
   An instance of `ActiveRecord::Relation` containing the resources
   that match the user's search criteria.
   By default, these resources are passed to the table partial to be displayed.
-- `@search_term`:
+- `search_term`:
   A string containing the term the user has searched for, if any.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Table
 %>
 
-<% content_for(:title) { @page.resource_name.pluralize.titleize } %>
+<% content_for(:title) { page.resource_name.pluralize.titleize } %>
 
 <% content_for(:search) do %>
   <form class="search">
@@ -33,7 +33,7 @@ It renders the `_table` partial to display details about the resources.
       name="search"
       class="search__input"
       placeholder="Search"
-      value="<%= @search_term %>"
+      value="<%= search_term %>"
     />
     <span class="search__hint">
       Press enter to search
@@ -44,12 +44,12 @@ It renders the `_table` partial to display details about the resources.
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to(
-    "New #{@page.resource_name.titleize.downcase}",
-    [:new, Administrate::NAMESPACE, @page.resource_name],
+    "New #{page.resource_name.titleize.downcase}",
+    [:new, Administrate::NAMESPACE, page.resource_name],
     class: "button",
   ) %>
 </header>
 
-<%= render "collection", collection_presenter: @page, resources: @resources %>
+<%= render "collection", collection_presenter: page, resources: resources %>
 
-<%= paginate @resources %>
+<%= paginate resources %>

--- a/administrate/app/views/administrate/application/new.html.erb
+++ b/administrate/app/views/administrate/application/new.html.erb
@@ -5,9 +5,9 @@ This view is the template for the "new resource" page.
 It displays a header, and then renders the `_form` partial
 to do the heavy lifting.
 
-## Instance variables:
+## Local variables:
 
-- `@page`:
+- `page`:
   An instance of [Administrate::Page::Form][1].
   Contains helper methods to help display a form,
   and knows which attributes should be displayed in the resource's form.
@@ -15,11 +15,11 @@ to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "New #{@page.resource_name.titleize}" } %>
+<% content_for(:title) { "New #{page.resource_name.titleize}" } %>
 
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to 'Back', :back, class: "button" %>
 </header>
 
-<%= render 'form' %>
+<%= render 'form', page: page %>

--- a/administrate/app/views/administrate/application/show.html.erb
+++ b/administrate/app/views/administrate/application/show.html.erb
@@ -5,9 +5,9 @@ This view is the template for the show page.
 It renders the attributes of a resource,
 as well as a link to its edit page.
 
-## Instance variables:
+## Local variables:
 
-- `@page`:
+- `page`:
   An instance of [Administrate::Page::Show][1].
   Contains methods for accessing the resource to be displayed on the page,
   as well as helpers for describing how each attribute of the resource
@@ -16,19 +16,19 @@ as well as a link to its edit page.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
 %>
 
-<% content_for(:title) { @page.page_title } %>
+<% content_for(:title) { page.page_title } %>
 
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
   <%= link_to(
     "Edit",
-    [:edit, Administrate::NAMESPACE, @page.resource],
+    [:edit, Administrate::NAMESPACE, page.resource],
     class: "button",
   ) %>
 </header>
 
 <dl>
-  <% @page.attributes.each do |attribute| %>
+  <% page.attributes.each do |attribute| %>
     <dt class="attribute-label"><%= attribute.name.titleize %></dt>
 
     <dd class="attribute-data attribute-data--<%=attribute.html_class%>"


### PR DESCRIPTION
Inspiration: http://thepugautomatic.com/2013/05/locals/
## Problem:

It is idiomatic in Rails to use instance variables to pass data from controllers to views.

However, there are a number of disadvantages to this approach:
- If you mistype an instance variable in a view,
  the application quietly swallows the error
  and returns `nil`.
- Instance variables can be set from anywhere in a controller,
  which can lead to spaghetti code
  and confusion about which variables
  are available for use in the view.
## Solution:

By passing local variables explicitly to views, we can be more confident about the API between controllers and views.
