### PR TITLE
Prevent white-space from appearing above header button when title is unusually long

### DIFF
--- a/app/assets/stylesheets/administrate/components/_header.scss
+++ b/app/assets/stylesheets/administrate/components/_header.scss
@@ -1,5 +1,5 @@
 .header {
-  align-items: flex-end;
+  align-items: baseline;
   display: flex;
   justify-content: space-between;
   margin-bottom: $base-spacing * 2;


### PR DESCRIPTION
When I visit the edit page for a resource with a long title I notice some unsightly white-space above the show page link that appears next to the h1 tag. See image:

![flex-end](https://cloud.githubusercontent.com/assets/56636/11083775/35369550-882b-11e5-9572-41e2243d77a7.png)

This whitespace is caused by the following CSS: 

``` css
.header {
  align-items: flex-end;
}
```

To get rid of this white-space we can change flex-end to flex-start or baseline, see below:

![baseline](https://cloud.githubusercontent.com/assets/56636/11083941/ef8fea7c-882c-11e5-8ed6-381a20af1d59.png)

I will understand if you prefer flex-start over baseline.