### PR TITLE
Fix sidebar__link:last-child

### DIFF
--- a/app/assets/stylesheets/administrate/components/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/components/_sidebar.scss
@@ -6,14 +6,14 @@
 
   &__item {
     &:last-child {
-      padding-bottom: $base-spacing;
+      margin-bottom: $base-spacing;
     }
   }
 
   &__link {
     color: $base-font-color;
     display: block;
-    padding-top: $base-spacing;
+    margin-top: $base-spacing;
     transition: color 0.05s linear;
 
     &--active {

--- a/app/assets/stylesheets/administrate/components/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/components/_sidebar.scss
@@ -4,15 +4,17 @@
   overflow-y: auto;
   padding: 0 $base-spacing;
 
+  &__item {
+    &:last-child {
+      padding-bottom: $base-spacing;
+    }
+  }
+
   &__link {
     color: $base-font-color;
     display: block;
     padding-top: $base-spacing;
     transition: color 0.05s linear;
-
-    &:last-child {
-      padding-bottom: $base-spacing;
-    }
 
     &--active {
       color: $blue;

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -9,7 +9,7 @@ as defined by the DashboardManifest.
 
 <ul class="sidebar__list">
   <% DashboardManifest::DASHBOARDS.each do |resource| %>
-    <li>
+    <li class="sidebar__item">
       <%= link_to(
         display_resource_name(resource),
         [namespace, resource],


### PR DESCRIPTION
Hi all!

The `&:last-child` in the `sidebar__link` wasn't working properly since the link is inside an `li` so it's always the last item and the padding was always applied and the space between items was too big.

I solved it by adding a new class `sidebar__item` to the `li` and moving the `:last-child` to it. I also changed the paddings to margins, so you only can click the item when you press the link and not the space above it.