### PR TITLE
Use `@example.com` for all sample email addresses

### DIFF
--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -15,7 +15,7 @@ Product.destroy_all
   name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
   Customer.create(
     name: name,
-    email: Faker::Internet.free_email(name),
+    email: Faker::Internet.safe_email(name),
   )
 end
 


### PR DESCRIPTION
Fixes #149

## Problem:

The demo app uses realistic email addresses, generated by [Faker].
If any of the generated emails are real,
they may be picked up by web crawlers and receive spam.

Big thanks to @lorenzk for pointing out this downside of realistic
emails.

[Faker]: https://github.com/stympy/faker

## Solution:

Use [Faker]'s `#safe_email` method, which uses `example.com` for all
email domains.

`example.com` is a reserved domain, and sending emails to it is a no-op.