### PR TITLE
Select the correct dashboard for polymorphic fields

### DIFF
--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    polymorphic_path([:admin, field.data])
+    [Administrate::NAMESPACE, field.data]
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [:admin, field.data],
+    [Administrate::NAMESPACE, field.data],
   ) %>
 <% end %>

--- a/lib/administrate/fields/polymorphic.rb
+++ b/lib/administrate/fields/polymorphic.rb
@@ -3,6 +3,11 @@ require_relative "associative"
 module Administrate
   module Field
     class Polymorphic < Associative
+      protected
+
+      def associated_dashboard
+        "#{data.class.name}Dashboard".constantize.new
+      end
     end
   end
 end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -1,4 +1,5 @@
 require "administrate/fields/polymorphic"
+require "support/constant_helpers"
 require "support/field_matchers"
 
 describe Administrate::Field::Polymorphic do
@@ -16,4 +17,23 @@ describe Administrate::Field::Polymorphic do
   end
 
   it { should_permit_param(:foo, for_attribute: :foo) }
+
+  describe "#display_associated_resource" do
+    it "displays through the dashboard based on the polymorphic class name" do
+      begin
+        Thing = Class.new
+        ThingDashboard = Class.new do
+          def display_resource(*)
+            :success
+          end
+        end
+
+        field = Administrate::Field::Polymorphic.new(:foo, Thing.new, :show)
+        display = field.display_associated_resource
+        expect(display).to eq :success
+      ensure
+        remove_constants :Thing, :ThingDashboard
+      end
+    end
+  end
 end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -30,6 +30,7 @@ describe Administrate::Field::Polymorphic do
 
         field = Administrate::Field::Polymorphic.new(:foo, Thing.new, :show)
         display = field.display_associated_resource
+
         expect(display).to eq :success
       ensure
         remove_constants :Thing, :ThingDashboard


### PR DESCRIPTION
For a polymorphic relation, the correct dashboard should be taken from the class of the associated object if it exists, not from the name of the attribute like in the base class associative.

This also updates the default polymorphic views to use the configurable namespace.

Fixes #245