### PR TITLE
Fixes issue #241

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -18,5 +18,5 @@ that displays all possible records to associate with.
 
 <%= f.label field.permitted_attribute %>
 <%= f.select(field.permitted_attribute) do %>
-  <%= options_for_select(field.associated_resource_options) %>
+  <%= options_for_select(field.associated_resource_options, field.data.try(:id)) %>
 <% end %>

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -20,14 +20,26 @@ describe "order form" do
   end
 
   describe "belongs_to relationships" do 
-    it 'uses the stored value as the selected value' do 
+    it "uses the stored value as the selected value" do
       order = create(:order)
       customer = order.customer
 
       visit edit_admin_order_path(order)
-      expect(page).to have_select('Customer', selected: customer.name)
+      expect(page).to have_select("Customer", selected: customer.name)
     end
+
+    it "pre-fills belongs_to select boxes" do
+      create(:customer)
+      order = create(:order)
+
+      visit edit_admin_order_path(order)
+      value = find("select[name='order[customer_id]']").value
+
+      expect(value).to eq(order.customer_id.to_s)
+    end 
   end
+
+
 
   describe "has_many relationships" do
     it "can select multiple options" do

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -31,15 +31,12 @@ describe "order form" do
     it "pre-fills belongs_to select boxes" do
       create(:customer)
       order = create(:order)
-
+      
       visit edit_admin_order_path(order)
       value = find("select[name='order[customer_id]']").value
-
       expect(value).to eq(order.customer_id.to_s)
-    end 
+    end
   end
-
-
 
   describe "has_many relationships" do
     it "can select multiple options" do

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -19,6 +19,16 @@ describe "order form" do
     )
   end
 
+  describe "belongs_to relationships" do 
+    it 'uses the stored value as the selected value' do 
+      order = create(:order)
+      customer = order.customer
+
+      visit edit_admin_order_path(order)
+      expect(page).to have_select('Customer', selected: customer.name)
+    end
+  end
+
   describe "has_many relationships" do
     it "can select multiple options" do
       order = create(:order)

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -19,7 +19,7 @@ describe "order form" do
     )
   end
 
-  describe "belongs_to relationships" do 
+  describe "belongs_to relationships" do
     it "uses the stored value as the selected value" do
       order = create(:order)
       customer = order.customer
@@ -31,7 +31,6 @@ describe "order form" do
     it "pre-fills belongs_to select boxes" do
       create(:customer)
       order = create(:order)
-      
       visit edit_admin_order_path(order)
       value = find("select[name='order[customer_id]']").value
       expect(value).to eq(order.customer_id.to_s)


### PR DESCRIPTION
Fixes #241

## Problem:

The selected value for a belongs to field was not shown to the user when editing a resource.

If a belongs to field has a selected value it will now be shown when the user goes to the edit page to make changes.

## Solution:

use the selected field provided by `options_for_select`

 ` options_for_select(field.associated_resource_options, field.data.try(:id))`