### PR TITLE
Add lang attribute to html element

### DIFF
--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -13,7 +13,7 @@ By default, it renders:
 %>
 
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />


### PR DESCRIPTION
Improves accessibility, among other things like assisting user agents in providing definitions using a dictionary.