### PR TITLE
Update Nokogiri for a security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
     percy-capybara (1.0.0)


### PR DESCRIPTION
## Problem:

Running `bundle-audit` gives a security warning:

```
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
 Already up-to-date.
 ruby-advisory-db: 239 advisories
 Name: nokogiri
 Version: 1.6.7
 Advisory: CVE-2015-5312
 Criticality: High
 URL:
 https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
 Title: Nokogiri gem contains several vulnerabilities in libxml2
 Solution: upgrade to >= 1.6.7.1
 ```

## Solution:

Update nokogiri to `1.6.7.1` with `bundle update nokogiri`.