### PR TITLE
Add generators for asset files

### DIFF
--- a/lib/generators/administrate/assets/assets_generator.rb
+++ b/lib/generators/administrate/assets/assets_generator.rb
@@ -1,0 +1,13 @@
+require "administrate/view_generator"
+
+module Administrate
+  module Generators
+    class AssetsGenerator < Administrate::ViewGenerator
+      def copy_assets
+        Rails::Generators.invoke("administrate:assets:images")
+        Rails::Generators.invoke("administrate:assets:javascripts")
+        Rails::Generators.invoke("administrate:assets:stylesheets")
+      end
+    end
+  end
+end

--- a/lib/generators/administrate/assets/images_generator.rb
+++ b/lib/generators/administrate/assets/images_generator.rb
@@ -1,0 +1,17 @@
+require "rails/generators/base"
+
+module Administrate
+  module Generators
+    module Assets
+      class ImagesGenerator < Rails::Generators::Base
+        IMAGES_PATH = "app/assets/images/administrate"
+
+        source_root File.expand_path("../../../../../", __FILE__)
+
+        def copy_images
+          directory IMAGES_PATH, IMAGES_PATH
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/administrate/assets/javascripts_generator.rb
+++ b/lib/generators/administrate/assets/javascripts_generator.rb
@@ -1,0 +1,17 @@
+require "rails/generators/base"
+
+module Administrate
+  module Generators
+    module Assets
+      class JavascriptsGenerator < Rails::Generators::Base
+        JAVASCRIPTS_PATH = "app/assets/javascripts/administrate"
+
+        source_root File.expand_path("../../../../../", __FILE__)
+
+        def copy_javascripts
+          directory JAVASCRIPTS_PATH, JAVASCRIPTS_PATH
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/administrate/assets/stylesheets_generator.rb
+++ b/lib/generators/administrate/assets/stylesheets_generator.rb
@@ -1,0 +1,17 @@
+require "rails/generators/base"
+
+module Administrate
+  module Generators
+    module Assets
+      class StylesheetsGenerator < Rails::Generators::Base
+        STYLESHEETS_PATH = "app/assets/stylesheets/administrate"
+
+        source_root File.expand_path("../../../../../", __FILE__)
+
+        def copy_stylesheets
+          directory STYLESHEETS_PATH, STYLESHEETS_PATH
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/assets/images_generator_spec.rb
+++ b/spec/generators/assets/images_generator_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "generators/administrate/assets/images_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Assets::ImagesGenerator, :generator do
+  describe "administrate:assets:images" do
+    it "copies the images directory into the `administrate` namespace" do
+      images_directory = "app/assets/images/administrate/**/*"
+
+      run_generator []
+
+      each_file_in(images_directory) do |copied_file_path|
+        expected_contents = File.read(copied_file_path)
+        contents = File.read(file(copied_file_path))
+
+        expect(contents).to eq(expected_contents)
+      end
+    end
+  end
+end

--- a/spec/generators/assets/javascripts_generator_spec.rb
+++ b/spec/generators/assets/javascripts_generator_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "generators/administrate/assets/javascripts_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Assets::JavascriptsGenerator, :generator do
+  describe "administrate:assets:javascripts" do
+    it "copies the javascripts directory into the `administrate` namespace" do
+      javascripts_directory = "app/assets/javascripts/administrate/**/*"
+
+      run_generator []
+
+      each_file_in(javascripts_directory) do |copied_file_path|
+        expected_contents = File.read(copied_file_path)
+        contents = File.read(file(copied_file_path))
+
+        expect(contents).to eq(expected_contents)
+      end
+    end
+  end
+end

--- a/spec/generators/assets/stylesheets_generator_spec.rb
+++ b/spec/generators/assets/stylesheets_generator_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "generators/administrate/assets/stylesheets_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::Assets::StylesheetsGenerator, :generator do
+  describe "administrate:assets:stylesheets" do
+    it "copies the stylesheets directory into the `administrate` namespace" do
+      stylesheets_directory = "app/assets/stylesheets/administrate/**/*"
+
+      run_generator []
+
+      each_file_in(stylesheets_directory) do |copied_file_path|
+        expected_contents = File.read(copied_file_path)
+        contents = File.read(file(copied_file_path))
+
+        expect(contents).to eq(expected_contents)
+      end
+    end
+  end
+end

--- a/spec/generators/assets_generator_spec.rb
+++ b/spec/generators/assets_generator_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require "generators/administrate/assets/assets_generator"
+require "support/generator_spec_helpers"
+
+describe Administrate::Generators::AssetsGenerator, :generator do
+  describe "administrate:assets" do
+    it "runs all sub-generators" do
+      allow(Rails::Generators).to receive(:invoke)
+
+      run_generator []
+
+      %w[images javascripts stylesheets].each do |asset|
+        expect(Rails::Generators).
+          to invoke_generator("administrate:assets:#{asset}")
+      end
+    end
+  end
+end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -15,6 +15,20 @@ module GeneratorSpecHelpers
     )
   end
 
+  def invoke_generator(*args)
+    have_received(:invoke).with(*args)
+  end
+
+  def each_file_in(path)
+    files = Dir.glob(path)
+
+    files.each do |file_path|
+      if File.file?(file_path)
+        yield file_path
+      end
+    end
+  end
+
   private
 
   def copy_to_generator_root(destination, template)


### PR DESCRIPTION
Closes #187

## Problem:

Many people want to customize the stylesheets and javascripts
that get applied to Administrate dashboards.

To do that, they must copy over the default assets
from Adminsitrate's source into their own host application,
and edit those files to add custom behavior or styles.

This approach is error-prone and not approachable.

## Solution:

Add a generator for copying over default styles and javascripts
into the user's host application.

## Usage:

```
 # Copy image assets into `app/assets/images/administrate`
rails generate administrate:assets:images

 # Copy javascript assets into `app/assets/javascripts/administrate`
rails generate administrate:assets:javascripts

 # Copy stylesheet assets into `app/assets/stylesheets/administrate`
rails generate administrate:assets:stylesheets

 # Runs all of the above generators
rails generate administrate:assets
```

## ToDo:

- [x] Actually run these generators and edit the files to verify they work.