### PR TITLE
Checkboxes should not appear to be centrally-aligned

### DIFF
--- a/app/assets/stylesheets/administrate/components/_form.scss
+++ b/app/assets/stylesheets/administrate/components/_form.scss
@@ -36,5 +36,6 @@
   [type="checkbox"],
   [type="radio"] {
     margin: $small-spacing 0 ($base-spacing + $form-input-padding);
+    width: auto;
   }
 }


### PR DESCRIPTION
## Problem

All form input elements have the following SCSS applied:

``` scss
  input,
  select,
  .selectize-control {
    @include span-columns(4 of 12);
  }

```
This causes check-boxes to appear in the middle of their columns, see the pic:

![screenshot from 2015-11-10 03-37-16](https://cloud.githubusercontent.com/assets/56636/11053982/1e661634-875e-11e5-931e-a42204dd122f.png)

## Solution

The world is just not ready for centrally-aligned check-boxes, so I have added `width: auto` to check-box inputs to ensure that they appear left aligned, see the next pic:

![screenshot from 2015-11-10 03-53-10](https://cloud.githubusercontent.com/assets/56636/11054036/b0db3364-875e-11e5-9613-47e1aa14734d.png)

I have read the contributing guidelines, and can't really think of a way to test this, besides visual inspection.