### PR TITLE
Revise development environment config to omit db host argument

### DIFF
--- a/spec/example_app/config/database.yml
+++ b/spec/example_app/config/database.yml
@@ -2,7 +2,6 @@ development: &default
   adapter: postgresql
   database: administrate-prototype_development
   encoding: utf8
-  host: localhost
   min_messages: warning
   pool: 2
   timeout: 5000


### PR DESCRIPTION
This actually causes problems on Ubuntu and is not necessary for Mac.

Closes #296.
