### PR TITLE
Add search support for ActiveRecord::Enum columns

### DIFF
--- a/app/views/fields/enum/_form.html.erb
+++ b/app/views/fields/enum/_form.html.erb
@@ -1,0 +1,19 @@
+<%#
+# Enum Form Partial
+
+This partial renders an input element for a string attribute.
+By default, the input is a text field.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Enum][1].
+  A wrapper around the Enum pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Enum
+%>
+
+<%= f.label field.attribute %>
+<%= f.select field.attribute, field.enum_options %>

--- a/app/views/fields/enum/_index.html.erb
+++ b/app/views/fields/enum/_index.html.erb
@@ -1,0 +1,18 @@
+<%#
+# Enum Index Partial
+
+This partial renders a string attribute
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered as a truncated string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Enum][1].
+  A wrapper around the Enum pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Enum
+%>
+
+<%= field.data.humanize %>

--- a/app/views/fields/enum/_show.html.erb
+++ b/app/views/fields/enum/_show.html.erb
@@ -1,0 +1,19 @@
+<%#
+# Enum Show Partial
+
+This partial renders an enum attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered as text with
+whitespace preserved.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Enum][1].
+  A wrapper around the enum value mapped by ActiveRecord.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Enum
+%>
+
+<span class="preserve-whitespace"><%= field.data.humanize %></span>

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -9,6 +9,7 @@ require "administrate/fields/number"
 require "administrate/fields/polymorphic"
 require "administrate/fields/string"
 require "administrate/fields/text"
+require "administrate/fields/enum"
 
 module Administrate
   class BaseDashboard

--- a/lib/administrate/fields/base.rb
+++ b/lib/administrate/fields/base.rb
@@ -16,11 +16,11 @@ module Administrate
         false
       end
 
-      def self.search_predicate(attribute, term)
+      def self.search_predicate(attribute, _term)
         "lower(#{attribute}) LIKE ?"
       end
 
-      def self.search_term(attribute, term)
+      def self.search_term(_attribute, term)
         "%#{term}%"
       end
 

--- a/lib/administrate/fields/base.rb
+++ b/lib/administrate/fields/base.rb
@@ -16,6 +16,14 @@ module Administrate
         false
       end
 
+      def self.search_predicate(attribute, term)
+        "lower(#{attribute}) LIKE ?"
+      end
+
+      def self.search_term(attribute, term)
+        "%#{term}%"
+      end
+
       def initialize(attribute, data, page, options = {})
         @attribute = attribute
         @data = data

--- a/lib/administrate/fields/deferred.rb
+++ b/lib/administrate/fields/deferred.rb
@@ -24,6 +24,26 @@ module Administrate
         options.fetch(:searchable, deferred_class.searchable?)
       end
 
