### PR TITLE
Redirect from the root path to the admin root

### DIFF
--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
 
     root controller: DashboardManifest::ROOT_DASHBOARD, action: :index
   end
+
+  root to: redirect("/admin")
 end


### PR DESCRIPTION
## Problem:

When users visit the root URL of the demo site,
they see the default Rails welcome page
with no links or references about where to go from there.

## Solution:

Automatically redirect from the root URL to the admin dashboard.