### PR TITLE
Fix menu style for the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Upcoming Release
 
+* [UI] Fix menu style for the sidebar
 * [#161] [FEATURE] Translation: Mandarin Chinese
 * [#142] [FEATURE] Translation: Brazilian Portuguese
 * [#171] [FEATURE] Translation: Polish

--- a/app/assets/stylesheets/administrate/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/_sidebar.scss
@@ -4,11 +4,15 @@
   overflow-y: auto;
   padding: 0 $base-spacing;
 
+  &__list li:first-child a {
+    padding-top: $base-spacing;
+  }
+
   &__link {
     @include fill-parent;
     color: $base-font-color;
     display: block;
-    padding-top: $base-spacing;
+    padding-bottom: $base-spacing;
     transition: color 0.05s linear;
 
     &--active {


### PR DESCRIPTION
Hello! 

In the sidebar for the last item in the list, there is no retreat from the bottom. Because of this, the last item in the list is sometimes not visible:

![before](https://cloud.githubusercontent.com/assets/700998/11033896/23d0729c-86f8-11e5-84b4-ee998bb930ed.png)

I modified styles to fix it:

![after](https://cloud.githubusercontent.com/assets/700998/11033897/23d6ab1c-86f8-11e5-8939-749108a86972.png)

