### PR TITLE
Fix show page alignment issues

### DIFF
--- a/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -3,6 +3,8 @@
   @include span-columns(2 of 12);
   margin-top: 0;
   text-align: right;
+  margin-bottom: 1.85em;
+  clear: left;
 }
 
 .attribute-data--string {

--- a/administrate/app/views/fields/belongs_to/_show.html.erb
+++ b/administrate/app/views/fields/belongs_to/_show.html.erb
@@ -14,7 +14,6 @@ By default, the relationship is rendered as a link to the associated object.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
 %>
-
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to field.data, [Administrate::NAMESPACE, field.data] -%>
 <% end %>

--- a/administrate/app/views/fields/boolean/_show.html.erb
+++ b/administrate/app/views/fields/boolean/_show.html.erb
@@ -15,5 +15,4 @@ as a string representation of the boolean value.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Boolean
 %>
-
-<%= field.to_s %>
+<%= field.to_s -%>

--- a/administrate/app/views/fields/date_time/_show.html.erb
+++ b/administrate/app/views/fields/date_time/_show.html.erb
@@ -15,7 +15,6 @@ as a localized date & time string.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
 %>
-
 <% if field.data %>
-  <%= l field.data %>
+  <%= l field.data -%>
 <% end %>

--- a/administrate/app/views/fields/email/_show.html.erb
+++ b/administrate/app/views/fields/email/_show.html.erb
@@ -14,5 +14,4 @@ By default, the relationship is rendered as a `mailto` link.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Email
 %>
-
-<%= mail_to field.data %>
+<%= mail_to field.data -%>

--- a/administrate/app/views/fields/has_one/_show.html.erb
+++ b/administrate/app/views/fields/has_one/_show.html.erb
@@ -14,7 +14,6 @@ By default, the relationship is rendered as a link to the associated object.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
 %>
-
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to field.data, [Administrate::NAMESPACE, field.data] -%>
 <% end %>

--- a/administrate/app/views/fields/image/_show.html.erb
+++ b/administrate/app/views/fields/image/_show.html.erb
@@ -14,5 +14,4 @@ By default, the attribute is rendered as an image tag.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
 %>
-
-<%= image_tag field.data %>
+<%= image_tag field.data -%>

--- a/administrate/app/views/fields/number/_show.html.erb
+++ b/administrate/app/views/fields/number/_show.html.erb
@@ -15,5 +15,4 @@ using the formatting options given in the resource's dashboard.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Number
 %>
-
-<%= field.to_s %>
+<%= field.to_s -%>

--- a/administrate/app/views/fields/polymorphic/_show.html.erb
+++ b/administrate/app/views/fields/polymorphic/_show.html.erb
@@ -15,10 +15,9 @@ By default, the relationship is rendered as a link to the associated object.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Polymorphic
 %>
-
 <% if field.data %>
   <%= link_to(
     field.data.to_s,
     polymorphic_path([:admin, field.data])
-  ) %>
+  ) -%>
 <% end %>

--- a/administrate/app/views/fields/string/_show.html.erb
+++ b/administrate/app/views/fields/string/_show.html.erb
@@ -14,5 +14,4 @@ By default, the attribute is rendered as an unformatted string.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
 %>
-
-<%= field.data %>
+<%= field.data -%>

--- a/administrate/app/views/fields/text/_show.html.erb
+++ b/administrate/app/views/fields/text/_show.html.erb
@@ -1,1 +1,1 @@
-<%= field.data %>
+<%= field.data -%>


### PR DESCRIPTION
This fixes the alignment issues on the show page by removing the space
between the comment and the field, and adding the hyphen to the ERB tag.

We might want to remove the space from all the other partials too for
consistency.

I've also added a margin to the bottom of the label tags which improves the spacing when fields are empty.

<img width="1392" alt="screen shot 2015-11-02 at 14 43 08" src="https://cloud.githubusercontent.com/assets/165531/10884575/a6923f4a-8170-11e5-89b2-ce84a50c70f9.png">

Fixed:

<img width="1392" alt="screen shot 2015-11-02 at 14 43 35" src="https://cloud.githubusercontent.com/assets/165531/10884578/a98a74e2-8170-11e5-9af5-751bceb63d85.png">