### PR TITLE
Don't hard-code Administrate's URL namespace

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -37,7 +37,7 @@ module Administrate
 
       if resource.save
         redirect_to(
-          [Administrate::NAMESPACE, resource],
+          [namespace, resource],
           notice: translate_with_resource("create.success"),
         )
       else
@@ -50,7 +50,7 @@ module Administrate
     def update
       if requested_resource.update(resource_params)
         redirect_to(
-          [Administrate::NAMESPACE, requested_resource],
+          [namespace, requested_resource],
           notice: translate_with_resource("update.success"),
         )
       else
@@ -105,7 +105,8 @@ module Administrate
       dashboard.permitted_attributes
     end
 
-    delegate :resource_class, :resource_name, to: :resource_resolver
+    delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
+    helper_method :namespace
 
     def resource_resolver
       @_resource_resolver ||=

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -47,7 +47,7 @@ to display a collection of resources in an HTML table.
       <tr class="table__row"
           role="link"
           tabindex="0"
-          data-url="<%= polymorphic_path([Administrate::NAMESPACE, resource]) -%>"
+          data-url="<%= polymorphic_path([namespace, resource]) -%>"
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
@@ -57,13 +57,13 @@ to display a collection of resources in an HTML table.
 
         <td><%= link_to(
           t("administrate.actions.edit"),
-          [:edit, Administrate::NAMESPACE, resource],
+          [:edit, namespace, resource],
           class: "action-edit",
         ) %></td>
 
         <td><%= link_to(
           t("administrate.actions.destroy"),
-          [Administrate::NAMESPACE, resource],
+          [namespace, resource],
           class: "table__action--destroy",
           method: :delete,
           data: { confirm: t("administrate.actions.confirm") }

--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -14,7 +14,7 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([Administrate::NAMESPACE, page.resource], html: { class: "form" }) do |f| %>
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -12,7 +12,7 @@ as defined by the DashboardManifest.
     <li>
       <%= link_to(
         display_resource_name(resource),
-        [Administrate::NAMESPACE, resource],
+        [namespace, resource],
         class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
       ) %>
     </li>

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -22,7 +22,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
   <div class="header-actions">
     <%= link_to(
       "Show #{page.page_title}",
-      [Administrate::NAMESPACE, page.resource],
+      [namespace, page.resource],
       class: "button",
     ) %>
   </div>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -48,7 +48,7 @@ It renders the `_table` partial to display details about the resources.
   <div class="header-actions">
     <%= link_to(
       "New #{page.resource_name.titleize.downcase}",
-      [:new, Administrate::NAMESPACE, page.resource_name],
+      [:new, namespace, page.resource_name],
       class: "button",
     ) %>
   </div>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -23,7 +23,7 @@ as well as a link to its edit page.
   <div class="header-actions">
     <%= link_to(
       "Edit",
-      [:edit, Administrate::NAMESPACE, page.resource],
+      [:edit, namespace, page.resource],
       class: "button",
     ) %>
   </div>

--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [namespace, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [namespace, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [namespace, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -18,6 +18,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [namespace, field.data],
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data]
+    [namespace, field.data]
   ) %>
 <% end %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -19,6 +19,6 @@ By default, the relationship is rendered as a link to the associated object.
 <% if field.data %>
   <%= link_to(
     field.display_associated_resource,
-    [Administrate::NAMESPACE, field.data],
+    [namespace, field.data],
   ) %>
 <% end %>

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -9,7 +9,6 @@ require "sass-rails"
 require "selectize-rails"
 require "sprockets/railtie"
 
-require "administrate/namespace"
 require "administrate/page/form"
 require "administrate/page/show"
 require "administrate/page/collection"

--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -1,3 +1,0 @@
-module Administrate
-  NAMESPACE = :admin
-end

--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -1,5 +1,3 @@
-require "administrate/namespace"
-
 module Administrate
   class ResourceResolver
     def initialize(controller_path)
@@ -8,6 +6,10 @@ module Administrate
 
     def dashboard_class
       Object.const_get(resource_class_name + "Dashboard")
+    end
+
+    def namespace
+      controller_path.split("/").first
     end
 
     def resource_class
@@ -33,7 +35,7 @@ module Administrate
     end
 
     def controller_path_parts
-      controller_path.singularize.split("/") - [Administrate::NAMESPACE.to_s]
+      controller_path.singularize.split("/")[1..-1]
     end
 
     attr_reader :controller_path

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "fields/has_one/_index", type: :view do
-  context "without an associated records" do
+  context "without an associated record" do
     it "displays nothing" do
       has_one = double(data: nil)
 
@@ -26,7 +26,7 @@ describe "fields/has_one/_index", type: :view do
 
       render(
         partial: "fields/has_one/index.html.erb",
-        locals: { field: has_one },
+        locals: { field: has_one, namespace: "admin" },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "administrate/fields/has_one"
 
 describe "fields/has_one/_show", type: :view do
-  context "without an associated records" do
+  context "without an associated record" do
     it "displays nothing" do
       has_one = instance_double(
         "Administrate::Field::HasOne",
@@ -31,7 +31,7 @@ describe "fields/has_one/_show", type: :view do
 
       render(
         partial: "fields/has_one/show.html.erb",
-        locals: { field: has_one },
+        locals: { field: has_one, namespace: "admin" },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/polymorphic/_index_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_index_spec.rb
@@ -26,7 +26,7 @@ describe "fields/polymorphic/_index", type: :view do
 
       render(
         partial: "fields/polymorphic/index.html.erb",
-        locals: { field: polymorphic },
+        locals: { field: polymorphic, namespace: "admin" },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -31,7 +31,7 @@ describe "fields/polymorphic/_show", type: :view do
 
       render(
         partial: "fields/polymorphic/show.html.erb",
-        locals: { field: polymorphic },
+        locals: { field: polymorphic, namespace: "admin" },
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/lib/administrate/resource_resolver_spec.rb
+++ b/spec/lib/administrate/resource_resolver_spec.rb
@@ -1,32 +1,9 @@
 require "spec_helper"
+require "active_support/core_ext/string/inflections"
 require "support/constant_helpers"
 require "administrate/resource_resolver"
 
 describe Administrate::ResourceResolver do
-  describe "#resource_class" do
-    it "handles global-namepsace models" do
-      begin
-        class User; end
-        resolver = Administrate::ResourceResolver.new("admin/users")
-
-        expect(resolver.resource_class).to eq(User)
-      ensure
-        remove_constants :User
-      end
-    end
-
-    it "handles namespaced models" do
-      begin
-        module Blog; class Post; end; end
-        resolver = Administrate::ResourceResolver.new("admin/blog/posts")
-
-        expect(resolver.resource_class).to eq(Blog::Post)
-      ensure
-        remove_constants :Blog
-      end
-    end
-  end
-
   describe "#dashboard_class" do
     it "handles global-namepsace models" do
       begin
@@ -45,6 +22,38 @@ describe Administrate::ResourceResolver do
         resolver = Administrate::ResourceResolver.new("admin/blog/posts")
 
         expect(resolver.dashboard_class).to eq(Blog::PostDashboard)
+      ensure
+        remove_constants :Blog
+      end
+    end
+  end
+
+  describe "#namespace" do
+    it "returns the top-level namespace" do
+      resolver = Administrate::ResourceResolver.new("foobar/user")
+
+      expect(resolver.namespace).to eq("foobar")
+    end
+  end
+
+  describe "#resource_class" do
+    it "handles global-namepsace models" do
+      begin
+        class User; end
+        resolver = Administrate::ResourceResolver.new("admin/users")
+
+        expect(resolver.resource_class).to eq(User)
+      ensure
+        remove_constants :User
+      end
+    end
+
+    it "handles namespaced models" do
+      begin
+        module Blog; class Post; end; end
+        resolver = Administrate::ResourceResolver.new("admin/blog/posts")
+
+        expect(resolver.resource_class).to eq(Blog::Post)
       ensure
         remove_constants :Blog
       end

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -17,7 +17,7 @@ module Features
 
   def url_for(model)
     "/" + [
-      Administrate::NAMESPACE,
+      :admin,
       model.class.to_s.underscore.pluralize,
       model.to_param,
     ].join("/")


### PR DESCRIPTION
Closes #281 
Related to #330, #332.

## Problem:

Administrate requires that its dashboards be mounted at `/admin`.

In applications with an `Admin` model, Administrate will cause an error because it will try to define `Admin` as a module when it's already been defined as a class.

The hard-coded namespace limits users' freedom in defining their own URL schema, and prevents users from mounting multiple Administrate dashboards at once.

## Solution:

Dynamically evaluate Administrate's namespace from the request's URL.  This dynamically calculated value is used for all links and redirects in Administrate dashboards.

The namespace is now only set by generators.  If a user wants to change their namespace away from the default of `admin`, they must run the generators and manually change `admin` to the namespace of their choice.

## Next Steps:

Change generators to accept (or read from some configuration file) an optional namespace argument instead of always using the `admin` namespace.