+      def enum_options
+        options.fetch(:enum, nil)
+      end
+
+      def search_predicate(attribute, term)
+        if enum_options
+          deferred_class.search_predicate(attribute, term, enum_options)
+        else
+          deferred_class.search_predicate(attribute, term)
+        end
+      end
+
+      def search_term(attribute, term)
+        if enum_options
+          deferred_class.search_term(attribute, term, enum_options)
+        else
+          deferred_class.search_term(attribute, term)
+        end
+      end
+
       delegate(
         :html_class,
         :permitted_attribute,

--- a/lib/administrate/fields/enum.rb
+++ b/lib/administrate/fields/enum.rb
@@ -6,16 +6,12 @@ module Administrate
       def self.search_predicate(attribute, term, options)
         if options.keys.include?(term)
           "#{attribute} = ?"
-        else
-          nil
         end
       end
 
       def self.search_term(_attribute, term, options)
         if options.keys.include?(term)
           options[term]
-        else
-          nil
         end
       end
 
@@ -24,7 +20,7 @@ module Administrate
       end
 
       def enum_options
-        options[:enum].keys.map {|k| [k.humanize, k]}
+        options[:enum].keys.map { |k| [k.humanize, k] }
       end
     end
   end

--- a/lib/administrate/fields/enum.rb
+++ b/lib/administrate/fields/enum.rb
@@ -18,6 +18,14 @@ module Administrate
           nil
         end
       end
+
+      def data
+        @data.to_s[0...truncation_length]
+      end
+
+      def enum_options
+        options[:enum].keys.map {|k| [k.humanize, k]}
+      end
     end
   end
 end

--- a/lib/administrate/fields/enum.rb
+++ b/lib/administrate/fields/enum.rb
@@ -11,7 +11,7 @@ module Administrate
         end
       end
 
-      def self.search_term(attribute, term, options)
+      def self.search_term(_attribute, term, options)
         if options.keys.include?(term)
           options[term]
         else

--- a/lib/administrate/fields/enum.rb
+++ b/lib/administrate/fields/enum.rb
@@ -1,0 +1,23 @@
+require_relative "string"
+
+module Administrate
+  module Field
+    class Enum < Field::String
+      def self.search_predicate(attribute, term, options)
+        if options.keys.include?(term)
+          "#{attribute} = ?"
+        else
+          nil
+        end
+      end
+
+      def self.search_term(attribute, term, options)
+        if options.keys.include?(term)
+          options[term]
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -21,16 +21,25 @@ module Administrate
     delegate :resource_class, to: :resolver
 
     def query
-      search_attributes.map { |attr| "lower(#{attr}) LIKE ?" }.join(" OR ")
+      search_attributes.map do |attr, field_class|
+        field_class.search_predicate(attr, term)
+      end.compact.join(" OR ")
     end
 
     def search_terms
-      ["%#{term.downcase}%"] * search_attributes.count
+      search_attributes.map do |attr, field_class|
+        field_class.search_term(attr, term)
+      end.compact
     end
 
     def search_attributes
-      attribute_types.keys.select do |attribute|
-        attribute_types[attribute].searchable?
+      @search_attributes ||= attribute_types.keys.inject({}) do |attrs, attribute|
+        field_class = attribute_types[attribute]
+        if field_class.searchable?
+          attrs.merge(attribute => field_class)
+        else
+          attrs
+        end
       end
     end
 

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -33,14 +33,15 @@ module Administrate
     end
 
     def search_attributes
-      @search_attributes ||= attribute_types.keys.inject({}) do |attrs, attribute|
-        field_class = attribute_types[attribute]
-        if field_class.searchable?
-          attrs.merge(attribute => field_class)
-        else
-          attrs
+      @search_attributes ||=
+        attribute_types.keys.reduce({}) do |attrs, attribute|
+          field_class = attribute_types[attribute]
+          if field_class.searchable?
+            attrs.merge(attribute => field_class)
+          else
+            attrs
+          end
         end
-      end
     end
 
     def attribute_types

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -7,7 +7,7 @@ module Administrate
         boolean: "Field::Boolean",
         date: "Field::DateTime",
         datetime: "Field::DateTime",
-        enum: "Field::String",
+        enum: "Field::Enum",
         float: "Field::Number",
         integer: "Field::Number",
         time: "Field::DateTime",
@@ -16,7 +16,6 @@ module Administrate
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {
-        enum: { searchable: false },
         float: { decimals: 2 },
       }
 
@@ -67,9 +66,19 @@ module Administrate
 
         if type
           ATTRIBUTE_TYPE_MAPPING.fetch(type, DEFAULT_FIELD_TYPE) +
-            options_string(ATTRIBUTE_OPTIONS_MAPPING.fetch(type, {}))
+            options_string(attribute_type_options(type, attribute.to_s))
         else
           association_type(attribute)
+        end
+      end
+
+      def attribute_type_options(type, attr)
+        base_options = ATTRIBUTE_OPTIONS_MAPPING.fetch(type, {})
+
+        if type == :enum
+          base_options.merge({enum: klass.send(attr.pluralize)})
+        else
+          base_options
         end
       end
 

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -76,7 +76,7 @@ module Administrate
         base_options = ATTRIBUTE_OPTIONS_MAPPING.fetch(type, {})
 
         if type == :enum
-          base_options.merge({enum: klass.send(attr.pluralize)})
+          base_options.merge(enum: klass.send(attr.pluralize))
         else
           base_options
         end

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -14,7 +14,7 @@ class OrderDashboard < Administrate::BaseDashboard
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
-    status: Field::Enum,
+    status: Field::Enum.with_options(enum: {'pending' => 0, 'confirmed' => 1}),
   }
 
   READ_ONLY_ATTRIBUTES = [
@@ -31,6 +31,7 @@ class OrderDashboard < Administrate::BaseDashboard
     :total_price,
     :line_items,
     :shipped_at,
+    :status,
   ]
 
   FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -14,7 +14,7 @@ class OrderDashboard < Administrate::BaseDashboard
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
-    status: Field::Enum.with_options(enum: {'pending' => 0, 'confirmed' => 1}),
+    status: Field::Enum.with_options(enum: { "pending" => 0, "confirmed" => 1 }),
   }
 
   READ_ONLY_ATTRIBUTES = [

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -14,6 +14,7 @@ class OrderDashboard < Administrate::BaseDashboard
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
+    status: Field::Enum,
   }
 
   READ_ONLY_ATTRIBUTES = [

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -14,7 +14,8 @@ class OrderDashboard < Administrate::BaseDashboard
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
-    status: Field::Enum.with_options(enum: { "pending" => 0, "confirmed" => 1 }),
+    status: Field::Enum.with_options(
+      enum: { "pending" => 0, "confirmed" => 1 }),
   }
 
   READ_ONLY_ATTRIBUTES = [

--- a/spec/example_app/app/models/order.rb
+++ b/spec/example_app/app/models/order.rb
@@ -10,6 +10,8 @@ class Order < ActiveRecord::Base
   validates :address_state, presence: true
   validates :address_zip, presence: true
 
+  enum status: [:pending, :confirmed]
+
   def total_price
     line_items.map(&:total_price).reduce(0, :+)
   end

--- a/spec/example_app/db/migrate/20151209033200_add_status_to_orders.rb
+++ b/spec/example_app/db/migrate/20151209033200_add_status_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrders < ActiveRecord::Migration
+  def change
+    add_column :orders, :status, :integer, null: false, default: 0
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150916011117) do
+ActiveRecord::Schema.define(version: 20151209033200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,9 +59,10 @@ ActiveRecord::Schema.define(version: 20150916011117) do
     t.string   "address_city"
     t.string   "address_state"
     t.string   "address_zip"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.datetime "shipped_at"
+    t.integer  "status",           default: 0, null: false
   end
 
   add_index "orders", ["customer_id"], name: "index_orders_on_customer_id", using: :btree

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -34,7 +34,7 @@ Customer.all.each do |customer|
       address_city: Faker::Address.city,
       address_state: Faker::Address.state_abbr,
       address_zip: Faker::Address.zip,
-      status: [0,1].sample,
+      status: [0, 1].sample,
     )
 
     item_count = (1..3).to_a.sample

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -34,6 +34,7 @@ Customer.all.each do |customer|
       address_city: Faker::Address.city,
       address_state: Faker::Address.state_abbr,
       address_zip: Faker::Address.zip,
