### PR TITLE
Fixes the paths for generated views

### DIFF
--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -21,7 +21,11 @@ module Administrate
     end
 
     def resource_path
-      args.first.try(:underscore).try(:pluralize) || "application"
+      if args.none? || args.first == "application"
+        "application"
+      else
+        args.first.underscore.pluralize
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #202.
 
## Problem:

The documentation correctly states that view generated via `rails g
administrate:views` should live under
`app/views/administrate/application/`. The generatator puts them under
`app/views/admin/applications/` though.

## Solution:

The methods that create the paths need to be adapted.

## Nota bene:

While running the tests, the first arg for the generator is empty. When
the generator is run inside a project, the first arg is `application`.
This leads to the view paths having `applications` instead of
`application`. This commit fixes this as well.