### PR TITLE
Release Administrate v 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Upcoming Release
 
+### 0.1.2 (December 09, 2015)
+
 * [#251] [FEATURE] Raise a helpful error when an attribute is missing from
   `ATTRIBUTE_TYPES`
 * [#298] [FEATURE] Support ActiveRecord model I18n translations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    administrate (0.1.1)
+    administrate (0.1.2)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.6)
       inline_svg (~> 0.6)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate", "~> 0.1.1"
+gem "administrate", "~> 0.1.2"
 ```
 
 Re-bundle, then run the installer:

--- a/lib/administrate/version.rb
+++ b/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
## New Features

* #251  Raise a helpful error when an attribute is missing from `ATTRIBUTE_TYPES`
* #298  Support ActiveRecord model I18n translations
* #312  Add a `nil` option to `belongs_to` form fields

## UI Changes

* #231  Fix layout issue on show page where a long label next to an empty value would cause following fields on the page to be mis-aligned.
* #309  Fix layout issue in datetime pickers where months and years would not wrap correctly.
* #306  Wrap long text lines (on word breaks) on show pages
* #214  Improve header layout when there is a long page title
* #198  Improve spacing around bottom link in sidebar
* #206  Left-align checkboxes in boolean form fields
* #315  Remove the `IDS` suffix for `HasMany` form field labels

## Bug Fixes

* #259  Make installation generator more robust by ignoring dynamically generated, unnamed models
* #243  Fix up a "Show" button on the edit page that was not using the `display_resource` method.
* #248  Improve polymorphic relationship's dashboard class detection.
* #247  Populate `has_many` and `belongs_to` select boxes with the current value of the relationship.

## I18n Changes

* #217  Dutch
* #263  Swedish
* #272  Danish
* #270  Don't apologize about missing relationship support.
* #237  Fix broken paths for several I18n files (de, es, fr, pt-BR, vi).

## Optimizations

* #266  Save a few database queries by using cached counts