### PR TITLE
Add translations for ActiveRecord models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Upcoming Release
 
+* [FEATURE] Add translations for ActiveRecord models
 * [#142] [FEATURE] Translation: Brazilian Portuguese
 * [#171] [FEATURE] Translation: Polish
 * [#153] [FEATURE] Translation: Russian

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -11,7 +11,7 @@ as defined by the DashboardManifest.
   <% DashboardManifest::DASHBOARDS.each do |resource| %>
     <li>
       <%= link_to(
-        resource.to_s.titleize,
+        resource.to_s.classify.constantize.model_name.human(default: resource.to_s.titleize),
         [Administrate::NAMESPACE, resource],
         class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
       ) %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -21,7 +21,9 @@ It renders the `_table` partial to display details about the resources.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Table
 %>
 
-<% content_for(:title) { page.resource_name.pluralize.titleize } %>
+<% content_for(:title) do
+  page.resource_name.classify.constantize.model_name.human(default: page.resource_name.pluralize.titleize)
+end %>
 
 <% content_for(:search) do %>
   <form class="search">

--- a/spec/features/sidebar_spec.rb
+++ b/spec/features/sidebar_spec.rb
@@ -8,4 +8,14 @@ describe "sidebar" do
 
     expect(active_link.text).to eq "Customers"
   end
+
+  it "displays translated name of model" do
+    allow(Customer.model_name).to receive(:human).and_return('Users')
+
+    visit admin_customers_path
+
+    sidebar = find(".sidebar__list")
+    expect(sidebar).to have_link("Users")
+    expect(page).to have_header("Users")
+  end
 end


### PR DESCRIPTION
Hi. Added translation support for ActiveRecord models in the sidebar and on the index page (header).

File locale must be of such content:
```yml
en:
  activerecord:
    models:
      bet: Rates
```