### PR TITLE
Add specs for Administrate::Search class

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -1,3 +1,6 @@
+require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/object/blank"
+
 module Administrate
   class Search
     def initialize(resolver, term)

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -15,9 +15,9 @@ end
 
 describe Administrate::Search do
   describe "#run" do
-    let(:resolver) { double(
-      resource_class: User,
-      dashboard_class: MockDashboard) }
+    let(:resolver) do
+      double(resource_class: User, dashboard_class: MockDashboard)
+    end
 
     it "returns all records when no search term" do
       begin

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -22,7 +22,7 @@ describe Administrate::Search do
     it "returns all records when no search term" do
       begin
         class User; end
-
+        resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = described_class.new(resolver, nil)
         expect(User).to receive(:all)
 
@@ -35,6 +35,7 @@ describe Administrate::Search do
     it "returns all records when search is empty" do
       begin
         class User; end
+        resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = described_class.new(resolver, "   ")
         expect(User).to receive(:all)
 
@@ -47,6 +48,7 @@ describe Administrate::Search do
     it "searches using lower() + LIKE for all searchable fields" do
       begin
         class User; end
+        resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = described_class.new(resolver, "test")
         expected_query = [
           "lower(name) LIKE ? OR lower(email) LIKE ?",

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -13,19 +13,9 @@ class MockDashboardClass
   }
 end
 
-class MockResolver
-  def resource_class
-    User
-  end
-
-  def dashboard_class
-    MockDashboardClass
-  end
-end
-
 describe Administrate::Search do
   describe "#run" do
-    let(:resolver) { MockResolver.new }
+    let(:resolver) { double(resource_class: User, dashboard_class: MockDashboardClass) }
 
     it "returns all records when no search term" do
       begin

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -5,7 +5,7 @@ require "administrate/fields/email"
 require "administrate/fields/number"
 require "administrate/search"
 
-class MockDashboardClass
+class MockDashboard
   ATTRIBUTE_TYPES = {
     name: Administrate::Field::String,
     email: Administrate::Field::Email,
@@ -15,7 +15,9 @@ end
 
 describe Administrate::Search do
   describe "#run" do
-    let(:resolver) { double(resource_class: User, dashboard_class: MockDashboardClass) }
+    let(:resolver) { double(
+      resource_class: User,
+      dashboard_class: MockDashboard) }
 
     it "returns all records when no search term" do
       begin

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -15,10 +15,6 @@ end
 
 describe Administrate::Search do
   describe "#run" do
-    let(:resolver) do
-      double(resource_class: User, dashboard_class: MockDashboard)
-    end
-
     it "returns all records when no search term" do
       begin
         class User; end


### PR DESCRIPTION
This class had no spec coverage and I'd like to start implementing search for Enum fields. Can't have new features without covering our existing ones :smile: 