### PR TITLE
Default ActiveRecord::Enum fields to String type instead of Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#270] [I18n] Don't apologize about missing relationship support.
 * [#237] [I18n] Fix broken paths for several I18n files (de, es, fr, pt-BR, vi).
 * [#266] [OPTIM] Save a few database queries by using cached counts
+* [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
 
 ### 0.1.1 (November 12, 2015)
 

--- a/lib/administrate/fields/deferred.rb
+++ b/lib/administrate/fields/deferred.rb
@@ -15,7 +15,9 @@ module Administrate
       end
 
       def ==(other)
-        deferred_class == other.deferred_class && options == other.options
+        other.respond_to?(:deferred_class) &&
+          deferred_class == other.deferred_class &&
+          options == other.options
       end
 
       def searchable?

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -7,6 +7,7 @@ module Administrate
         boolean: "Field::Boolean",
         date: "Field::DateTime",
         datetime: "Field::DateTime",
+        enum: "Field::String",
         float: "Field::Number",
         integer: "Field::Number",
         time: "Field::DateTime",
@@ -15,6 +16,7 @@ module Administrate
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {
+        enum: { searchable: false },
         float: { decimals: 2 },
       }
 
@@ -61,7 +63,7 @@ module Administrate
       end
 
       def field_type(attribute)
-        type = klass.column_types[attribute.to_s].type
+        type = column_type_for_attribute(attribute.to_s)
 
         if type
           ATTRIBUTE_TYPE_MAPPING.fetch(type, DEFAULT_FIELD_TYPE) +
@@ -69,6 +71,19 @@ module Administrate
         else
           association_type(attribute)
         end
+      end
+
+      def column_type_for_attribute(attr)
+        if enum_column?(attr)
+          :enum
+        else
+          klass.column_types[attr].type
+        end
+      end
+
+      def enum_column?(attr)
+        klass.respond_to?(:defined_enums) &&
+          klass.defined_enums.keys.include?(attr)
       end
 
       def association_type(attribute)

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -124,6 +124,30 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         end
       end
 
+      it "detects enum field as `String`" do
+        begin
+          ActiveRecord::Schema.define do
+            create_table :shipments do |t|
+              t.integer :status
+            end
+          end
+
+          class Shipment < ActiveRecord::Base
+            enum status: [:ready, :processing, :shipped]
+            reset_column_information
+          end
+
+          run_generator ["shipment"]
+          load file("app/dashboards/shipment_dashboard.rb")
+          attrs = ShipmentDashboard::ATTRIBUTE_TYPES
+
+          expect(attrs[:status]).
+            to eq(Administrate::Field::String.with_options(searchable: false))
+        ensure
+          remove_constants :Shipment, :ShipmentDashboard
+        end
+      end
+
       it "detects boolean values" do
         begin
           ActiveRecord::Schema.define do


### PR DESCRIPTION
This inspects the class to see if it has defined enums per the ActiveRecord 4.1+ API. If the column in question is an Enum, by default interpret it as a String field.

Fixes #290.