### PR TITLE
Assume unknown db column types are un-searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#171] [FEATURE] Translation: Polish
 * [#153] [FEATURE] Translation: Russian
 * [#148] [FEATURE] Translation: French
+* [#193] [BUGFIX] Don't assume that unrecognized db column types are searchable
 * [#156] [COMPAT] Include missing `sass-rails` dependency in gemspec
 * [COMPAT] Update repository structure so Bundler can pull the gem from github.
   (e.g. `gem "administrate", github: "thoughtbot/administrate"`)

--- a/lib/administrate/fields/deferred.rb
+++ b/lib/administrate/fields/deferred.rb
@@ -16,10 +16,13 @@ module Administrate
         deferred_class == other.deferred_class && options == other.options
       end
 
+      def searchable?
+        options.fetch(:searchable, deferred_class.searchable?)
+      end
+
       delegate(
         :html_class,
         :permitted_attribute,
-        :searchable?,
         to: :deferred_class,
       )
     end

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -11,13 +11,14 @@ module Administrate
         integer: "Field::Number",
         time: "Field::DateTime",
         text: "Field::Text",
+        string: "Field::String",
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {
         float: { decimals: 2 },
       }
 
-      DEFAULT_FIELD_TYPE = "Field::String"
+      DEFAULT_FIELD_TYPE = "Field::String.with_options(searchable: false)"
       COLLECTION_ATTRIBUTE_LIMIT = 4
       READ_ONLY_ATTRIBUTES = %w[id created_at updated_at]
 

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 require "administrate/fields/deferred"
 require "administrate/fields/string"
 
@@ -12,6 +12,32 @@ describe Administrate::Field::Deferred do
 
       expect(Administrate::Field::String).
         to have_received(:permitted_attribute).with(:foo)
+    end
+  end
+
+  describe "#searchable?" do
+    context "when given a `searchable` option" do
+      it "returns the value given" do
+        searchable_deferred = Administrate::Field::Deferred.
+          new(double(searchable?: false), searchable: true)
+        unsearchable_deferred = Administrate::Field::Deferred.
+          new(double(searchable?: true), searchable: false)
+
+        expect(searchable_deferred.searchable?).to eq(true)
+        expect(unsearchable_deferred.searchable?).to eq(false)
+      end
+    end
+
+    context "when not given a `searchable` option" do
+      it "falls back to the default of the deferred class" do
+        searchable_deferred = Administrate::Field::Deferred.
+          new(double(searchable?: true))
+        unsearchable_deferred = Administrate::Field::Deferred.
+          new(double(searchable?: false))
+
+        expect(searchable_deferred.searchable?).to eq(true)
+        expect(unsearchable_deferred.searchable?).to eq(false)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #178

## Problem:

If users have a database set up with unknown column types,
Administrate treats those columns as a string.
This can cause bugs when users try to search,
because the unknown database column might not support
the string search operator.

## Solution:

- Add a `searchable` option to all field types,
  which specifies whether it is one of
  the resource's plaintext search fields.
- For unknown db column types, give the field
  a default option of `searchable: false`.