### PR TITLE
Use Kaminari syntax in controller's comment hint

### DIFF
--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -5,7 +5,9 @@ module Admin
     #
     # def index
     #   super
-    #   @resources = <%= class_name %>.all.paginate(10, params[:page])
+    #   @resources = <%= class_name %>.
+    #     page(params[:page]).
+    #     per(10)
     # end
 
     # Define a custom finder by overriding the `find_resource` method:


### PR DESCRIPTION
Wrap the method chain onto multiple lines because it's likely
the developer will want to add some `order` details or other scopes
to the chain.
