### PR TITLE
Associate fields with original resource

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -16,8 +16,9 @@ module Administrate
         false
       end
 
-      def initialize(attribute, data, page, options = {})
+      def initialize(attribute, resource, data, page, options = {})
         @attribute = attribute
+        @resource = resource
         @data = data
         @page = page
         @options = options
@@ -39,7 +40,7 @@ module Administrate
         "/fields/#{self.class.field_type}/#{page}"
       end
 
-      attr_reader :attribute, :data, :page
+      attr_reader :attribute, :resource, :data, :page
 
       protected
 

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -16,7 +16,7 @@ module Administrate
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)
         field = dashboard.attribute_type_for(attribute_name)
-        field.new(attribute_name, value, page)
+        field.new(attribute_name, resource, value, page)
       end
 
       def get_attribute_value(resource, attribute_name)

--- a/spec/generators/field_generator_spec.rb
+++ b/spec/generators/field_generator_spec.rb
@@ -9,7 +9,7 @@ describe Administrate::Generators::FieldGenerator, :generator do
         run_generator ["foobar"]
 
         load file("app/fields/foobar_field.rb")
-        field = FoobarField.new(:attr_name, "value", "show")
+        field = FoobarField.new(:attr_name, nil, "value", "show")
 
         expect(field.name).to eq("attr_name")
         expect(field.data).to eq("value")

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -11,7 +11,7 @@ describe Administrate::Field::BelongsTo do
     it "returns a partial based on the page being rendered" do
       page = :show
       owner = double
-      field = Administrate::Field::BelongsTo.new(:owner, owner, page)
+      field = Administrate::Field::BelongsTo.new(:owner, nil, owner, page)
 
       path = field.to_partial_path
 
@@ -27,7 +27,7 @@ describe Administrate::Field::BelongsTo do
 
         association = Administrate::Field::BelongsTo.
           with_options(class_name: "Foo")
-        field = association.new(:customers, [], :show)
+        field = association.new(:customers, nil, [], :show)
         candidates = field.associated_resource_options
 
         expect(Foo).to have_received(:all)

--- a/spec/lib/fields/boolean_spec.rb
+++ b/spec/lib/fields/boolean_spec.rb
@@ -9,7 +9,7 @@ describe Administrate::Field::Boolean do
     it "returns a partial based on the page being rendered" do
       page = :show
       boolean = double
-      field = Administrate::Field::Boolean.new(:price, boolean, page)
+      field = Administrate::Field::Boolean.new(:price, nil, boolean, page)
 
       path = field.to_partial_path
 
@@ -21,8 +21,8 @@ describe Administrate::Field::Boolean do
 
   describe "#to_s" do
     it "prints true or false" do
-      t = Administrate::Field::Boolean.new(:quantity, true, :show)
-      f = Administrate::Field::Boolean.new(:quantity, false, :show)
+      t = Administrate::Field::Boolean.new(:quantity, nil, true, :show)
+      f = Administrate::Field::Boolean.new(:quantity, nil, false, :show)
 
       expect(t.to_s).to eq("true")
       expect(f.to_s).to eq("false")
@@ -30,7 +30,7 @@ describe Administrate::Field::Boolean do
 
     context "when data is nil" do
       it "returns a dash" do
-        boolean = Administrate::Field::Boolean.new(:boolean, nil, :page)
+        boolean = Administrate::Field::Boolean.new(:boolean, nil, nil, :page)
 
         expect(boolean.to_s).to eq("-")
       end

--- a/spec/lib/fields/email_spec.rb
+++ b/spec/lib/fields/email_spec.rb
@@ -4,7 +4,8 @@ describe Administrate::Field::Email do
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show
-      field = Administrate::Field::Email.new(:email, "foo@example.com", page)
+      field = Administrate::Field::Email.new(:email, nil, "foo@example.com",
+                                             page)
 
       path = field.to_partial_path
 

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -7,7 +7,7 @@ describe Administrate::Field::HasMany do
     it "returns a partial based on the page being rendered" do
       page = :show
       items = double
-      field = Administrate::Field::HasMany.new(:items, items, page)
+      field = Administrate::Field::HasMany.new(:items, nil, items, page)
 
       path = field.to_partial_path
 
@@ -20,7 +20,7 @@ describe Administrate::Field::HasMany do
       begin
         WidgetDashboard = Class.new
         widgets = []
-        field = Administrate::Field::HasMany.new(:widgets, widgets, :show)
+        field = Administrate::Field::HasMany.new(:widgets, nil, widgets, :show)
 
         page = field.associated_collection
 
@@ -40,7 +40,7 @@ describe Administrate::Field::HasMany do
 
         association = Administrate::Field::HasMany.
           with_options(class_name: "Foo")
-        field = association.new(:customers, [], :show)
+        field = association.new(:customers, nil, [], :show)
         collection = field.associated_collection
         attributes = collection.attribute_names
 
@@ -58,7 +58,7 @@ describe Administrate::Field::HasMany do
       resources = MockRelation.new([:a] * (limit + 1))
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, nil, resources, :show)
 
       expect(field.more_than_limit?).to eq(true)
     end
@@ -68,7 +68,7 @@ describe Administrate::Field::HasMany do
       resources = MockRelation.new([:a] * limit)
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, nil, resources, :show)
 
       expect(field.more_than_limit?).to eq(false)
     end
