### PR TITLE
Fix seeds

### DIFF
--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -19,7 +19,7 @@ Product.destroy_all
   )
 end
 
-product_attributes = YAML.load_file("./db/seeds/products.yml")
+product_attributes = YAML.load_file(Rails.root.join('db/seeds/products.yml'))
 
 product_attributes.each do |attributes|
   Product.create attributes.merge(price: 20 + rand(50))


### PR DESCRIPTION
Hello. When you run `bin/setup`, I get the following error:
```
-- add_foreign_key("line_items", "orders")
   -> 0.0045s
-- add_foreign_key("line_items", "products")
   -> 0.0028s
-- add_foreign_key("orders", "customers")
   -> 0.0028s
-- initialize_schema_migrations_table()
   -> 0.0015s
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - ./db/seeds/products.yml
/Users/mgrachev/administrate/spec/example_app/db/seeds.rb:22:in `<top (required)>'
/Users/mgrachev/administrate/vendor/bundle/gems/activesupport-4.2.2/lib/active_support/dependencies.rb:268:in `load'
/Users/mgrachev/administrate/vendor/bundle/gems/activesupport-4.2.2/lib/active_support/dependencies.rb:268:in `block in load'
/Users/mgrachev/administrate/vendor/bundle/gems/activesupport-4.2.2/lib/active_support/dependencies.rb:240:in `load_dependency'
/Users/mgrachev/administrate/vendor/bundle/gems/activesupport-4.2.2/lib/active_support/dependencies.rb:268:in `load'
/Users/mgrachev/administrate/vendor/bundle/gems/railties-4.2.2/lib/rails/engine.rb:547:in `load_seed'
/Users/mgrachev/Development/Rails/work/administrate/vendor/bundle/gems/activerecord-4.2.2/lib/active_record/tasks/database_tasks.rb:250:in `load_seed'
/Users/mgrachev/administrate/vendor/bundle/gems/activerecord-4.2.2/lib/active_record/railties/databases.rake:180:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:setup => db:seed
(See full trace by running task with --trace)
```

Minor improvements when loading seed.