### PR TITLE
Have Hound ignore `spec/example_app/db/schema.rb`

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,5 @@
+ruby:
+  config_file: .ruby-style.yml
 scss:
   enabled: true
   config_file: .scss-lint.yml

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Exclude:
+    - "spec/example_app/db/schema.rb"


### PR DESCRIPTION
## Problem:

By default, Hound ignores `db/schema.rb` because it's a generated file.
When we moved our demo app into `spec/example_app`,
Hound started paying attention to the schema file.

## Solution:

Add a custom `.ruby-style` file
that ignores the schema file in its new location.