### PR TITLE
Fix padding on input[type='file']

### DIFF
--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -71,7 +71,7 @@ input[type="radio"] {
 }
 
 input[type="file"] {
-  padding-bottom: $base-spacing / 2;
+  padding-bottom: ($base-spacing / 4) 0;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -71,7 +71,7 @@ input[type="radio"] {
 }
 
 input[type="file"] {
-  padding-bottom: ($base-spacing / 4) 0;
+  padding: ($base-spacing / 4) 0;
   width: 100%;
 }
 


### PR DESCRIPTION
All of the padding on the `input[type='file']` was on the bottom previously, causing the button to align above the center of the label. It was fixed by splitting the padding between the top and bottom.

Before ![before](http://cloud.coneybeare.me/e5Nk/Screen%20Shot%202015-12-14%20at%2010.58.02%20PM.jpg)

After (Safari) ![after safari](http://cloud.coneybeare.me/e5Be/Screen%20Shot%202015-12-14%20at%2011.01.39%20PM.jpg)

After (Chrome) ![after chrome](http://cloud.coneybeare.me/e54c/Screen%20Shot%202015-12-14%20at%2011.02.23%20PM.jpg)