### PR TITLE
Update Nokogiri to v 1.6.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ group :test do
   gem "formulaic"
   gem "fuubar"
   gem "launchy"
-  gem "nokogiri", "~> 1.6.6.4"
   gem "percy-capybara"
   gem "poltergeist"
   gem "shoulda-matchers", "~> 2.8.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.1)
     momentjs-rails (2.10.6)
       railties (>= 3.1)
@@ -167,8 +167,8 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
     percy-capybara (1.0.0)
       percy-client (>= 1.0.0)
@@ -310,7 +310,6 @@ DEPENDENCIES
   high_voltage
   i18n-tasks
   launchy
-  nokogiri (~> 1.6.6.4)
   percy-capybara
   pg
   poltergeist

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -33,7 +33,6 @@ group :test do
   gem "formulaic"
   gem "fuubar"
   gem "launchy"
-  gem "nokogiri", "~> 1.6.6.4"
   gem "percy-capybara"
   gem "poltergeist"
   gem "shoulda-matchers", "~> 2.8.0", :require => false


### PR DESCRIPTION
## Problem:

Our app doesn't directly depend on nokogiri -
the test suite depends on Capybara,
which in turn depends on Nokogiri.

Because of this, we should not have `nokogiri`
referenced explicitly in our Gemfile.

Commit 12e0db4 upgraded nokogiri
by explicitly setting the desired version
in the Gemfile.

## Solution:

Several PRs (#285, #293) have used a different approach
for upgrading Nokogiri, in order to get their build passing.

They ran `bundle update nokogiri`
without explicitly setting the desired version in the Gemfile.
The most recent version of nokogiri contains the required security fix,
so it solves the original problem.

This commit reverts the changes made in 12e0db4,
and updates nokogiri
using the standard `bundle update nokogiri` approach.