### PR TITLE
Generated nested Admin::ApplicationController

### DIFF
--- a/lib/generators/administrate/install/templates/application_controller.rb
+++ b/lib/generators/administrate/install/templates/application_controller.rb
@@ -4,16 +4,18 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-class Admin::ApplicationController < Administrate::ApplicationController
-  before_filter :authenticate_admin
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_filter :authenticate_admin
 
-  def authenticate_admin
-    # TODO Add authentication logic here.
+    def authenticate_admin
+      # TODO Add authentication logic here.
+    end
+
+    # Override this value to specify the number of elements to display at a time
+    # on index pages. Defaults to 20.
+    # def records_per_page
+    #   params[:per_page] || 20
+    # end
   end
-
-  # Override this value to specify the number of elements to display at a time
-  # on index pages. Defaults to 20.
-  # def records_per_page
-  #   params[:per_page] || 20
-  # end
 end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -13,9 +13,10 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
       expect(controller).to exist
       expect(controller).to have_correct_syntax
-      expect(controller).to contain(
-        "class Admin::ApplicationController < Administrate::ApplicationController"
-      )
+      expect(controller).to contain <<-RB.strip_heredoc
+        module Admin
+          class ApplicationController < Administrate::ApplicationController
+      RB
     end
   end
 


### PR DESCRIPTION
The current generator for `Admin::ApplicationController` uses the
compact style, which is a styleguide violation for our Rubopcop (and
transitively Hound) configuration.