### PR TITLE
Use optimistic versioning for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [BUGFIX] Fix asset precompilation issue for `datetime_picker_rails` gem.
 * [BUGFIX] Remove erroneous "Showing 5 of 1" messages
   from has_many relationships on the `show` page.
+* [COMPAT] Use optimistic versioning for all dependencies.
 * [DOC] Update README with a better description of the repo.
 * [DOC] Move changelog to root of repository, improve labels, add key.
 * [DOC] Add comments to all template files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ PATH
   remote: administrate
   specs:
     administrate (0.0.12)
-      autoprefixer-rails
+      autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.5)
       inline_svg (~> 0.6)
       kaminari (~> 0.16)
-      momentjs-rails (>= 2.9.0)
+      momentjs-rails (~> 2.8)
       neat (~> 1.1)
       normalize-rails (~> 3.0)
       rails (~> 4.2)

--- a/administrate/administrate.gemspec
+++ b/administrate/administrate.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "autoprefixer-rails"
+  s.add_dependency "autoprefixer-rails", "~> 6.0"
   s.add_dependency "datetime_picker_rails", "~> 0.0.5"
   s.add_dependency "inline_svg", "~> 0.6"
   s.add_dependency "kaminari", "~> 0.16"
-  s.add_dependency "momentjs-rails", ">= 2.9.0"
+  s.add_dependency "momentjs-rails", "~> 2.8"
   s.add_dependency "neat", "~> 1.1"
   s.add_dependency "normalize-rails", "~> 3.0"
   s.add_dependency "rails", "~> 4.2"


### PR DESCRIPTION
Problem:

Bundling the gem for deployment raised the errors:

```
WARNING:  open-ended dependency on autoprefixer-rails (>= 0) is not recommended
  if autoprefixer-rails is semantically versioned, use:
    add_runtime_dependency 'autoprefixer-rails', '~> 0'
WARNING:  open-ended dependency on momentjs-rails (>= 2.9.0) is not recommended
  if momentjs-rails is semantically versioned, use:
    add_runtime_dependency 'momentjs-rails', '~> 2.9', '>= 2.9.0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```

Solution:

Use optimistic versioning for all dependencies,
under the assumption they're all using semantic versioning.
