### PR TITLE
[BUGFIX] existing date values were being cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#148] [FEATURE] Translation: French
 * [#147] [FEATURE] Translation: German
 * [#193] [BUGFIX] Don't assume that unrecognized db column types are searchable
+* [#194] [BUGFIX] Don't clear out datetime values in form fields
 * [#156] [COMPAT] Include missing `sass-rails` dependency in gemspec
 * [COMPAT] Update repository structure so Bundler can pull the gem from github.
   (e.g. `gem "administrate", github: "thoughtbot/administrate"`)

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara-webkit", ">= 1.2.0"
+  gem "poltergeist"
   gem "database_cleaner"
   gem "formulaic"
   gem "fuubar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,9 +84,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.7.1)
-      capybara (>= 2.3.0, < 2.6.0)
-      json
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -182,6 +180,11 @@ GEM
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
     pg (0.18.3)
+    poltergeist (1.7.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -294,6 +297,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -308,7 +314,6 @@ DEPENDENCIES
   awesome_print
   bundler-audit
   byebug
-  capybara-webkit (>= 1.2.0)
   coffee-rails (~> 4.1.0)
   database_cleaner
   delayed_job_active_record
@@ -325,6 +330,7 @@ DEPENDENCIES
   launchy
   newrelic_rpm
   pg
+  poltergeist
   pry-rails
   rack-timeout
   rails (= 4.2.2)

--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,3 +1,3 @@
 $(function () {
-  $(".datetimepicker").datetimepicker({ format: "DD/MM/YYYY hh:mm:ss A" });
+  $(".datetimepicker").datetimepicker({ format: "YYYY-MM-DD HH:mm:ss" });
 });

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -57,16 +57,6 @@ describe "order form" do
   end
 
   describe "datetime field" do
-    pending "correctly parses dates" do
-      order = create(:order)
-
-      visit edit_admin_order_path(order)
-      fill_in("Shipped at", with: "09/03/2015 7:18 AM")
-      click_on "Update Order"
-
-      expect(page).to have_content("Thu, Sep 3, 2015 at 07:18:00 AM")
-    end
-
     it "responds to the date/time picker date format", :js do
       order = create(:order)
 
@@ -75,6 +65,16 @@ describe "order form" do
       click_on "Update Order"
 
       expect(page).to have_content("Fri, Jan 2, 2015 at 03:04:05 AM")
+    end
+
+    it "populates and persists the existing value", :js do
+      time = Time.new(2015, 01, 02, 03, 04, 05)
+      order = create(:order, shipped_at: time)
+
+      visit edit_admin_order_path(order)
+      click_on "Update Order"
+
+      expect(order.reload.shipped_at).to eq(time)
     end
 
     def select_from_datepicker(time)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path("../../spec/example_app/config/environment", __FILE__)
 
 require "rspec/rails"
 require "shoulda/matchers"
+require "capybara/poltergeist"
 
 Dir[Rails.root.join("../../spec/support/**/*.rb")].each { |file| require file }
 
@@ -21,7 +22,5 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 end
 
-Capybara::Webkit.configure(&:block_unknown_urls)
-
 ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit
+Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
Fixes #135

## Problem:

When a user edits a resource
with a `Date`, `Time`, or `DateTime` attribute,
and the attribute already has a value,
the date-time picker clears out the value.

Unless the user re-fills the field,
the value will be reset and will cause an error
when they hit "submit".

## Solution:

Update the `datetimepicker` date format
to match the Rails default.