### PR TITLE
Add break-word to preserve-whitespace

### DIFF
--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -8,6 +8,7 @@
 
 .preserve-whitespace {
   white-space: pre;
+  word-wrap: break-word;
 }
 
 .attribute-data {


### PR DESCRIPTION
Before:

<img width="1280" alt="screen shot 2015-12-08 at 13 21 34" src="https://cloud.githubusercontent.com/assets/905225/11655507/a432e286-9dae-11e5-8fd7-5175dac6ed16.png">


After:

<img width="1280" alt="screen shot 2015-12-08 at 13 18 49" src="https://cloud.githubusercontent.com/assets/905225/11655496/864c5766-9dae-11e5-9db5-a0ea528b36a8.png">

