### PR TITLE
Improve default resource display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@
 
 ### Upcoming Release
 
+* [#191] [CHANGE] Improve API for specifying how resources are displayed
+  across the dashboard.
+  * Models are now displayed with a sensible default - (e.g. "User #2")
+  * Users can define `ModelDashboard#display_resource(resource)` for custom
+    display behavior
+  * Users who have generated views for the following field types
+    may need to update them to take advantage of the new API:
+    * HasOne
+    * HasMany
+    * PolyMorphic
+    * BelongsTo
 * [#223] [FEATURE] Translation: Vietnamese
 * [#161] [FEATURE] Translation: Mandarin Chinese
 * [#196] [FEATURE] Translation: Taiwanese Mandarin

--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -17,9 +17,6 @@ that displays all possible records to associate with.
 %>
 
 <%= f.label field.permitted_attribute %>
-<%= f.collection_select(
-  field.permitted_attribute,
-  field.candidate_records,
-  :id,
-  :to_s,
-) %>
+<%= f.select(field.permitted_attribute) do %>
+  <%= options_for_select(field.associated_resource_options) %>
+<% end %>

--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -16,5 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to(
+    field.display_associated_resource,
+    [Administrate::NAMESPACE, field.data],
+  ) %>
 <% end %>

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -16,5 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to(
+    field.display_associated_resource,
+    [Administrate::NAMESPACE, field.data],
+  ) %>
 <% end %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -21,12 +21,6 @@ and is augmented with [Selectize].
 
 <%= f.label field.attribute_key %>
 
-<%= f.collection_select(
-  field.attribute_key,
-  field.candidate_records,
-  :id,
-  :to_s,
-  {},
-  { multiple: true },
-)
-%>
+<%= f.select(field.attribute_key, nil, {}, multiple: true) do %>
+  <%= options_for_select(field.associated_resource_options) %>
+<% end %>

--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -17,6 +17,6 @@ so this partial renders a message to that effect.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
 %>
 
-<%= f.label field.permitted_attribute %>
+<%= f.label field.attribute %>
 
 <%= t("administrate.fields.has_one.not_supported") %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -16,5 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to(
+    field.display_associated_resource,
+    [Administrate::NAMESPACE, field.data],
+  ) %>
 <% end %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -16,5 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to field.data, [Administrate::NAMESPACE, field.data] %>
+  <%= link_to(
+    field.display_associated_resource,
+    [Administrate::NAMESPACE, field.data],
+  ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -18,7 +18,7 @@ By default, the relationship is rendered as a link to the associated object.
 
 <% if field.data %>
   <%= link_to(
-    field.data.to_s,
+    field.display_associated_resource,
     polymorphic_path([:admin, field.data])
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -18,7 +18,7 @@ By default, the relationship is rendered as a link to the associated object.
 
 <% if field.data %>
   <%= link_to(
-    field.data.to_s,
-    polymorphic_path([:admin, field.data])
+    field.display_associated_resource,
+    [:admin, field.data],
   ) %>
 <% end %>

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -35,5 +35,9 @@ module Administrate
     def collection_attributes
       self.class::COLLECTION_ATTRIBUTES
     end
+
+    def display_resource(resource)
+      "#{resource.class} ##{resource.id}"
+    end
   end
 end

--- a/lib/administrate/fields/associative.rb
+++ b/lib/administrate/fields/associative.rb
@@ -1,0 +1,25 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class Associative < Base
+      def display_associated_resource
+        associated_dashboard.display_resource(data)
+      end
+
+      protected
+
+      def associated_dashboard
+        "#{associated_class_name}Dashboard".constantize.new
+      end
+
+      def associated_class
+        associated_class_name.constantize
+      end
+
+      def associated_class_name
+        options.fetch(:class_name, attribute.to_s.singularize.camelcase)
+      end
+    end
+  end
+end

--- a/lib/administrate/fields/base.rb
+++ b/lib/administrate/fields/base.rb
@@ -1,4 +1,5 @@
 require_relative "deferred"
+require "active_support/core_ext/string/inflections"
 
 module Administrate
   module Field

--- a/lib/administrate/fields/belongs_to.rb
+++ b/lib/administrate/fields/belongs_to.rb
@@ -1,8 +1,8 @@
-require_relative "base"
+require_relative "associative"
 
 module Administrate
   module Field
-    class BelongsTo < Field::Base
+    class BelongsTo < Associative
       def self.permitted_attribute(attr)
         :"#{attr}_id"
       end
@@ -11,14 +11,20 @@ module Administrate
         self.class.permitted_attribute(attribute)
       end
 
-      def candidate_records
-        Object.const_get(associated_class_name).all
+      def associated_resource_options
+        candidate_resources.map do |resource|
+          [display_candidate_resource(resource), resource.id]
+        end
       end
 
       private
 
-      def associated_class_name
-        options.fetch(:class_name, attribute.to_s.camelcase)
+      def candidate_resources
+        associated_class.all
+      end
+
+      def display_candidate_resource(resource)
+        associated_dashboard.display_resource(resource)
       end
     end
   end

--- a/lib/administrate/fields/date_time.rb
+++ b/lib/administrate/fields/date_time.rb
@@ -1,3 +1,5 @@
+require_relative "base"
+
 module Administrate
   module Field
     class DateTime < Base

--- a/lib/administrate/fields/deferred.rb
+++ b/lib/administrate/fields/deferred.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/module/delegation"
+
 module Administrate
   module Field
     class Deferred

--- a/lib/administrate/fields/has_many.rb
+++ b/lib/administrate/fields/has_many.rb
@@ -1,9 +1,9 @@
-require_relative "base"
+require_relative "associative"
 require "administrate/page/collection"
 
 module Administrate
   module Field
-    class HasMany < Field::Base
+    class HasMany < Associative
       DEFAULT_LIMIT = 5
 
       def self.permitted_attribute(attribute)
@@ -18,8 +18,10 @@ module Administrate
         permitted_attribute.keys.first
       end
 
-      def candidate_records
-        Object.const_get(associated_class_name).all
+      def associated_resource_options
+        candidate_resources.map do |resource|
+          [display_candidate_resource(resource), resource.id]
+        end
       end
 
       def limit
@@ -40,12 +42,12 @@ module Administrate
 
       private
 
-      def associated_dashboard
-        Object.const_get("#{associated_class_name}Dashboard").new
+      def candidate_resources
+        associated_class.all
       end
 
-      def associated_class_name
-        options.fetch(:class_name, attribute.to_s.singularize.camelcase)
+      def display_candidate_resource(resource)
+        associated_dashboard.display_resource(resource)
       end
     end
   end

--- a/lib/administrate/fields/has_one.rb
+++ b/lib/administrate/fields/has_one.rb
@@ -1,9 +1,8 @@
-require_relative "base"
-require_relative "belongs_to"
+require_relative "associative"
 
 module Administrate
   module Field
-    class HasOne < BelongsTo
+    class HasOne < Associative
       def self.permitted_attribute(attr)
         attr
       end

--- a/lib/administrate/fields/polymorphic.rb
+++ b/lib/administrate/fields/polymorphic.rb
@@ -1,8 +1,8 @@
-require_relative "base"
+require_relative "associative"
 
 module Administrate
   module Field
-    class Polymorphic < Base
+    class Polymorphic < Associative
     end
   end
 end

--- a/lib/administrate/page/form.rb
+++ b/lib/administrate/page/form.rb
@@ -17,7 +17,7 @@ module Administrate
       end
 
       def page_title
-        resource.to_s
+        dashboard.display_resource(resource)
       end
 
       protected

--- a/lib/administrate/page/show.rb
+++ b/lib/administrate/page/show.rb
@@ -11,7 +11,7 @@ module Administrate
       attr_reader :resource
 
       def page_title
-        resource.to_s
+        dashboard.display_resource(resource)
       end
 
       def attributes

--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -40,4 +40,11 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   end.join("\n")
 %>
   ]
+
+  # Overwrite this method to customize how <%= file_name.pluralize.humanize.downcase %> are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(<%= file_name %>)
+  #   "<%= class_name %> ##{<%= file_name %>.id}"
+  # end
 end

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+require "administrate/fields/has_one"
+
+describe "fields/has_one/_form", type: :view do
+  it "displays the field name" do
+    has_one = instance_double(
+      "Administrate::Field::HasOne",
+      attribute: "Commentable",
+    )
+
+    render(
+      partial: "fields/has_one/form.html.erb",
+      locals: { field: has_one, f: form_builder },
+    )
+
+    expect(rendered.strip).to include("Commentable")
+  end
+
+  it "does not display a form" do
+    has_one = instance_double(
+      "Administrate::Field::HasOne",
+      attribute: "Commentable",
+    )
+
+    render(
+      partial: "fields/has_one/form.html.erb",
+      locals: { field: has_one, f: form_builder },
+    )
+
+    expect(rendered).
+      to include(t("administrate.fields.has_one.not_supported"))
+  end
+
+  def form_builder
+    double("Form Builder", label: "Commentable")
+  end
+end

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-describe "fields/polymorphic/_index", type: :view do
+describe "fields/has_one/_index", type: :view do
   context "without an associated records" do
     it "displays nothing" do
-      polymorphic = double(data: nil)
+      has_one = double(data: nil)
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
-        locals: { field: polymorphic },
+        partial: "fields/has_one/index.html.erb",
+        locals: { field: has_one },
       )
 
       expect(rendered.strip).to eq("")
@@ -18,15 +18,15 @@ describe "fields/polymorphic/_index", type: :view do
     it "renders a link to the record" do
       product = create(:product)
       product_path = polymorphic_path([:admin, product])
-      polymorphic = instance_double(
-        "Administrate::Field::Polymorphic",
+      has_one = instance_double(
+        "Administrate::Field::HasOne",
         data: product,
         display_associated_resource: product.name,
       )
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
-        locals: { field: polymorphic },
+        partial: "fields/has_one/index.html.erb",
+        locals: { field: has_one },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -1,13 +1,18 @@
 require "rails_helper"
+require "administrate/fields/has_one"
 
-describe "fields/polymorphic/_index", type: :view do
+describe "fields/has_one/_show", type: :view do
   context "without an associated records" do
     it "displays nothing" do
-      polymorphic = double(data: nil)
+      has_one = instance_double(
+        "Administrate::Field::HasOne",
+        display_associated_resource: "",
+        data: nil,
+      )
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
-        locals: { field: polymorphic },
+        partial: "fields/has_one/show.html.erb",
+        locals: { field: has_one },
       )
 
       expect(rendered.strip).to eq("")
@@ -18,15 +23,15 @@ describe "fields/polymorphic/_index", type: :view do
     it "renders a link to the record" do
       product = create(:product)
       product_path = polymorphic_path([:admin, product])
-      polymorphic = instance_double(
-        "Administrate::Field::Polymorphic",
-        data: product,
+      has_one = instance_double(
+        "Administrate::Field::HasOne",
         display_associated_resource: product.name,
+        data: product,
       )
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
-        locals: { field: polymorphic },
+        partial: "fields/has_one/show.html.erb",
+        locals: { field: has_one },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
+require "administrate/fields/polymorphic"
 
 describe "fields/polymorphic/_show", type: :view do
   context "without an associated records" do
     it "displays nothing" do
-      polymorphic = double(data: nil)
+      polymorphic = instance_double(
+        "Administrate::Field::Polymorphic",
+        display_associated_resource: "",
+        data: nil,
+      )
 
       render(
         partial: "fields/polymorphic/show.html.erb",
@@ -17,15 +22,20 @@ describe "fields/polymorphic/_show", type: :view do
   context "with an associated record" do
     it "renders a link to the record" do
       product = create(:product)
-      polymorphic = double(data: product)
       product_path = polymorphic_path([:admin, product])
+      polymorphic = instance_double(
+        "Administrate::Field::Polymorphic",
+        display_associated_resource: product.name,
+        data: product,
+      )
 
       render(
         partial: "fields/polymorphic/show.html.erb",
         locals: { field: polymorphic },
       )
 
-      expect(rendered.strip).to eq("<a href=\"#{product_path}\">#{product}</a>")
+      expected = "<a href=\"#{product_path}\">#{product.name}</a>"
+      expect(rendered.strip).to eq(expected)
     end
   end
 end

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -23,4 +23,15 @@ describe CustomerDashboard do
         to eq(Field::Number.with_options(prefix: "$", decimals: 2))
     end
   end
+
+  describe "#display_resource" do
+    it "returns the customer's name" do
+      customer = double(name: "Example Customer")
+      dashboard = CustomerDashboard.new
+
+      rendered_resource = dashboard.display_resource(customer)
+
+      expect(rendered_resource).to eq(customer.name)
+    end
+  end
 end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -14,4 +14,8 @@ class CustomerDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys - [:name]
   FORM_ATTRIBUTES = [:name, :email, :email_subscriber]
+
+  def display_resource(customer)
+    customer.name
+  end
 end

--- a/spec/example_app/app/dashboards/line_item_dashboard.rb
+++ b/spec/example_app/app/dashboards/line_item_dashboard.rb
@@ -21,4 +21,8 @@ class LineItemDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = ATTRIBUTES + [:total_price]
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTES + [:total_price]
   FORM_ATTRIBUTES = ATTRIBUTES
+
+  def display_resource(line_item)
+    "Line Item #%04d" % line_item.id
+  end
 end

--- a/spec/example_app/app/dashboards/product_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_dashboard.rb
@@ -20,4 +20,8 @@ class ProductDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = ATTRIBUTES
   FORM_ATTRIBUTES = ATTRIBUTES
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTES
+
+  def display_resource(resource)
+    resource.name
+  end
 end

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -7,8 +7,4 @@ class Customer < ActiveRecord::Base
   def lifetime_value
     orders.map(&:total_price).reduce(0, :+)
   end
-
-  def to_s
-    name
-  end
 end

--- a/spec/example_app/app/models/line_item.rb
+++ b/spec/example_app/app/models/line_item.rb
@@ -7,10 +7,6 @@ class LineItem < ActiveRecord::Base
   validates :unit_price, presence: true
   validates :quantity, presence: true
 
-  def to_s
-    "Line Item #%04d" % id
-  end
-
   def total_price
     unit_price * quantity
   end

--- a/spec/example_app/app/models/order.rb
+++ b/spec/example_app/app/models/order.rb
@@ -10,10 +10,6 @@ class Order < ActiveRecord::Base
   validates :address_state, presence: true
   validates :address_zip, presence: true
 
-  def to_s
-    "Order ##{id}"
-  end
-
   def total_price
     line_items.map(&:total_price).reduce(0, :+)
   end

--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -6,10 +6,6 @@ class Product < ActiveRecord::Base
   validates :slug, uniqueness: true
   validate :valid_slug
 
-  def to_s
-    name
-  end
-
   def name=(value)
     self.slug = value.to_s.parameterize
     super(value)

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -17,7 +17,7 @@ describe "customer index page" do
     visit admin_customers_path
     click_row_for(customer)
 
-    expect(page).to have_header(customer.to_s)
+    expect(page).to have_header(displayed(customer))
     expect(page).to have_content(customer.name)
     expect(page).to have_content(customer.email)
   end

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "line item index page" do
 
     expect(page).to have_header("Line Items")
     expect(page).to have_content(line_item.unit_price)
-    expect(page).to have_content(line_item.product.to_s)
+    expect(page).to have_content(displayed(line_item.product))
   end
 
   it "links to the line item show page", :js do
@@ -17,9 +17,9 @@ RSpec.describe "line item index page" do
     visit admin_line_items_path
     click_row_for(line_item)
 
-    expect(page).to have_header(line_item.to_s)
-    expect(page).to have_content(line_item.to_s)
-    expect(page).to have_content(line_item.product.to_s)
+    expect(page).to have_header(displayed(line_item))
+    expect(page).to have_content(displayed(line_item))
+    expect(page).to have_content(displayed(line_item.product))
   end
 
   it "links to the edit page" do
@@ -28,7 +28,7 @@ RSpec.describe "line item index page" do
     visit admin_line_items_path
     click_on "Edit"
 
-    expect(page).to have_header("Edit #{line_item}")
+    expect(page).to have_header("Edit #{displayed(line_item)}")
   end
 
   it "links to the new page" do

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -52,7 +52,7 @@ describe "order form" do
 
     def find_option(associated_model, field_id)
       field = find("#order_" + field_id)
-      field.find("option", text: associated_model.to_s)
+      field.find("option", text: displayed(associated_model))
     end
   end
 

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -14,7 +14,7 @@ feature "order index page" do
     order = create(:order)
 
     visit admin_orders_path
-    click_on(order.customer.to_s)
+    click_on(displayed(order.customer))
 
     expect(page).to have_header(order.customer.name)
   end
@@ -25,7 +25,7 @@ feature "order index page" do
     visit admin_orders_path
     click_row_for(order)
 
-    expect(page).to have_header(order.to_s)
+    expect(page).to have_header(displayed(order))
     expect(page).to have_link(order.customer.name)
   end
 

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -17,6 +17,6 @@ feature "order index page" do
     visit admin_order_path(line_item.order)
     click_row_for(line_item)
 
-    expect(page).to have_header(line_item.to_s)
+    expect(page).to have_header(displayed(line_item))
   end
 end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "customer show page" do
 
     click_row_for(order)
 
-    expect(page).to have_header(order.to_s)
+    expect(page).to have_header(displayed(order))
   end
 
   it "link-ifies the email" do
@@ -56,6 +56,6 @@ RSpec.describe "customer show page" do
     visit admin_customer_path(customer)
     click_on "Edit"
 
-    expect(page).to have_header("Edit #{customer}")
+    expect(page).to have_header("Edit #{displayed(customer)}")
   end
 end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/belongs_to"
 require "support/constant_helpers"
 require "support/field_matchers"
@@ -29,7 +28,7 @@ describe Administrate::Field::BelongsTo do
         association = Administrate::Field::BelongsTo.
           with_options(class_name: "Foo")
         field = association.new(:customers, [], :show)
-        candidates = field.candidate_records
+        candidates = field.associated_resource_options
 
         expect(Foo).to have_received(:all)
         expect(candidates).to eq([])

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -1,4 +1,3 @@
-require "rails_helper"
 require "administrate/fields/deferred"
 require "administrate/fields/string"
 

--- a/spec/lib/fields/email_spec.rb
+++ b/spec/lib/fields/email_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/email"
 
 describe Administrate::Field::Email do

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/has_many"
 require "support/constant_helpers"
 require "support/mock_relation"
@@ -18,12 +17,17 @@ describe Administrate::Field::HasMany do
 
   describe "#associated_collection" do
     it "returns an index page for the dashboard of the associated attribute" do
-      orders = []
-      field = Administrate::Field::HasMany.new(:orders, orders, :show)
+      begin
+        WidgetDashboard = Class.new
+        widgets = []
+        field = Administrate::Field::HasMany.new(:widgets, widgets, :show)
 
-      page = field.associated_collection
+        page = field.associated_collection
 
-      expect(page).to be_instance_of(Administrate::Page::Collection)
+        expect(page).to be_instance_of(Administrate::Page::Collection)
+      ensure
+        remove_constants :WidgetDashboard
+      end
     end
   end
 

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/has_one"
 require "support/constant_helpers"
 
@@ -12,25 +11,6 @@ describe Administrate::Field::HasOne do
       path = field.to_partial_path
 
       expect(path).to eq("/fields/has_one/#{page}")
-    end
-  end
-
-  describe "class_name option" do
-    it "determines what dashboard is used to present the association" do
-      begin
-        Foo = Class.new
-        allow(Foo).to receive(:all).and_return([])
-
-        association = Administrate::Field::HasOne.
-          with_options(class_name: "Foo")
-        field = association.new(:customers, [], :show)
-        candidates = field.candidate_records
-
-        expect(Foo).to have_received(:all)
-        expect(candidates).to eq([])
-      ensure
-        remove_constants :Foo
-      end
     end
   end
 end

--- a/spec/lib/fields/image_spec.rb
+++ b/spec/lib/fields/image_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/image"
 
 describe Administrate::Field::Image do

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/number"
 require "support/field_matchers"
 

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/polymorphic"
 require "support/field_matchers"
 

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "administrate/fields/string"
 require "support/field_matchers"
 

--- a/spec/lib/pages/form_spec.rb
+++ b/spec/lib/pages/form_spec.rb
@@ -3,7 +3,7 @@ require "administrate/page/form"
 describe Administrate::Page::Form do
   describe "#page_title" do
     it "is the value of the resource's key attribute" do
-      customer = double(to_s: "Worf")
+      customer = double(name: "Worf")
       page = Administrate::Page::Form.new(CustomerDashboard.new, customer)
 
       expect(page.page_title).to eq("Worf")

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -3,7 +3,7 @@ require "administrate/page/show"
 describe Administrate::Page::Show do
   describe "#page_title" do
     it "is the stringified resource" do
-      customer = double(to_s: "Worf")
+      customer = double(name: "Worf")
       page = Administrate::Page::Show.new(CustomerDashboard.new, customer)
 
       expect(page.page_title).to eq("Worf")

--- a/spec/support/dashboard_helpers.rb
+++ b/spec/support/dashboard_helpers.rb
@@ -1,0 +1,12 @@
+module DashboardHelpers
+  def displayed(resource)
+    (resource.class.to_s + "Dashboard").
+      constantize.
+      new.
+      display_resource(resource)
+  end
+end
+
+RSpec.configure do |config|
+  config.include DashboardHelpers
+end


### PR DESCRIPTION
Closes #129

## Problem:

Administrate relies on `#to_s`
to display resources throughout the system.
In order to get Administrate working correctly,
developers must define `#to_s` on all models
that will be displayed in the admin dashboard.

This process is not documented,
can be confusing,
and gets in the way of a zero-configuration dashboard.

## Solution:

Add `Administrate::BaseDashboard#display_resource`,
which takes a resource and returns a sensible string representation.
Devs can overwrite this method on a per-dashboard basis
to customize how their resources are displayed.

In order to document this method,
we generate comments in each dashboard class that follow the format:

```ruby
  # Overwrite this method to customize how line items are displayed
  # across all pages of the admin dashboard.
  #
  # def display_resource(line_item)
  #   "LineItem ##{line_item.id}"
  # end
```

## TODO

- [x] Add comments to generated dashboards
- [x] CHANGELOG