### PR TITLE
Administrate::Search: ensure that column names are quoted

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -21,7 +21,10 @@ module Administrate
     delegate :resource_class, to: :resolver
 
     def query
-      search_attributes.map { |attr| "lower(#{attr}) LIKE ?" }.join(" OR ")
+      conditions = search_attributes.map do |attr|
+        "lower(#{quote_attr(attr)}) LIKE ?"
+      end
+      conditions.join(" OR ")
     end
 
     def search_terms
@@ -36,6 +39,10 @@ module Administrate
 
     def attribute_types
       resolver.dashboard_class::ATTRIBUTE_TYPES
+    end
+
+    def quote_attr(attr)
+      resource_class.connection.quote_column_name(attr)
     end
 
     attr_reader :resolver, :term

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -43,11 +43,17 @@ describe Administrate::Search do
 
     it "searches using lower() + LIKE for all searchable fields" do
       begin
-        class User; end
+        class User
+          def self.connection
+            ActiveRecord::Base.connection
+          end
+        end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "test")
+        quoted_name = quote_attr(:name)
+        quoted_email = quote_attr(:email)
         expected_query = [
-          "lower(name) LIKE ? OR lower(email) LIKE ?",
+          "lower(#{quoted_name}) LIKE ? OR lower(#{quoted_email}) LIKE ?",
           "%test%",
           "%test%",
         ]
@@ -57,6 +63,10 @@ describe Administrate::Search do
       ensure
         remove_constants :User
       end
+    end
+
+    def quote_attr(attr)
+      ActiveRecord::Base.connection.quote_column_name(attr)
     end
   end
 end


### PR DESCRIPTION
One of my tables has a column named `group`, which is a keyword in PostgreSQL. This breaks search. This pull request ensures that column names in searches are quoted, which fixes this problem.
