### PR TITLE
Add Spanish translation for i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [DOC] Add CircleCI badge to README
 * [DOC] Add CodeClimate badge to README
 * [UI] Preserve whitespace when rendering text fields
+* [FEATURE] Add Spanish translation for i18n
 
 ### 0.1.0 (October 30, 2015)
 

--- a/administrate/config/locales/administrate.es.yml
+++ b/administrate/config/locales/administrate.es.yml
@@ -1,0 +1,23 @@
+---
+es:
+  administrate:
+    actions:
+      confirm: ¿Estás seguro?
+      destroy: Destruir
+      edit: Editar
+      show: Mostrar
+    controller:
+      create:
+        success: "%{resource} fue creado exitosamente."
+      destroy:
+        success: "%{resource} fue destruido exitosamente."
+      update:
+        success: "%{resource} fue actualizado exitosamente."
+    fields:
+      has_many:
+        more: Mostrando %{count} de %{total_count}
+        none: Ninguno
+      polymorphic:
+        not_supported: Los formularios con relaciones polimórficas no están soportados todavía. ¡Perdón!
+      has_one:
+        not_supported: Los formularios con relaciones HasOne no están soportados todavía. ¡Perdón!


### PR DESCRIPTION
I have a Rails project in production using rails_admin and I was considering removing it and writing an admin dashboard from scratch. But administrate came to the rescue and provided the right balance between customization and automatic code generation I was needing in this project.

Thank you! Here's my first small contribution to the project, hopefully won't be my last.