### PR TITLE
Make text fields respect whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [DOC] Add CircleCI badge to README
 * [DOC] Add CodeClimate badge to README
+* [UI] Preserve whitespace when rendering text fields
 
 ### 0.1.0 (October 30, 2015)
 

--- a/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/administrate/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -5,7 +5,7 @@
   text-align: right;
 }
 
-.attribute-data--string {
+.preserve-whitespace {
   white-space: pre;
 }
 

--- a/administrate/app/views/fields/text/_form.html.erb
+++ b/administrate/app/views/fields/text/_form.html.erb
@@ -1,2 +1,18 @@
+<%#
+# Text Form Partial
+
+This partial renders a textarea element for a text attribute.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Text][1].
+  A wrapper around the Text pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
+%>
+
 <%= f.label field.attribute %>
 <%= f.text_area field.attribute %>

--- a/administrate/app/views/fields/text/_index.html.erb
+++ b/administrate/app/views/fields/text/_index.html.erb
@@ -1,1 +1,18 @@
+<%#
+# Text Index Partial
+
+This partial renders a text attribute
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered as a truncated string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Text][1].
+  A wrapper around the Text pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
+%>
+
 <%= field.truncate %>

--- a/administrate/app/views/fields/text/_show.html.erb
+++ b/administrate/app/views/fields/text/_show.html.erb
@@ -1,1 +1,19 @@
-<%= field.data %>
+<%#
+# Text Show Partial
+
+This partial renders a text attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered as text with
+whitespace preserved.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Text][1].
+  A wrapper around the Text pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
+%>
+
+<span class="preserve-whitespace"><%= field.data %></span>


### PR DESCRIPTION
Removes the preservation of whitespace from string fields. I've also
taken the opportunity to add comments to the text field partials.

This replaces #125

<img width="1392" alt="screen shot 2015-11-02 at 16 40 36" src="https://cloud.githubusercontent.com/assets/165531/10887718/787de0a4-8180-11e5-9aa8-26e4b262dc33.png">
