### PR TITLE
Use local version of administrate in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,8 @@
 *.swo
 *.swp
 /.bundle
-/.env
-/.foreman
 /coverage/*
 /db/*.sqlite3
 /log/*
-/spec/example_app/log/*
-/spec/example_app/public/system
-/spec/example_app/public/assets
 /tags
 /tmp/*
-/spec/example_app/tmp/*

--- a/spec/example_app/.gitignore
+++ b/spec/example_app/.gitignore
@@ -1,0 +1,6 @@
+/.env
+/.foreman
+/log/*
+/public/assets
+/public/system
+/tmp/*

--- a/spec/example_app/Gemfile
+++ b/spec/example_app/Gemfile
@@ -2,7 +2,11 @@ source "https://rubygems.org"
 
 ruby "2.2.0"
 
-gem "administrate", github: "thoughtbot/administrate"
+if ENV["RACK_ENV"] == "production"
+  gem "administrate", github: "thoughtbot/administrate"
+else
+  gem "administrate", path: "../.."
+end
 
 gem "airbrake"
 gem "coffee-rails", "~> 4.1.0"

--- a/spec/example_app/Gemfile.lock
+++ b/spec/example_app/Gemfile.lock
@@ -1,6 +1,5 @@
-GIT
-  remote: git://github.com/thoughtbot/administrate.git
-  revision: bceb50c92de23a1697ac608502f22d303f1a2d8f
+PATH
+  remote: ../..
   specs:
     administrate (0.1.0)
       autoprefixer-rails (~> 6.0)
@@ -11,7 +10,7 @@ GIT
       neat (~> 1.1)
       normalize-rails (~> 3.0)
       rails (~> 4.2)
-      sass (~> 3.4)
+      sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
 
 GEM
@@ -250,7 +249,13 @@ GEM
     rspec-support (3.1.2)
     ruby-progressbar (1.7.1)
     safe_yaml (1.0.4)
-    sass (3.4.12)
+    sass (3.4.19)
+    sass-rails (5.0.4)
+      railties (>= 4.0.0, < 5.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     selectize-rails (0.12.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -273,6 +278,7 @@ GEM
     thor (0.19.1)
     thread (0.1.5)
     thread_safe (0.3.5)
+    tilt (2.0.1)
     timecop (0.7.3)
     tins (1.3.4)
     title (0.0.5)


### PR DESCRIPTION
## Problem:

When a contributor tries to run the example app by `cd`ing into
`spec/example_app`, running `bundle install`, and running the server,
the Gemfile downloads a separate copy of Administrate from the master
branch on Github. This prevents the contributor from testing out any
local changes to the Administrate source.

We cannot simply reference the relative path to the local Administrate
source, because that would make Heroku deploys fail.

## Solution:

Check the Rack environment to determine which source Bundler should use
for Administrate.

Contributors can now run `bundle install` and `foreman start` from their
`spec/example_app` directory to test local changes to Administrate.