### PR TITLE
Generate layout with `rails g administrate:views`

### DIFF
--- a/lib/generators/administrate/views/views_generator.rb
+++ b/lib/generators/administrate/views/views_generator.rb
@@ -4,6 +4,7 @@ module Administrate
   module Generators
     class ViewsGenerator < Administrate::ViewGenerator
       def copy_templates
+        Rails::Generators.invoke("administrate:views:layout")
         Rails::Generators.invoke("administrate:views:index", [resource_path])
         Rails::Generators.invoke("administrate:views:show", [resource_path])
         Rails::Generators.invoke("administrate:views:new", [resource_path])

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 require "generators/administrate/views/views_generator"
 require "support/generator_spec_helpers"
 
@@ -10,10 +10,16 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       run_generator [resource]
 
+      expect(Rails::Generators).to invoke_generator("administrate:views:layout")
+
       %w[index show new edit].each do |generator|
-        expect(Rails::Generators).to have_received(:invoke).
-          with("administrate:views:#{generator}", [resource])
+        expect(Rails::Generators).
+          to invoke_generator("administrate:views:#{generator}", [resource])
       end
     end
+  end
+
+  def invoke_generator(*args)
+    have_received(:invoke).with(*args)
   end
 end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -18,8 +18,4 @@ describe Administrate::Generators::ViewsGenerator, :generator do
       end
     end
   end
-
-  def invoke_generator(*args)
-    have_received(:invoke).with(*args)
-  end
 end


### PR DESCRIPTION
## Problem:

When users run `rails generate administrate:views`,
they expect all of Administrate's views to be generated.
Currently, the layout views and partials
are not generated through that command,
so users must run `rails generate administrate:views:layout` separately.

## Solution:

Automatically generate the layout files
when the user runs `rails generate adminsitrate:views`