### PR TITLE
[BUGFIX] Better detection of application models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   (e.g. `gem "administrate", github: "thoughtbot/administrate"`)
 * [COMPAT] Use ANSI SQL standards for case-insensitive search
 * [DOC] Add Rubygems version badge to README
+* [#124] [BUGFIX] Better detection of application models
 * [DOC] Add CircleCI badge to README
 * [DOC] Add CodeClimate badge to README
 * [UI] Preserve whitespace when rendering text fields

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -47,7 +47,7 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants
+        ActiveRecord::Base.descendants.select(&:table_exists?)
       end
 
       def dashboard_routes

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "generators/administrate/install/install_generator"
 require "support/generator_spec_helpers"
+require "support/constant_helpers"
 
 describe Administrate::Generators::InstallGenerator, :generator do
   describe "admin/application_controller" do
@@ -51,6 +52,20 @@ describe Administrate::Generators::InstallGenerator, :generator do
       run_generator
 
       expect(manifest).not_to contain("delayed/backend/active_record/jobs")
+    end
+
+    it "skips models that aren't backed by the database" do
+      begin
+        class ModelWithoutDBTable < ActiveRecord::Base; end
+        stub_generator_dependencies
+        manifest = file("app/dashboards/dashboard_manifest.rb")
+
+        run_generator
+
+        expect(manifest).not_to contain("model_without_db_table")
+      ensure
+        remove_constants :ModelWithoutDBTable
+      end
     end
   end
 


### PR DESCRIPTION
Closes #122.

## Problem:

Administrate assumes that all subclasses of `ActiveRecord::Base` are backed by database tables.

When a host application or gem defines a subclass of `ActiveRecord::Base` that doesn't have a corresponding database table, the installation generator sees an error:

```
postgresql_adapter.rb:596:in `async_exec': PG::UndefinedTable: ERROR:  relation "read_marks" does not exist (ActiveRecord::StatementInvalid)
LINE 5:                WHERE a.attrelid = '"read_marks"'::regclass
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"read_marks"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```

## Solution:

Verify that a model's database table exists before creating the model's dashboard.