### PR TITLE
Set up visual regression testing with Percy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem "formulaic"
   gem "fuubar"
   gem "launchy"
+  gem "percy-capybara"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.5.0)
       i18n (~> 0.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     formulaic (0.3.0)
       activesupport
       capybara
@@ -125,6 +127,7 @@ GEM
     hashdiff (0.2.2)
     high_voltage (2.4.0)
     highline (1.7.8)
+    httpclient (2.7.0)
     i18n (0.7.0)
     i18n-tasks (0.8.7)
       activesupport (>= 2.3.18)
@@ -160,12 +163,18 @@ GEM
     momentjs-rails (2.10.6)
       railties (>= 3.1)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
+    percy-capybara (1.0.0)
+      percy-client (>= 1.0.0)
+    percy-client (1.2.0)
+      faraday (>= 0.9)
+      httpclient (>= 2.6)
     pg (0.18.3)
     poltergeist (1.7.0)
       capybara (~> 2.1)
@@ -301,6 +310,7 @@ DEPENDENCIES
   high_voltage
   i18n-tasks
   launchy
+  percy-capybara
   pg
   poltergeist
   pry-rails

--- a/spec/features/visual_regression_spec.rb
+++ b/spec/features/visual_regression_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.feature "Visual regressions" do
+  after(:each) do |example|
+    Percy::Capybara.snapshot(page, name: example.full_description)
+  end
+
+  scenario "customer index" do
+    create_customer_with_fixed_info
+    visit admin_customers_path
+  end
+
+  scenario "searching interactions", :js do
+    visit admin_customers_path
+    fill_in(:search, with: "Test search")
+    sleep 1
+  end
+
+  scenario "customer with order" do
+    customer = create_customer_with_fixed_info
+    with_fixed_time { create(:order, customer: customer) }
+
+    visit admin_customer_path(customer)
+  end
+
+  scenario "customer edit page" do
+    customer = create_customer_with_fixed_info
+    visit edit_admin_customer_path(customer)
+  end
+
+  scenario "new customer page" do
+    visit new_admin_customer_path
+  end
+
+  def with_fixed_time
+    Timecop.freeze(Time.new(2015)) { yield }
+  end
+
+  def create_customer_with_fixed_info
+    with_fixed_time do
+      create(:customer, name: "Sample Data", email: "sample@example.com")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,13 @@
 ENV["RAILS_ENV"] = "test"
+require "dotenv"
+Dotenv.load
 
 require File.expand_path("../../spec/example_app/config/environment", __FILE__)
 
 require "rspec/rails"
 require "shoulda/matchers"
 require "capybara/poltergeist"
+require "percy/capybara/rspec"
 
 Dir[Rails.root.join("../../spec/support/**/*.rb")].each { |file| require file }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,4 @@ RSpec.configure do |config|
   config.order = :random
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: "percy.io")


### PR DESCRIPTION
See https://percy.io/

## Problem:

For pull requests with UI changes, it can be difficult to tell if the
changes affect elements on other pages.
It can also be tedious to pull the changes down to a local machine
if the contributor has forgotten to add screenshots.

## Solution:

Add visual regression snapshots to our test suite with Percy.
After we record the inital set of screenshots,
future test suite runs will be compared against them
to recognize and call out any changes.