### PR TITLE
Add uglifier to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,5 @@ end
 group :staging, :production do
   gem "rack-timeout"
   gem "rails_stdout_logging"
+  gem "uglifier"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,9 @@ GEM
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uglifier (2.7.2)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -306,6 +309,7 @@ DEPENDENCIES
   rspec-rails (~> 3.1.0)
   shoulda-matchers (~> 2.8.0)
   timecop
+  uglifier
   unicorn
   web-console (>= 2.1.3)
   webmock


### PR DESCRIPTION
## Problem:

The demo app could not deploy on Heroku
because of a missing dependency on uglifier.

## Solution:

Add uglifier to the `production` group in the Gemfile.