### PR TITLE
Allow content marked up with the .preserve-whitespace CSS class to wrap

### DIFF
--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -6,7 +6,7 @@
 }
 
 .preserve-whitespace {
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .attribute-data {


### PR DESCRIPTION
The `.preserve-whitespace` CSS class contains `white-space: pre;` which prevents text from wrapping, causing a horizontal scroll-bar anytime a Field::Text attribute contains more content than can fit on one line. See the screenshot below:

![image4214](https://cloud.githubusercontent.com/assets/56636/11081750/6912fda0-8817-11e5-95c9-275a09ae68ce.png)

This is fixed by using `white-space: pre-wrap;` as shown in the image below:

![image4225](https://cloud.githubusercontent.com/assets/56636/11081781/b3767c14-8817-11e5-9dc1-aa3366f13818.png)

Just a small thing.
