### PR TITLE
Stub out sidebar generator in layout gen tests

### DIFF
--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -5,6 +5,7 @@ require "support/generator_spec_helpers"
 describe Administrate::Generators::Views::LayoutGenerator, :generator do
   describe "administrate:views:layout" do
     it "copies the layout template into the `admin/application` namespace" do
+      allow(Rails::Generators).to receive(:invoke)
       expected_contents = File.read(
         "app/views/layouts/administrate/application.html.erb",
       )
@@ -16,6 +17,7 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
     end
 
     it "copies the flashes partial into the `admin/application` namespace" do
+      allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_flashes")
       generated_file = file("app/views/admin/application/_flashes.html.erb")
 
@@ -35,6 +37,7 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
     end
 
     it "copies the javascript partial into the `admin/application` namespace" do
+      allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_javascript")
       generated_file = file("app/views/admin/application/_javascript.html.erb")
 


### PR DESCRIPTION
Follow-up to #328.

## Problem:

When the layout generator invokes the sidebar generator,
the tests do not recognize the file created by the sidebar generator,
and the file does not get cleaned up after the test.

## Solution:

Stub out the invocation of the sidebar generator
when we're testing the layout generator.