### PR TITLE
Use ANSI SQL standards for case-insensitive search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#156] [COMPAT] Include missing `sass-rails` dependency in gemspec
 * [COMPAT] Update repository structure so Bundler can pull the gem from github.
   (e.g. `gem "administrate", github: "thoughtbot/administrate"`)
+* [COMPAT] Use ANSI SQL standards for case-insensitive search
 * [DOC] Add Rubygems version badge to README
 * [DOC] Add CircleCI badge to README
 * [DOC] Add CodeClimate badge to README

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -18,11 +18,11 @@ module Administrate
     delegate :resource_class, to: :resolver
 
     def query
-      search_attributes.map { |attr| "#{attr} ILIKE ?" }.join(" OR ")
+      search_attributes.map { |attr| "lower(#{attr}) LIKE ?" }.join(" OR ")
     end
 
     def search_terms
-      ["%#{term}%"] * search_attributes.count
+      ["%#{term.downcase}%"] * search_attributes.count
     end
 
     def search_attributes


### PR DESCRIPTION
`ILIKE` is supported in Postgres but not other common SQL databases.
Use `LIKE` and `lower` ANSI SQL standards instead for broader support.

https://www-304.ibm.com/support/knowledgecenter/SSGU8G_12.1.0/com.ibm.sqls.doc/ids_sqs_1388.htm
https://www-304.ibm.com/support/knowledgecenter/SSGU8G_12.1.0/com.ibm.sqls.doc/ids_sqs_1567.htm