### PR TITLE
Ensure that collection rows are proper links

### DIFF
--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -47,3 +47,20 @@
 .cell-label--number {
   text-align: right;
 }
+
+.cell-link {
+  color: inherit;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.cell-action-link {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+}

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -56,20 +56,22 @@ to display a collection of resources in an HTML table.
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <%= render_field attribute %>
+            <%= link_to render_field(attribute),
+                        polymorphic_path([namespace, resource]),
+                        class: 'cell-link' %>
           </td>
         <% end %>
 
-        <td><%= link_to(
+        <td class="cell-action"><%= link_to(
           t("administrate.actions.edit"),
           [:edit, namespace, resource],
-          class: "action-edit",
+          class: "cell-action-link action-edit",
         ) %></td>
 
-        <td><%= link_to(
+        <td class="cell-action"><%= link_to(
           t("administrate.actions.destroy"),
           [namespace, resource],
-          class: "table__action--destroy",
+          class: "cell-action-link table__action--destroy",
           method: :delete,
           data: { confirm: t("administrate.actions.confirm") }
         ) %></td>


### PR DESCRIPTION
Collection rows were fake links simulated by JavaScript. This breaks browsers that have JavaScript disabled, and also breaks middleclick and 'right click -> Open in New Tab'. This commit turns collection rows into proper links.
