### PR TITLE
Populate has_many and belongs_to in edit view

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -18,5 +18,5 @@ that displays all possible records to associate with.
 
 <%= f.label field.permitted_attribute %>
 <%= f.select(field.permitted_attribute) do %>
-  <%= options_for_select(field.associated_resource_options) %>
+  <%= options_for_select(field.associated_resource_options, field.selected_option) %>
 <% end %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -22,5 +22,5 @@ and is augmented with [Selectize].
 <%= f.label field.attribute_key %>
 
 <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>
-  <%= options_for_select(field.associated_resource_options) %>
+  <%= options_for_select(field.associated_resource_options, field.selected_options) %>
 <% end %>

--- a/lib/administrate/fields/belongs_to.rb
+++ b/lib/administrate/fields/belongs_to.rb
@@ -17,6 +17,10 @@ module Administrate
         end
       end
 
+      def selected_option
+        data && data.id
+      end
+
       private
 
       def candidate_resources

--- a/lib/administrate/fields/has_many.rb
+++ b/lib/administrate/fields/has_many.rb
@@ -24,6 +24,10 @@ module Administrate
         end
       end
 
+      def selected_options
+        data && data.map(&:id)
+      end
+
       def limit
         options.fetch(:limit, DEFAULT_LIMIT)
       end

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -19,6 +19,17 @@ describe "order form" do
     )
   end
 
+  describe "belongs_to relationships" do
+    it "has stored value selected" do
+      create(:customer)
+      order = create(:order)
+
+      visit edit_admin_order_path(order)
+      expected = order.customer.id.to_s
+      expect(find_field("Customer").value).to eq expected
+    end
+  end
+
   describe "has_many relationships" do
     it "can select multiple options" do
       order = create(:order)
@@ -48,6 +59,16 @@ describe "order form" do
       expect(page).to have_flash(
         t("administrate.controller.update.success", resource: "Order")
       )
+    end
+
+    it "has stored values selected" do
+      order = create(:order)
+      create_list(:line_item, 3, order: order)
+
+      visit edit_admin_order_path(order)
+
+      expected = order.line_items.pluck(:id).map(&:to_s)
+      expect(find("#order_line_item_ids").value).to eq expected
     end
 
     def find_option(associated_model, field_id)


### PR DESCRIPTION
Fix for #244.

I found out while implementing this PR that #239 is a fix for the same issue, but it puts the logic in the view. I put it in the field class.

I reused @weimeng's tests since they work well. Thanks.