### PR TITLE
Update datetime_picker_rails for better wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * [#298] [FEATURE] Support ActiveRecord model I18n translations
 * [#231] [UI] Fix layout issue on show page where a long label next to an empty
   value would cause following fields on the page to be mis-aligned.
+* [#309] [UI] Fix layout issue in datetime pickers where months and years
+  would not wrap correctly.
 * [#259] [BUGFIX] Make installation generator more robust
   by ignoring dynamically generated, unnamed models
 * [#243] [BUGFIX] Fix up a "Show" button on the edit page that was not using the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     administrate (0.1.1)
       autoprefixer-rails (~> 6.0)
-      datetime_picker_rails (~> 0.0.5)
+      datetime_picker_rails (~> 0.0.6)
       inline_svg (~> 0.6)
       jquery-rails (~> 4.0)
       kaminari (~> 0.16)
@@ -62,7 +62,7 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.3)
-    autoprefixer-rails (6.1.0.1)
+    autoprefixer-rails (6.1.2)
       execjs
       json
     awesome_print (1.6.1)
@@ -87,7 +87,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
-    datetime_picker_rails (0.0.5)
+    datetime_picker_rails (0.0.6)
       momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.2)
     delayed_job (4.1.1)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "autoprefixer-rails", "~> 6.0"
-  s.add_dependency "datetime_picker_rails", "~> 0.0.5"
+  s.add_dependency "datetime_picker_rails", "~> 0.0.6"
   s.add_dependency "inline_svg", "~> 0.6"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "kaminari", "~> 0.16"

--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,3 +1,6 @@
 $(function () {
-  $(".datetimepicker").datetimepicker({ format: "YYYY-MM-DD HH:mm:ss" });
+  $(".datetimepicker").datetimepicker({
+    debug: false,
+    format: "YYYY-MM-DD HH:mm:ss",
+  });
 });


### PR DESCRIPTION
## Problem:

`datetime_picker_rails` version 0.0.5 and earlier
have a bug that causes month and year selection buttons
to overflow their parent container.

## Solution:

This bug was fixed in `datetime_picker_rails` version 0.0.6.
Upgrading to that version fixes the visual bug.