### PR TITLE
Change admin directory

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -37,7 +37,7 @@ module Administrate
 
       if resource.save
         redirect_to(
-          [Administrate::NAMESPACE, resource],
+          [Administrate::Config.admin_namespace, resource],
           notice: translate_with_resource("create.success"),
         )
       else
@@ -50,7 +50,7 @@ module Administrate
     def update
       if requested_resource.update(resource_params)
         redirect_to(
-          [Administrate::NAMESPACE, requested_resource],
+          [Administrate::Config.admin_directory, requested_resource],
           notice: translate_with_resource("update.success"),
         )
       else

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -47,7 +47,7 @@ to display a collection of resources in an HTML table.
       <tr class="table__row"
           role="link"
           tabindex="0"
-          data-url="<%= polymorphic_path([Administrate::NAMESPACE, resource]) -%>"
+          data-url="<%= polymorphic_path([Administrate::Config.admin_directory, resource]) -%>"
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
@@ -57,13 +57,13 @@ to display a collection of resources in an HTML table.
 
         <td><%= link_to(
           t("administrate.actions.edit"),
-          [:edit, Administrate::NAMESPACE, resource],
+          [:edit, Administrate::Config.admin_directory, resource],
           class: "action-edit",
         ) %></td>
 
         <td><%= link_to(
           t("administrate.actions.destroy"),
-          [Administrate::NAMESPACE, resource],
+          [Administrate::Config.admin_directory, resource],
           class: "table__action--destroy",
           method: :delete,
           data: { confirm: t("administrate.actions.confirm") }

--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -14,7 +14,7 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([Administrate::NAMESPACE, page.resource], html: { class: "form" }) do |f| %>
+<%= form_for([Administrate::Config.admin_directory, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -12,7 +12,7 @@ as defined by the DashboardManifest.
     <li>
       <%= link_to(
         display_resource_name(resource),
-        [Administrate::NAMESPACE, resource],
+        [Administrate::Config.admin_directory, resource],
         class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
       ) %>
     </li>

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -22,7 +22,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
   <div class="header-actions">
     <%= link_to(
       "Show #{page.page_title}",
-      [Administrate::NAMESPACE, page.resource],
+      [Administrate::Config.admin_directory, page.resource],
       class: "button",
     ) %>
   </div>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -48,7 +48,7 @@ It renders the `_table` partial to display details about the resources.
   <div class="header-actions">
     <%= link_to(
       "New #{page.resource_name.titleize.downcase}",
-      [:new, Administrate::NAMESPACE, page.resource_name],
+      [:new, Administrate::Config.admin_directory, page.resource_name],
       class: "button",
     ) %>
   </div>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -23,7 +23,7 @@ as well as a link to its edit page.
   <div class="header-actions">
     <%= link_to(
       "Edit",
-      [:edit, Administrate::NAMESPACE, page.resource],
+      [:edit, Administrate::Config.admin_directory, page.resource],
       class: "button",
     ) %>
   </div>

--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [Administrate::Config.admin_directory, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [Administrate::Config.admin_directory, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [Administrate::Config.admin_directory, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [Administrate::Config.admin_directory, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data]
+    [Administrate::Config.admin_directory, field.data]
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [Administrate::Config.admin_directory, field.data],
   ) %>
 <% end %>

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -1,5 +1,3 @@
-require "administrate/engine"
-
 module Administrate
   module Config
     @admin_directory = "admin"
@@ -18,3 +16,5 @@ module Administrate
     yield Administrate::Config
   end
 end
+
+require "administrate/engine"

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -2,9 +2,14 @@ require "administrate/engine"
 
 module Administrate
   module Config
+    @admin_directory = "admin"
+
     module ClassMethods
       attr_accessor :admin_directory
-      @@admin_directory = "admin"
+
+      def admin_namespace
+        admin_directory.camelize
+      end
     end
     extend ClassMethods
   end

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -1,4 +1,15 @@
 require "administrate/engine"
 
 module Administrate
+  module Config
+    module ClassMethods
+      attr_accessor :admin_directory
+      @@admin_directory = "admin"
+    end
+    extend ClassMethods
+  end
+
+  def self.configure
+    yield Administrate::Config
+  end
 end

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -9,7 +9,6 @@ require "sass-rails"
 require "selectize-rails"
 require "sprockets/railtie"
 
-require "administrate/namespace"
 require "administrate/page/form"
 require "administrate/page/show"
 require "administrate/page/collection"

--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -1,3 +1,0 @@
-module Administrate
-  NAMESPACE = :admin
-end

--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -1,5 +1,3 @@
-require "administrate/namespace"
-
 module Administrate
   class ResourceResolver
     def initialize(controller_path)
@@ -33,7 +31,7 @@ module Administrate
     end
 
     def controller_path_parts
-      controller_path.singularize.split("/") - [Administrate::NAMESPACE.to_s]
+      controller_path.singularize.split("/") - [Administrate::Config.admin_directory.to_s]
     end
 
     attr_reader :controller_path

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -33,7 +33,7 @@ module Administrate
       def create_resource_controller
         template(
           "controller.rb.erb",
-          "app/controllers/admin/#{file_name.pluralize}_controller.rb",
+          "app/controllers/#{Administrate::Config.admin_directory}/#{file_name.pluralize}_controller.rb",
         )
       end
 

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -33,7 +33,12 @@ module Administrate
       def create_resource_controller
         template(
           "controller.rb.erb",
-          "app/controllers/#{Administrate::Config.admin_directory}/#{file_name.pluralize}_controller.rb",
+          File.join(
+            "app",
+            "controllers",
+            Administrate::Config.admin_directory,
+            "#{file_name.pluralize}_controller.rb",
+          ),
         )
       end
 

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,5 +1,5 @@
-module Admin
-  class <%= class_name.pluralize %>Controller < Admin::ApplicationController
+module <%= Administrate::Config.admin_namespace %>
+  class <%= class_name.pluralize %>Controller < <%= Administrate::Config.admin_namespace %>::ApplicationController
     # To customize the behavior of this controller,
     # simply overwrite any of the RESTful actions. For example:
     #

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -9,7 +9,12 @@ module Administrate
       def create_dashboard_controller
         copy_file(
           "application_controller.rb",
-          "app/controllers/#{Administrate::Config.admin_directory}/application_controller.rb"
+          File.join(
+            "app",
+            "controllers",
+            Administrate::Config.admin_directory,
+            "application_controller.rb",
+          ),
         )
       end
 

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -9,7 +9,7 @@ module Administrate
       def create_dashboard_controller
         copy_file(
           "application_controller.rb",
-          "app/controllers/admin/application_controller.rb"
+          "app/controllers/#{Administrate::Config.admin_directory}/application_controller.rb"
         )
       end
 

--- a/lib/generators/administrate/install/templates/application_controller.rb.erb
+++ b/lib/generators/administrate/install/templates/application_controller.rb.erb
@@ -4,7 +4,7 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-module Admin
+module <%= Administrate::Config.admin_namespace %>
   class ApplicationController < Administrate::ApplicationController
     before_filter :authenticate_admin
 

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -17,7 +17,7 @@ module Features
 
   def url_for(model)
     "/" + [
-      Administrate::NAMESPACE,
+      Administrate::Config.admin_directory,
       model.class.to_s.underscore.pluralize,
       model.to_param,
     ].join("/")


### PR DESCRIPTION
Why:

* For existing application this could be problematic, especially with
  name collisions

This change addresses the need by:

* Allowing the installation directory to be configured in the app, only
  once and uses that any time a generator is called. It could be
  configured like this:

```ruby
Administrate.configure do |config|
  config.admin_directory = "administrate"
end
```

Re-opened from #330 because I changed the branches in my repo and had to close it.