### PR TITLE
Generate SHOW_PAGE_ATTRIBUTES as an explicit array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * [#269] [FEATURE] Add a generator for copying default layout files
 * [#328] [FEATURE] Add a generator for copying default sidebar partial
 * [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
+* [#364] [FEATURE] Improve dashboard generator by explicitly listing out the
+  generated `SHOW_PAGE_ATTRIBUTES` array elements.
 * [#297] [I18n] Add Italian translations
 * [#307] [I18n] Fix German grammatical errors
 

--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -28,7 +28,13 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+  SHOW_PAGE_ATTRIBUTES = [
+<%=
+  attributes.map do |attr|
+    "    :#{attr},"
+  end.join("\n")
+%>
+  ]
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -397,6 +397,31 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     end
   end
 
+  describe "SHOW_PAGE_ATTRIBUTES" do
+    it "includes all attributes" do
+      begin
+        ActiveRecord::Schema.define do
+          create_table :foos do |t|
+            t.string :name
+            t.timestamps
+          end
+        end
+
+        class Foo < ActiveRecord::Base
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+
+        attrs = FooDashboard::SHOW_PAGE_ATTRIBUTES
+        expect(attrs).to match_array([:name, :id, :created_at, :updated_at])
+      ensure
+        remove_constants :Foo, :FooDashboard
+      end
+    end
+  end
+
   describe "resource controller" do
     it "has valid syntax" do
       controller = file("app/controllers/admin/customers_controller.rb")


### PR DESCRIPTION
Closes #130

## Problem:

The dashboard generator specifies:

```ruby
SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
```

This means that the order of the show page attributes
is dependent on the order of keys in the `ATTRIBUTE_TYPES` hash.

Ruby hashes happen to be ordered,
but we shouldn't make an assumption that hashes are ordered
because that is not a property that hashes are designed to have.

## Solution:

Because we assume that users will be editing `SHOW_PAGE_ATTRIBUTES`
to customize the contents and order of show page attributes,
we'll generate an explicit array for them to modify.