### PR TITLE
Add a generator for the admin dashboard layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Upcoming Release
 
+* [#269] [FEATURE] Add a generator for copying default layout files
 * [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
 * [#297] [I18n] Add Italian translations
 * [#307] [I18n] Fix German grammatical errors

--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -1,0 +1,22 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    module Views
+      class LayoutGenerator < Administrate::ViewGenerator
+        source_root template_source_path
+
+        def copy_template
+          copy_file(
+            "../../layouts/administrate/application.html.erb",
+            "app/views/layouts/admin/application.html.erb",
+          )
+
+          copy_resource_template("_sidebar")
+          copy_resource_template("_javascript")
+          copy_resource_template("_flashes")
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "generators/administrate/views/layout_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Views::LayoutGenerator, :generator do
+  describe "administrate:views:layout" do
+    it "copies the layout template into the `admin/application` namespace" do
+      expected_contents = File.read(
+        "app/views/layouts/administrate/application.html.erb",
+      )
+
+      run_generator []
+      contents = File.read(file("app/views/layouts/admin/application.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the flashes partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_flashes")
+      generated_file = file("app/views/admin/application/_flashes.html.erb")
+
+      run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the sidebar partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_sidebar")
+      generated_file = file("app/views/admin/application/_sidebar.html.erb")
+
+      run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the javascript partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_javascript")
+      generated_file = file("app/views/admin/application/_javascript.html.erb")
+
+      run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
+end


### PR DESCRIPTION
Closes #181, #258 

## Problem:

Many developers need to customize the layout of their admin dashboards.
In order to do so now, they must manually copy a template
from Administrate's source into their host application.

## Solution:

Add a simple generator that copies over the relevant files
for users to customize the layout.