### PR TITLE
Explicitly set ruby version for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+machine:
+  ruby:
+    version: 2.2.3
 dependencies:
   post:
     - bundle exec appraisal install


### PR DESCRIPTION
## Problem:

Since we updated to Ruby 2.2.3 in 079c17f,
CircleCI hasn't been able to detect the proper ruby version
and builds have been failing as a result.

## Solution:

Explicitly set the ruby version to 2.2.3 in the circle.yml config file.