### PR TITLE
Remove database host config for Linux support

### DIFF
--- a/spec/example_app/config/database.yml
+++ b/spec/example_app/config/database.yml
@@ -2,7 +2,6 @@ development: &default
   adapter: postgresql
   database: administrate-prototype_development
   encoding: utf8
-  host: localhost
   min_messages: warning
   pool: 2
   timeout: 5000


### PR DESCRIPTION
Fixes #296.

## Problem:

Ubuntu (and possibly other Linux distributions)
don't recognize `localhost` as a valid host parameter
in `config/database.yml`.

Running `bin/setup` gives them the error:

```
Couldn't create database for {"adapter"=>"postgresql",
"database"=>"administrate-prototype_development",
"encoding"=>"utf8",
"host"=>"localhost",
"min_messages"=>"warning",
"pool"=>2,
"timeout"=>5000}
```

## Solution:

Remove the `host` key from `config/database.yml`.

Without the `host` key, OS X defaults to `localhost`
and Ubuntu defaults to its Linux-y equivalent.