### PR TITLE
Save apologies for tragedies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   with the current value of the relationship.
 * [#217] [I18n] Dutch
 * [#263] [I18n] Swedish
+* [#270] [I18n] Don't apologize about missing relationship support.
 * [#237] [I18n] Fix broken paths for several I18n files (de, es, fr, pt-BR, vi).
 
 ### 0.1.1 (November 12, 2015)

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -18,6 +18,6 @@ de:
         more: "%{count} von %{total_count}"
         none: Keine
       polymorphic:
-        not_supported: Polymorphe Beziehungen werden noch nicht unterstützt. Sorry!
+        not_supported: Polymorphe Beziehungen werden nicht unterstützt.
       has_one:
-        not_supported: HasOne-beziehungen werden noch nicht unterstützt. Sorry!
+        not_supported: HasOne-beziehungen werden nicht unterstützt.

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -18,6 +18,6 @@ en:
         more: Showing %{count} of %{total_count}
         none: None
       polymorphic:
-        not_supported: Polymorphic relationship forms are not supported yet. Sorry!
+        not_supported: Polymorphic relationship forms are not supported.
       has_one:
-        not_supported: HasOne relationship forms are not supported yet. Sorry!
+        not_supported: HasOne relationship forms are not supported.

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -18,6 +18,6 @@ es:
         more: Mostrando %{count} de %{total_count}
         none: Ninguno
       polymorphic:
-        not_supported: Los formularios con relaciones polimórficas no están soportados todavía. ¡Perdón!
+        not_supported: Los formularios con relaciones polimórficas no están soportados.
       has_one:
-        not_supported: Los formularios con relaciones HasOne no están soportados todavía. ¡Perdón!
+        not_supported: Los formularios con relaciones HasOne no están soportados.

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -18,6 +18,6 @@ fr:
         more: "%{count} sur %{total_count}"
         none: Aucun
       polymorphic:
-        not_supported: Les relations polymorphiques dans les formulaires ne sont pas encore supportées. Désolé !
+        not_supported: Les relations polymorphiques dans les formulaires ne sont pas supportées.
       has_one:
-        not_supported: Les relations HasOne dans les formulaires ne sont pas encore supportées. Désolé !
+        not_supported: Les relations HasOne dans les formulaires ne sont pas supportées.

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -18,6 +18,6 @@ nl:
         more: Resultaat %{count} van %{total_count}
         none: Geen
       polymorphic:
-        not_supported: Polymorphische relaties formulieren worden nog niet ondersteund. Sorry!
+        not_supported: Polymorphische relaties formulieren worden niet ondersteund.
       has_one:
-        not_supported: HasOne relaties formulieren worden nog niet ondersteund. Sorry!
+        not_supported: HasOne relaties formulieren worden niet ondersteund.

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -18,6 +18,6 @@ pl:
         more: Wyświetlanie %{count} z %{total_count}
         none: Brak
       polymorphic:
-        not_supported: Relacje polimorficzne nie są jeszcze obsługiwane. Przepraszamy!
+        not_supported: Relacje polimorficzne nie są obsługiwane.
       has_one:
-        not_supported: Relacje jeden-do-jednego nie są jeszcze obsługiwane. Przepraszamy!
+        not_supported: Relacje jeden-do-jednego nie są obsługiwane.

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -19,6 +19,6 @@ pt-BR:
         more: "Exibindo %{count} de %{total_count}"
         none: Nenhum
       polymorphic:
-        not_supported: Relações polimórmficas nos formulários não são suportadas ainda. Desculpe!
+        not_supported: Relações polimórmficas nos formulários não são suportadas.
       has_one:
-        not_supported: Relações um para muitos nos formulários não são suportadas ainda. Desculpe!
+        not_supported: Relações um para muitos nos formulários não são suportadas.

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -18,6 +18,6 @@ ru:
         more: "%{count} из %{total_count}"
         none: Нет
       polymorphic:
-        not_supported: Полиморфные отношения в формах не поддерживаются. Извините!
+        not_supported: Полиморфные отношения в формах не поддерживаются.
       has_one:
-        not_supported: HasOne отношения в формах не поддерживаются. Извините!
+        not_supported: HasOne отношения в формах не поддерживаются.

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -18,6 +18,6 @@ sv:
         more: "%{count} av %{total_count}"
         none: Inga
       polymorphic:
-        not_supported: Formulär med polymorfiska relationer stöds inte än. Vi ber om ursäkt!
+        not_supported: Formulär med polymorfiska relationer stöds inte.
       has_one:
-        not_supported: Formulär med HasOne relationer stöds inte än. Vi ber om ursäkt!
+        not_supported: Formulär med HasOne relationer stöds inte.

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -18,6 +18,6 @@ vi:
         more: "%{count} trên %{total_count}"
         none: Không
       polymorphic:
-        not_supported: Quan hệ Polymorphic chưa được hỗ trợ. Xin lỗi!
+        not_supported: Quan hệ Polymorphic chưa được hỗ trợ.
       has_one:
-        not_supported: Quan hệ HasOne chưa được hỗ trợ. Xin lỗi!
+        not_supported: Quan hệ HasOne chưa được hỗ trợ.

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -18,6 +18,6 @@ zh-CN:
         more: 显示所有 %{total_count} 中 %{count} 条
         none: 无
       polymorphic:
-        not_supported: 对不起，Polymorphic 关系暂不支持!
+        not_supported: Polymorphic 关系暂不支持
       has_one:
-        not_supported: 对不起，HasOne 关系暂不支持!
+        not_supported: HasOne 关系暂不支持.

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -18,6 +18,6 @@ zh-TW:
         more: 顯示 %{total_count} 筆中的 %{count} 筆資料
         none: 無
       polymorphic:
-        not_supported: 很抱歉，表單尚未支援 Polymorphic 關聯。
+        not_supported: 表單尚未支援 Polymorphic 關聯。
       has_one:
-        not_supported: 很抱歉，表單尚未支援 HasOne 關聯。
+        not_supported: 表單尚未支援 HasOne 關聯。


### PR DESCRIPTION
We do want polymorphic and hasone relationship support, but we aren't
sorry that they aren't there.

While here, remove the word "yet". It will get there when it gets there,
and won't get there if it isn't needed. "Yet" is not agile.