### PR TITLE
Sets the css class name for forms

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -14,7 +14,7 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([Administrate::NAMESPACE, page.resource], class: "form") do |f| %>
+<%= form_for([Administrate::NAMESPACE, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe "edit form" do
+  it "has the correct css class_name" do
+    customer = create(:customer)
+
+    visit edit_admin_customer_path(customer)
+
+    expect(page).to have_css("form.form")
+  end
+end


### PR DESCRIPTION
Problem:
The syntax for setting a css class 'form' on an generated form was
wrong. This was pointed out in #212.

Solution:
Uses the correct syntax with `html: { class: "form" }` to set the css
class name.

Fixes #212