### PR TITLE
Fixed pagination styles if kaminari already used in Rails-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Upcoming Release
 
+* [UI] Fixed pagination styles if kaminari already used in Rails-app
 * [#161] [FEATURE] Translation: Mandarin Chinese
 * [#142] [FEATURE] Translation: Brazilian Portuguese
 * [#171] [FEATURE] Translation: Polish

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -52,4 +52,4 @@ It renders the `_table` partial to display details about the resources.
 
 <%= render "collection", collection_presenter: page, resources: resources %>
 
-<%= paginate resources %>
+<%= paginate resources, views_prefix: 'administrate' %>

--- a/app/views/administrate/kaminari/_first_page.html.erb
+++ b/app/views/administrate/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, :remote => remote %>
+</span>

--- a/app/views/administrate/kaminari/_gap.html.erb
+++ b/app/views/administrate/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/administrate/kaminari/_last_page.html.erb
+++ b/app/views/administrate/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, :remote => remote %>
+</span>

--- a/app/views/administrate/kaminari/_next_page.html.erb
+++ b/app/views/administrate/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote %>
+</span>

--- a/app/views/administrate/kaminari/_page.html.erb
+++ b/app/views/administrate/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil} %>
+</span>

--- a/app/views/administrate/kaminari/_paginator.html.erb
+++ b/app/views/administrate/kaminari/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/administrate/kaminari/_prev_page.html.erb
+++ b/app/views/administrate/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote %>
+</span>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -4,6 +4,8 @@ search:
     - "app/helpers"
     - "app/pages"
     - "app/views"
+  exclude:
+    - "app/views/administrate/kaminari"
 
 data:
   read:

--- a/gemfiles/.gitignore
+++ b/gemfiles/.gitignore
@@ -1,1 +1,3 @@
 *.gemfile.lock
+.bundle
+vendor


### PR DESCRIPTION
Hi.

If in the Rails-app already used gem `kaminari` and uses the changed views from `app/views/kaminari`, `administrate` incorrectly displays pagination:

![before](https://cloud.githubusercontent.com/assets/700998/11043922/1627f088-8730-11e5-9c35-cc4dc1cc1509.png)

After my changes:

![after](https://cloud.githubusercontent.com/assets/700998/11043921/15c24d32-8730-11e5-9d3f-a8ff190e910c.png)