### PR TITLE
Make BelongsTo fields nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#251] [FEATURE] Raise a helpful error when an attribute is missing from
   `ATTRIBUTE_TYPES`
 * [#298] [FEATURE] Support ActiveRecord model I18n translations
+* [#312] [FEATURE] Add a `nil` option to `belongs_to` form fields
 * [#231] [UI] Fix layout issue on show page where a long label next to an empty
   value would cause following fields on the page to be mis-aligned.
 * [#309] [UI] Fix layout issue in datetime pickers where months and years

--- a/lib/administrate/fields/belongs_to.rb
+++ b/lib/administrate/fields/belongs_to.rb
@@ -12,7 +12,7 @@ module Administrate
       end
 
       def associated_resource_options
-        candidate_resources.map do |resource|
+        [nil] + candidate_resources.map do |resource|
           [display_candidate_resource(resource), resource.id]
         end
       end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -31,7 +31,7 @@ describe Administrate::Field::BelongsTo do
         candidates = field.associated_resource_options
 
         expect(Foo).to have_received(:all)
-        expect(candidates).to eq([])
+        expect(candidates).to eq([nil])
       ensure
         remove_constants :Foo
       end


### PR DESCRIPTION
Prior to this commit, there was no way to set a `belongs_to`
relationship to `nil` through the UI.