### PR TITLE
Release Administrate version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@
 * `[BUGFIX]`: Fixes a bug with a non-breaking change.
 * `[COMPAT]`: Compatibility improvements - changes to make Administrate more
   compatible with different dependency versions.
+* `[I18n]`: Internationalization. Changes to translations or localizations.
 * `[DOC]`: Documentation changes. No changes to the library's behavior.
 
 ## Changes
 
 ### Upcoming Release
+
+### 0.1.1 (November 12, 2015)
 
 * [#191] [CHANGE] Improve API for specifying how resources are displayed
   across the dashboard.
@@ -25,29 +28,29 @@
     may need to update them to take advantage of the new API:
     * HasOne
     * HasMany
-    * PolyMorphic
+    * Polymorphic
     * BelongsTo
-* [#223] [FEATURE] Translation: Vietnamese
-* [#161] [FEATURE] Translation: Mandarin Chinese
-* [#196] [FEATURE] Translation: Taiwanese Mandarin
-* [#142] [FEATURE] Translation: Brazilian Portuguese
-* [#171] [FEATURE] Translation: Polish
-* [#153] [FEATURE] Translation: Russian
-* [#148] [FEATURE] Translation: French
-* [#147] [FEATURE] Translation: German
-* [#193] [BUGFIX] Don't assume that unrecognized db column types are searchable
+* [#126] [UI] Preserve whitespace when rendering text fields
 * [#194] [BUGFIX] Don't clear out datetime values in form fields
+* [#193] [BUGFIX] Don't assume that unrecognized db column types are searchable
+* [#124] [BUGFIX] Better detection of application models
 * [#156] [COMPAT] Include missing `sass-rails` dependency in gemspec
 * [#174] [COMPAT] Make several missing dependencies explicit.
-* [COMPAT] Update repository structure so Bundler can pull the gem from github.
+* [#144] [COMPAT] Update repository structure so Bundler can pull the gem from github.
   (e.g. `gem "administrate", github: "thoughtbot/administrate"`)
-* [COMPAT] Use ANSI SQL standards for case-insensitive search
-* [DOC] Add Rubygems version badge to README
-* [#124] [BUGFIX] Better detection of application models
-* [DOC] Add CircleCI badge to README
-* [DOC] Add CodeClimate badge to README
-* [UI] Preserve whitespace when rendering text fields
-* [#154] [FEATURE] Add Spanish translation for i18n
+* [#166] [COMPAT] Use ANSI SQL standards for case-insensitive search
+* [#223] [I18n] Vietnamese
+* [#161] [I18n] Mandarin Chinese
+* [#196] [I18n] Taiwanese Mandarin
+* [#142] [I18n] Brazilian Portuguese
+* [#171] [I18n] Polish
+* [#153] [I18n] Russian
+* [#148] [I18n] French
+* [#147] [I18n] German
+* [#154] [I18n] Spanish
+* [#120] [DOC] Add Rubygems version badge to README
+* [#165] [DOC] Add CircleCI badge to README
+* [#119] [DOC] Add CodeClimate badge to README
 
 ### 0.1.0 (October 30, 2015)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    administrate (0.1.0)
+    administrate (0.1.1)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.5)
       inline_svg (~> 0.6)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 A Rails engine that helps you put together a super-flexible admin dashboard.
 [Try the demo][demo].
 
+> Note: Administrate is still pre-1.0,
+> and there may be occasional breaking changes to the API.
+
 ![administrate](https://images.thoughtbot.com/announcing-administrate/DdP2CQfnSE23PI8AAnDc_Administrate.png)
 
 ## Guiding Principles
@@ -33,7 +36,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate"
+gem "administrate", "~> 0.1.1"
 ```
 
 Re-bundle, then run the installer:

--- a/lib/administrate/version.rb
+++ b/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## This PR:

- Update gem version
- Update README with recommended optimistic versioning for bundler
- Update README with warning about Administrate's pre-1.0 status
- Update CHANGELOG to fill in missing PR references
- sort CHANGELOG entries according to change type

## Changes:

* [#191] [CHANGE] Improve API for specifying how resources are displayed
  across the dashboard.
  * Models are now displayed with a sensible default - (e.g. "User #2")
  * Users can define `ModelDashboard#display_resource(resource)` for custom
    display behavior
  * Users who have generated views for the following field types
    may need to update them to take advantage of the new API:
    * HasOne
    * HasMany
    * Polymorphic
    * BelongsTo
* [#126] [UI] Preserve whitespace when rendering text fields
* [#194] [BUGFIX] Don't clear out datetime values in form fields
* [#193] [BUGFIX] Don't assume that unrecognized db column types are searchable
* [#124] [BUGFIX] Better detection of application models
* [#156] [COMPAT] Include missing `sass-rails` dependency in gemspec
* [#174] [COMPAT] Make several missing dependencies explicit.
* [#144] [COMPAT] Update repository structure so Bundler can pull the gem from github.
  (e.g. `gem "administrate", github: "thoughtbot/administrate"`)
* [#166] [COMPAT] Use ANSI SQL standards for case-insensitive search
* [#223] [I18n] Vietnamese
* [#161] [I18n] Mandarin Chinese
* [#196] [I18n] Taiwanese Mandarin
* [#142] [I18n] Brazilian Portuguese
* [#171] [I18n] Polish
* [#153] [I18n] Russian
* [#148] [I18n] French
* [#147] [I18n] German
* [#154] [I18n] Spanish
* [#120] [DOC] Add Rubygems version badge to README
* [#165] [DOC] Add CircleCI badge to README
* [#119] [DOC] Add CodeClimate badge to README