### PR TITLE
Display helpful message if attribute_name missing

### DIFF
--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -18,6 +18,18 @@ module Administrate
       self.class::ATTRIBUTE_TYPES
     end
 
+    def attribute_type_for(attribute_name)
+      attribute_types.fetch(attribute_name) do
+        fail "Attribute #{attribute_name} not in #{self.class}::ATTRIBUTE_TYPES"
+      end
+    end
+
+    def attribute_types_for(*attribute_names)
+      attribute_names.each_with_object({}) do |name, attributes|
+        attributes[name] = attribute_type_for(name)
+      end
+    end
+
     def form_attributes
       self.class::FORM_ATTRIBUTES
     end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -24,7 +24,7 @@ module Administrate
       end
     end
 
-    def attribute_types_for(*attribute_names)
+    def attribute_types_for(attribute_names)
       attribute_names.each_with_object({}) do |name, attributes|
         attributes[name] = attribute_type_for(name)
       end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -20,7 +20,7 @@ module Administrate
 
     def attribute_type_for(attribute_name)
       attribute_types.fetch(attribute_name) do
-        fail "Attribute #{attribute_name} could not be found in #{self.class}::ATTRIBUTE_TYPES"
+        fail attribute_not_found_message(attribute_name)
       end
     end
 
@@ -50,6 +50,12 @@ module Administrate
 
     def display_resource(resource)
       "#{resource.class} ##{resource.id}"
+    end
+
+    private
+
+    def attribute_not_found_message(attr)
+      "Attribute #{attr} could not be found in #{self.class}::ATTRIBUTE_TYPES"
     end
   end
 end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -20,7 +20,7 @@ module Administrate
 
     def attribute_type_for(attribute_name)
       attribute_types.fetch(attribute_name) do
-        fail "Attribute #{attribute_name} not in #{self.class}::ATTRIBUTE_TYPES"
+        fail "Attribute #{attribute_name} could not be found in #{self.class}::ATTRIBUTE_TYPES"
       end
     end
 

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -15,14 +15,7 @@ module Administrate
 
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)
-
-        field = dashboard.attribute_types.fetch(attribute_name) do
-          fail <<-ERROR_MESSAGE.strip_heredoc
-          Attribute :#{attribute_name} not found in #{dashboard.class}.
-          Perhaps you misspelled it or it is missing in
-          #{dashboard.class}::ATTRIBUTE_TYPES?
-          ERROR_MESSAGE
-        end
+        field = dashboard.attribute_type_for(attribute_name)
         field.new(attribute_name, value, page)
       end
 

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -19,6 +19,8 @@ module Administrate
         dashboard.
           attribute_types[attribute_name].
           new(attribute_name, value, page)
+      rescue NoMethodError
+        raise NoMethodError.new(error_message(attribute_name), :new)
       end
 
       def get_attribute_value(resource, attribute_name)
@@ -28,6 +30,15 @@ module Administrate
       end
 
       attr_reader :dashboard, :options
+
+      private
+
+      def error_message(attribute_name)
+        <<ERROR_MESSAGE
+Attribute `:#{attribute_name}' not found in dashboard #{dashboard.class}.
+Perhaps you misspelled it or it is missing in `#{dashboard.class}::ATTRIBUTE_TYPES'?
+ERROR_MESSAGE
+      end
     end
   end
 end

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -16,11 +16,14 @@ module Administrate
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)
 
-        dashboard.
-          attribute_types[attribute_name].
-          new(attribute_name, value, page)
-      rescue NoMethodError
-        raise NoMethodError.new(error_message(attribute_name), :new)
+        field = dashboard.attribute_types.fetch(attribute_name) do
+          fail <<-ERROR_MESSAGE.strip_heredoc
+          Attribute :#{attribute_name} not found in #{dashboard.class}.
+          Perhaps you misspelled it or it is missing in
+          #{dashboard.class}::ATTRIBUTE_TYPES?
+          ERROR_MESSAGE
+        end
+        field.new(attribute_name, value, page)
       end
 
       def get_attribute_value(resource, attribute_name)
@@ -30,15 +33,6 @@ module Administrate
       end
 
       attr_reader :dashboard, :options
