### PR TITLE
Fix BelongsTo form partial select field not setting selected attribute

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -18,5 +18,5 @@ that displays all possible records to associate with.
 
 <%= f.label field.permitted_attribute %>
 <%= f.select(field.permitted_attribute) do %>
-  <%= options_for_select(field.associated_resource_options) %>
+  <%= options_for_select(field.associated_resource_options, field.data ? field.data.id : nil) %>
 <% end %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -22,5 +22,5 @@ and is augmented with [Selectize].
 <%= f.label field.attribute_key %>
 
 <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>
-  <%= options_for_select(field.associated_resource_options) %>
+  <%= options_for_select(field.associated_resource_options, field.data ? field.data.map(&:id) : nil) %>
 <% end %>

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -19,6 +19,16 @@ describe "order form" do
     )
   end
 
+  describe "belongs_to relationships" do
+    it "has stored value selected" do
+      create(:customer)
+      order = create(:order)
+
+      visit edit_admin_order_path(order)
+      expect(find_field("Customer").value).to eq(order.customer.id.to_s)
+    end
+  end
+
   describe "has_many relationships" do
     it "can select multiple options" do
       order = create(:order)

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -60,6 +60,16 @@ describe "order form" do
       )
     end
 
+    it "has stored values selected" do
+      order = create(:order)
+      create_list(:line_item, 3, order: order)
+
+      visit edit_admin_order_path(order)
+      expect(find("#order_line_item_ids").value).to eq(
+        order.line_items.pluck(:id).map(&:to_s)
+      )
+    end
+
     def find_option(associated_model, field_id)
       field = find("#order_" + field_id)
       field.find("option", text: displayed(associated_model))


### PR DESCRIPTION
The selected attribute on select dropdown options is not currently being set, resulting in users having to manually re-select the already-selected option on editing a model. (What a mouthful! I could probably phrase this better, but it's 4am.)

Attempting a fix for this.