### PR TITLE
Fix up "Show" label on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   `ATTRIBUTE_TYPES`
 * [#231] [UI] Fix layout issue on show page where a long label next to an empty
   value would cause following fields on the page to be mis-aligned.
+* [#243] [BUGFIX] Fix up a "Show" button on the edit page that was not using the
+  `display_resource` method.
 * [#248] [BUGFIX] Improve polymorphic relationship's dashboard class detection.
 * [#247] [BUGFIX] Populate `has_many` and `belongs_to` select boxes
   with the current value of the relationship.

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -19,7 +19,11 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
 <header class="header">
   <h1 class="header-heading"><%= content_for(:title) %></h1>
-  <%= link_to "Show #{page.resource}", [Administrate::NAMESPACE, page.resource], class: "button" %>
+  <%= link_to(
+    "Show #{page.page_title}",
+    [Administrate::NAMESPACE, page.resource],
+    class: "button",
+  ) %>
 </header>
 
 <%= render "form", page: page %>

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -9,6 +9,14 @@ describe "customer edit page" do
     expect(page).to have_header("Edit #{customer.name}")
   end
 
+  it "has button to view customer details" do
+    customer = create(:customer)
+
+    visit edit_admin_customer_path(customer)
+
+    expect(page).to have_link("Show #{displayed(customer)}")
+  end
+
   it "has forms for the customer's attributes" do
     customer = create(:customer)
 


### PR DESCRIPTION
## Problem:

In fcd3fc7, we moved logic for displaying resources into dashboard
classes. Unfortunately, we missed migrating the edit page's "Show" link
over to use the new logic. It is currently displaying the resource using
Ruby's built-in `to_s` method.

## Solution:

Migrate the button to the new method of displaying resources.