-
-      private
-
-      def error_message(attribute_name)
-        <<ERROR_MESSAGE
-Attribute `:#{attribute_name}' not found in dashboard #{dashboard.class}.
-Perhaps you misspelled it or it is missing in `#{dashboard.class}::ATTRIBUTE_TYPES'?
-ERROR_MESSAGE
-      end
     end
   end
 end

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -14,7 +14,7 @@ module Administrate
       end
 
       def attribute_types
-        dashboard.attribute_types.slice(*attribute_names)
+        dashboard.attribute_types_for(*attribute_names)
       end
 
       def ordered_html_class(attr)

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -14,7 +14,7 @@ module Administrate
       end
 
       def attribute_types
-        dashboard.attribute_types_for(*attribute_names)
+        dashboard.attribute_types_for(attribute_names)
       end
 
       def ordered_html_class(attr)

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -24,6 +24,45 @@ describe CustomerDashboard do
     end
   end
 
+  describe "#attribute_type_for" do
+    context "for an existing attribute" do
+      it "returns the attribute field" do
+        dashboard = CustomerDashboard.new
+        field = dashboard.attribute_type_for(:name)
+        expect(field).to eq Administrate::Field::String
+      end
+    end
+
+    context "for a non-existent attribute" do
+      it "raises an exception" do
+        dashboard = CustomerDashboard.new
+        expect { dashboard.attribute_type_for(:foo) }.
+          to raise_error /Attribute foo not in CustomerDashboard/
+      end
+    end
+  end
+
+  describe "#attribute_types_for" do
+    context "for existing attributes" do
+      it "returns the attribute fields" do
+        dashboard = CustomerDashboard.new
+        fields = dashboard.attribute_types_for(:name, :email)
+        expect(fields).to match(
+          name: Administrate::Field::String,
+          email: Administrate::Field::Email,
+        )
+      end
+    end
+
+    context "for one non-existent attribute" do
+      it "raises an exception" do
+        dashboard = CustomerDashboard.new
+        expect { dashboard.attribute_types_for(:name, :foo) }.
+          to raise_error /Attribute foo not in CustomerDashboard/
+      end
+    end
+  end
+
   describe "#display_resource" do
     it "returns the customer's name" do
       customer = double(name: "Example Customer")

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -50,7 +50,7 @@ describe CustomerDashboard do
     context "for existing attributes" do
       it "returns the attribute fields" do
         dashboard = CustomerDashboard.new
-        fields = dashboard.attribute_types_for(:name, :email)
+        fields = dashboard.attribute_types_for([:name, :email])
         expect(fields).to match(
           name: Administrate::Field::String,
           email: Administrate::Field::Email,
@@ -61,7 +61,7 @@ describe CustomerDashboard do
     context "for one non-existent attribute" do
       it "raises an exception" do
         dashboard = CustomerDashboard.new
-        expect { dashboard.attribute_types_for(:name, :foo) }.
+        expect { dashboard.attribute_types_for([:name, :foo]) }.
           to raise_error missing_attribute_message("foo", "CustomerDashboard")
       end
     end

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -24,6 +24,10 @@ describe CustomerDashboard do
     end
   end
 
+  def missing_attribute_message(attribute, dashboard_class)
+    "Attribute #{attribute} could not be found in #{dashboard_class}::ATTRIBUTE_TYPES"
+  end
+
   describe "#attribute_type_for" do
     context "for an existing attribute" do
       it "returns the attribute field" do
@@ -37,7 +41,7 @@ describe CustomerDashboard do
       it "raises an exception" do
         dashboard = CustomerDashboard.new
         expect { dashboard.attribute_type_for(:foo) }.
-          to raise_error /Attribute foo not in CustomerDashboard/
+          to raise_error missing_attribute_message("foo", "CustomerDashboard")
       end
     end
   end
@@ -58,7 +62,7 @@ describe CustomerDashboard do
       it "raises an exception" do
         dashboard = CustomerDashboard.new
         expect { dashboard.attribute_types_for(:name, :foo) }.
-          to raise_error /Attribute foo not in CustomerDashboard/
+          to raise_error missing_attribute_message("foo", "CustomerDashboard")
       end
     end
   end


### PR DESCRIPTION
# Problem
If a field in `COLLECTION_ATTRIBUTES` has no key in `ATTRIBUTE_TYPES` either because I misspelled it or I forget to add it to `ATTRIBUTE_TYPES` I will get a undefined method new for `nil:NilClass` in `Page::Base`

# Solution
Don't access hash values directly but use `fetch`. If the attribute is not found the block raises an error with a helpful error message.

Closes #246