### PR TITLE
Allow showing a belongs to relation without a dashboard

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -42,5 +42,11 @@ module Administrate
     def clear_search_params
       params.except(:search, :page).permit(:order, :direction, :per_page)
     end
+
+    def link_to_if_route_exists(text, *routing_args)
+      link_to text, *routing_args
+    rescue StandardError
+      text
+    end
   end
 end

--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -17,7 +17,7 @@ By default, the relationship is rendered as a link to the associated object.
 
 <% if field.data %>
   <% if valid_action?(:show, field.attribute) %>
-    <%= link_to(
+    <%= link_to_if_route_exists(
       field.display_associated_resource,
       [namespace, field.data],
     ) %>

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -17,7 +17,7 @@ By default, the relationship is rendered as a link to the associated object.
 
 <% if field.data %>
   <% if valid_action?(:show, field.attribute) %>
-    <%= link_to(
+    <%= link_to_if_route_exists(
       field.display_associated_resource,
       [namespace, field.data],
     ) %>


### PR DESCRIPTION
Why:
- We might not want to have a Dashboard for all models listed, but still be
  able to show their representation on the show page of some other
  model. For instance, we might want to show a user's role name, but not
  be able to edit them.

This change addresses the need by:
- Showing the resource display if rails fails to create a link to it.
