### PR TITLE
faster conditional key fetching from a hash

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -26,9 +26,15 @@ module Administrate
     end
 
     def search_attributes
-      resolver.dashboard_class::ATTRIBUTE_TYPES.select do |_, type|
-        type.searchable?
-      end.keys
+      [].tap do |keys|
+        attribute_types.each do |key, type|
+          keys << key if type.searchable?
+        end
+      end
+    end
+
+    def attribute_types
+      resolver.dashboard_class::ATTRIBUTE_TYPES
     end
 
     attr_reader :resolver, :term

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -26,10 +26,9 @@ module Administrate
     end
 
     def search_attributes
-      [].tap do |keys|
-        attribute_types.each do |key, type|
-          keys << key if type.searchable?
-        end
+      attribute_types.keys.select! do |attribute|
+        type = attribute_types[attribute]
+        type.searchable?
       end
     end
 

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -26,7 +26,7 @@ module Administrate
     end
 
     def search_attributes
-      attribute_types.keys.select! do |attribute|
+      attribute_types.keys.select do |attribute|
         type = attribute_types[attribute]
         type.searchable?
       end


### PR DESCRIPTION
A hash's keys were being filtered in a slow way by iterating over the hash twice; this PR collects the keys conditionally in the first iteration.

Additionally, this PR has updated the version of `nokogiri` to get tests to pass on `CircleCI`.