### PR TITLE
Remove has_many `_ids` suffix from form labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#214] [UI] Improve header layout when there is a long page title
 * [#198] [UI] Improve spacing around bottom link in sidebar
 * [#206] [UI] Left-align checkboxes in boolean form fields
+* [#315] [UI] Remove the `IDS` suffix for `HasMany` form field labels
 * [#259] [BUGFIX] Make installation generator more robust
   by ignoring dynamically generated, unnamed models
 * [#243] [BUGFIX] Fix up a "Show" button on the edit page that was not using the

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -19,7 +19,7 @@ and is augmented with [Selectize].
 [Selectize]: http://brianreavis.github.io/selectize.js
 %>
 
-<%= f.label field.attribute_key %>
+<%= f.label field.attribute_key, field.attribute %>
 
 <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>
   <%= options_for_select(field.associated_resource_options, field.selected_options) %>

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "fields/has_many/_form", type: :view do
+  describe "the field label" do
+    it "displays the association name" do
+      has_many = double(
+        attribute_key: :associated_object_ids,
+        attribute: :associated_objects,
+      )
+
+      render(
+        partial: "fields/has_many/form.html.erb",
+        locals: { f: fake_form_builder, field: has_many },
+      )
+
+      expect(rendered).to include("Associated Objects")
+    end
+  end
+
+  def fake_form_builder
+    double("Form Builder").as_null_object.tap do |form_builder|
+      allow(form_builder).to receive(:label) do |*args|
+        args.second.to_s.titleize
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #303

## Problem:

When HasMany attributes are displayed in form fields,
their labels include the `_ids` suffix that Rails uses internally
(e.g. `line_item_ids`, `order_ids`).

![edit_order__3___administrate_prototype](https://cloud.githubusercontent.com/assets/829576/11697326/1ae107b8-9e87-11e5-984b-d3e518bec54d.png)

Users expect to see the pluralized form of the relationship name
(e.g. `line_items`, `orders`).

![edit_order__3___administrate_prototype](https://cloud.githubusercontent.com/assets/829576/11697349/37b29988-9e87-11e5-93d9-154427b5370c.png)

## Solution:

Pass in the desired label value explicitly instead of letting Rails
guess at the correct label.
