### PR TITLE
Update Nokogiri for a security patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,12 +28,13 @@ end
 
 group :test do
   gem "ammeter"
-  gem "poltergeist"
   gem "database_cleaner"
   gem "formulaic"
   gem "fuubar"
   gem "launchy"
+  gem "nokogiri", "~> 1.6.6.4"
   gem "percy-capybara"
+  gem "poltergeist"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
     percy-capybara (1.0.0)
@@ -310,6 +310,7 @@ DEPENDENCIES
   high_voltage
   i18n-tasks
   launchy
+  nokogiri (~> 1.6.6.4)
   percy-capybara
   pg
   poltergeist


### PR DESCRIPTION
## Problem:

Running `bundler-audit` reveals a security vulnerability in Nokogiri,
which can be traced back to a libxml2 vulnerability.

```
$ bundle-audit
Name: nokogiri
Version: 1.6.6.2
Advisory: CVE-2015-1819
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1374
Title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
Solution: upgrade to ~> 1.6.6.4, >= 1.6.7.rc4

Vulnerabilities found!
```

## Solution:

Update nokogiri to `~> 1.6.6.4`, as suggested.

Nokogiri is a dependency of capybara,
which is a dependency of poltergeist.

We only need to specify the nokogiri version for the `test` bundler group, which already depends on it.

## References:

https://github.com/rubysec/bundler-audit
https://github.com/sparklemotion/nokogiri/issues/1374
http://www.ubuntu.com/usn/usn-2812-1/