### PR TITLE
Add basic validations for Product slugs

### DIFF
--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -3,6 +3,8 @@ class Product < ActiveRecord::Base
   validates :image_url, presence: true
   validates :name, presence: true
   validates :price, presence: true
+  validates :slug, uniqueness: true
+  validate :valid_slug
 
   def to_s
     name
@@ -15,5 +17,11 @@ class Product < ActiveRecord::Base
 
   def to_param
     slug
+  end
+
+  def valid_slug
+    if slug.blank?
+      errors.add :name, "must have letters or numbers for the URL"
+    end
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -6,5 +6,20 @@ RSpec.describe Product do
     it { should validate_presence_of(:image_url) }
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:price) }
+
+    it "should not allow names that produce empty slugs" do
+      product = build(:product, name: "???")
+
+      product.validate
+
+      expect(product.errors[:name]).
+        to include("must have letters or numbers for the URL")
+    end
+
+    context "with other products in the database" do
+      subject { build(:product) }
+
+      it { should validate_uniqueness_of(:slug) }
+    end
   end
 end


### PR DESCRIPTION
Closes #162 

## Problem:

On the demo site, it's rather simple for users to craft product names
that don't translate into valid slugs.

When Rails tries to render links to these products, it throws a 500
error because it cannot generate a correct URL.

## Solution:

Add validators to ensure that all products have a valid and unique slug.