@@ -80,7 +80,7 @@ describe Administrate::Field::HasMany do
       resources = MockRelation.new([:a] * (limit + 1))
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, nil, resources, :show)
 
       expect(field.resources).to eq([:a] * limit)
     end
@@ -90,7 +90,7 @@ describe Administrate::Field::HasMany do
         resources = MockRelation.new([:a, :b, :c])
 
         association = Administrate::Field::HasMany.with_options(limit: 1)
-        field = association.new(:customers, resources, :show)
+        field = association.new(:customers, nil, resources, :show)
 
         expect(field.resources).to eq([:a])
       end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -6,7 +6,7 @@ describe Administrate::Field::HasOne do
     it "returns a partial based on the page being rendered" do
       page = :show
       owner = double
-      field = Administrate::Field::HasOne.new(:owner, owner, page)
+      field = Administrate::Field::HasOne.new(:owner, nil, owner, page)
 
       path = field.to_partial_path
 

--- a/spec/lib/fields/image_spec.rb
+++ b/spec/lib/fields/image_spec.rb
@@ -4,7 +4,7 @@ describe Administrate::Field::Image do
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show
-      field = Administrate::Field::Image.new(:image, "/a.jpg", page)
+      field = Administrate::Field::Image.new(:image, nil, "/a.jpg", page)
 
       path = field.to_partial_path
 

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -8,7 +8,7 @@ describe Administrate::Field::Number do
     it "returns a partial based on the page being rendered" do
       page = :show
       number = double
-      field = Administrate::Field::Number.new(:price, number, page)
+      field = Administrate::Field::Number.new(:price, nil, number, page)
 
       path = field.to_partial_path
 
@@ -20,8 +20,8 @@ describe Administrate::Field::Number do
 
   describe "#to_s" do
     it "defaults to displaying no decimal points" do
-      int = Administrate::Field::Number.new(:quantity, 3, :show)
-      float = Administrate::Field::Number.new(:quantity, 3.1415926, :show)
+      int = Administrate::Field::Number.new(:quantity, nil, 3, :show)
+      float = Administrate::Field::Number.new(:quantity, nil, 3.1415926, :show)
 
       expect(int.to_s).to eq("3")
       expect(float.to_s).to eq("3")
@@ -55,14 +55,14 @@ describe Administrate::Field::Number do
 
     context "when data is nil" do
       it "returns a dash" do
-        number = Administrate::Field::Number.new(:number, nil, :page)
+        number = Administrate::Field::Number.new(:number, nil, nil, :page)
 
         expect(number.to_s).to eq("-")
       end
     end
 
     def number_with_options(num, options)
-      Administrate::Field::Number.new(:number, num, :page, options)
+      Administrate::Field::Number.new(:number, nil, num, :page, options)
     end
   end
 end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -8,7 +8,7 @@ describe Administrate::Field::Polymorphic do
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show
-      field = Administrate::Field::Polymorphic.new(:foo, "hello", page)
+      field = Administrate::Field::Polymorphic.new(:foo, nil, "hello", page)
 
       path = field.to_partial_path
 
@@ -28,7 +28,8 @@ describe Administrate::Field::Polymorphic do
           end
         end
 
-        field = Administrate::Field::Polymorphic.new(:foo, Thing.new, :show)
+        field = Administrate::Field::Polymorphic.new(:foo, nil, Thing.new,
+                                                     :show)
         display = field.display_associated_resource
 
         expect(display).to eq :success

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -7,7 +7,7 @@ describe Administrate::Field::String do
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show
-      field = Administrate::Field::String.new(:string, "hello", page)
+      field = Administrate::Field::String.new(:string, nil, "hello", page)
 
       path = field.to_partial_path
 
@@ -19,14 +19,15 @@ describe Administrate::Field::String do
 
   describe "#truncate" do
     it "renders an empty string for nil" do
-      string = Administrate::Field::String.new(:description, nil, :show)
+      string = Administrate::Field::String.new(:description, nil, nil, :show)
 
       expect(string.truncate).to eq("")
     end
 
     it "defaults to displaying up to 50 characters" do
-      short = Administrate::Field::String.new(:title, lorem(30), :show)
-      long = Administrate::Field::String.new(:description, lorem(60), :show)
+      short = Administrate::Field::String.new(:title, nil, lorem(30), :show)
+      long = Administrate::Field::String.new(:description, nil, lorem(60),
+                                             :show)
 
       expect(short.truncate).to eq(lorem(30))
       expect(long.truncate).to eq(lorem(50))
@@ -42,7 +43,7 @@ describe Administrate::Field::String do
   end
 
   def string_with_options(string, options)
-    Administrate::Field::String.new(:string, string, :page, options)
+    Administrate::Field::String.new(:string, nil, string, :page, options)
   end
 
   def lorem(n)


### PR DESCRIPTION
This pull request adds a `resource` field to the Field class. This gives more flexibility to field views, allowing it to customize its display based on the original resource. For example, this will allow fields to display content based on two different columns.

My use case is as follows. My system has many Products. Each Product has a `name` (which is an internal name) and an optional `display_name`. I want to display the product name as follows:

```
product name here
(optional display name here) <--- this line is only shown if display_name is not nil
```

With this pull request, I'm able to write a view like this:

```
<%= field.resource.name %>
<% if field.resource.display_name %>
  <br>
  <small><%= field.resource.display_name %></small>
<% end %>
```
