### PR TITLE
use before_action instead of before_filter

### DIFF
--- a/lib/generators/administrate/install/templates/application_controller.rb
+++ b/lib/generators/administrate/install/templates/application_controller.rb
@@ -1,12 +1,12 @@
 # All Administrate controllers inherit from this `Admin::ApplicationController`,
 # making it the ideal place to put authentication logic or other
-# before_filters.
+# before_actions.
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_filter :authenticate_admin
+    before_action :authenticate_admin
 
     def authenticate_admin
       # TODO Add authentication logic here.

--- a/spec/example_app/app/controllers/admin/application_controller.rb
+++ b/spec/example_app/app/controllers/admin/application_controller.rb
@@ -1,11 +1,11 @@
 # All Administrate controllers inherit from this `Admin::ApplicationController`,
 # making it the ideal place to put authentication logic or other
-# before_filters.
+# before_actions.
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
 class Admin::ApplicationController < Administrate::ApplicationController
-  before_filter :authenticate_admin
+  before_action :authenticate_admin
 
   def authenticate_admin
     # TODO Add authentication logic here.


### PR DESCRIPTION
`before_filter` is deprecated and we should probably be using `before_action` to help with a Rails 5 update.

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```