### PR TITLE
Don't generate dashboards for non-constant models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   `ATTRIBUTE_TYPES`
 * [#231] [UI] Fix layout issue on show page where a long label next to an empty
   value would cause following fields on the page to be mis-aligned.
+* [#259] [BUGFIX] Make installation generator more robust
+  by ignoring dynamically generated, unnamed models
 * [#243] [BUGFIX] Fix up a "Show" button on the edit page that was not using the
   `display_resource` method.
 * [#248] [BUGFIX] Improve polymorphic relationship's dashboard class detection.

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -40,6 +40,10 @@ module Administrate
           puts "WARNING: Unable to generate a dashboard for #{invalid_model}."
           puts "         It is not connected to a database table."
         end
+
+        unnamed_constants.each do |invalid_model|
+          puts "NOTICE: Skipping dynamically generated model #{invalid_model}."
+        end
       end
 
       private
@@ -63,7 +67,7 @@ module Administrate
       end
 
       def invalid_database_models
-        models_without_tables + namespaced_models
+        models_without_tables + namespaced_models + unnamed_constants
       end
 
       def models_without_tables
@@ -72,6 +76,10 @@ module Administrate
 
       def namespaced_models
         database_models.select { |model| model.to_s.include?("::") }
+      end
+
+      def unnamed_constants
+        ActiveRecord::Base.descendants.reject { |d| d.name == d.to_s }
       end
 
       def dashboard_routes

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -67,6 +67,21 @@ describe Administrate::Generators::InstallGenerator, :generator do
         remove_constants :ModelWithoutDBTable
       end
     end
+
+    it "skips models that don't have a named constant" do
+      stub_generator_dependencies
+      ActiveRecord::Schema.define { create_table(:foos) }
+      _unnamed_model = Class.new(ActiveRecord::Base) do
+        def self.table_name
+          :foos
+        end
+      end
+
+      run_generator
+
+      manifest = file("app/dashboards/dashboard_manifest.rb")
+      expect(manifest).to have_correct_syntax
+    end
   end
 
   describe "config/routes.rb" do


### PR DESCRIPTION
Fixes #145 and #219

## Problem:

When the same `has_and_belongs_to_many` relationship is defined twice,
Rails generates an unnamed subclass of `ActiveRecord::Base`.
This is probably a bug in Rails.

The unnamed subclass shows up like this:

```ruby
> ActiveRecord::Base.descendants.last
 #<Class:0x007fddea1bdf08> (call '#<Class:0x007fddea1bdf08>.connection' to establish a connection)
```

When the install generator tries to populate the `DashboardManifest`
with all of the `ActiveRecord` models,
it trips up on unnamed models,
and generates a manifest with invalid syntax.

This results in a `NameError` for the user when they run the
`administrate:install` generator:

```
/gems/administrate-0.1.0/lib/generators/administrate/dashboard/dashboard_generator.rb:87:
in `const_get': wrong constant name #<class:0x007fcf52bfe248> (NameError)
```

This error most often pops up in applications
that are using the `spring` gem.

## Solution:

- Add a test case that reproduces the error
  by defining duplicate `has_many` associations.
- In the install generator, ignore any models that are not constants.
  We determine constants by checking that the model's `#name`
  matches its `#to_s`.
- Print a warning for the ignored models.