+      status: [0,1].sample,
     )
 
     item_count = (1..3).to_a.sample

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -142,8 +142,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           attrs = ShipmentDashboard::ATTRIBUTE_TYPES
 
           expect(attrs[:status]).
-            to eq(Administrate::Field::Enum.with_options(enum: {
-              "pending" => 0, "confirmed" => 1 }))
+            to eq(Administrate::Field::Enum.with_options(
+              enum: { "pending" => 0, "confirmed" => 1 }))
         ensure
           remove_constants :Shipment, :ShipmentDashboard
         end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -133,7 +133,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           end
 
           class Shipment < ActiveRecord::Base
-            enum status: [:ready, :processing, :shipped]
+            enum status: [:pending, :confirmed]
             reset_column_information
           end
 
@@ -142,7 +142,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           attrs = ShipmentDashboard::ATTRIBUTE_TYPES
 
           expect(attrs[:status]).
-            to eq(Administrate::Field::Enum.with_options(enum: {'ready' => 0, 'processing' => 1, 'shipped' => 2}))
+            to eq(Administrate::Field::Enum.with_options(enum: {
+              "pending" => 0, "confirmed" => 1 }))
         ensure
           remove_constants :Shipment, :ShipmentDashboard
         end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -142,7 +142,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           attrs = ShipmentDashboard::ATTRIBUTE_TYPES
 
           expect(attrs[:status]).
-            to eq(Administrate::Field::String.with_options(searchable: false))
+            to eq(Administrate::Field::Enum.with_options(enum: {'ready' => 0, 'processing' => 1, 'shipped' => 2}))
         ensure
           remove_constants :Shipment, :ShipmentDashboard
         end

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -12,7 +12,9 @@ class MockDashboard
     email: Administrate::Field::Email,
     phone: Administrate::Field::Number,
     status: Administrate::Field::Enum.with_options(
-      enum: {'pending' => 0, 'confirmed' => 1}),
+      enum: {
+        "pending" => 0, "confirmed" => 1
+      }),
   }
 end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -3,6 +3,7 @@ require "support/constant_helpers"
 require "administrate/fields/string"
 require "administrate/fields/email"
 require "administrate/fields/number"
+require "administrate/fields/enum"
 require "administrate/search"
 
 class MockDashboard
@@ -10,6 +11,8 @@ class MockDashboard
     name: Administrate::Field::String,
     email: Administrate::Field::Email,
     phone: Administrate::Field::Number,
+    status: Administrate::Field::Enum.with_options(
+      enum: {'pending' => 0, 'confirmed' => 1}),
   }
 end
 
@@ -42,6 +45,25 @@ describe Administrate::Search do
     end
 
     it "searches using lower() + LIKE for all searchable fields" do
+      begin
+        class User; end
+        resolver = double(resource_class: User, dashboard_class: MockDashboard)
+        search = Administrate::Search.new(resolver, "confirmed")
+        expected_query = [
+          "lower(name) LIKE ? OR lower(email) LIKE ? OR status = ?",
+          "%confirmed%",
+          "%confirmed%",
+          1,
+        ]
+        expect(User).to receive(:where).with(*expected_query)
+
+        search.run
+      ensure
+        remove_constants :User
+      end
+    end
+
+    it "omits enum fields from search if no matching enum value" do
       begin
         class User; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)


### PR DESCRIPTION
Bit of a work in progress/hack. Map all searchable fields into a hash and
allow each field class to customize the search predicate and comparison
term based on the passed search string. If no matching enum value is
found in the search term (based on == compare), omit enum field from
search string. Otherwise, try to map it to the correct integer value.

I think this needs a new class of some kind, perhaps something like `SearchField`, instantiated by either the Field class itself or the Deferred class which would avoid having to have the ugly class methods on the fields and the arity difference for enums only. I'm seriously open to design feedback on this one because, while It Works<sup>:tm:</sup>, it's not exactly nice looking right now.
