### PR TITLE
Update docs with correct view paths

### DIFF
--- a/docs/customizing_page_views.md
+++ b/docs/customizing_page_views.md
@@ -11,19 +11,19 @@ call the generators with no arguments.
 
 ```bash
 rails generate administrate:views:index
- # -> app/views/administrate/application/index.html.erb
- # -> app/views/administrate/application/_table.html.erb
+ # -> app/views/admin/application/index.html.erb
+ # -> app/views/admin/application/_table.html.erb
 
 rails generate administrate:views:show
- # -> app/views/administrate/application/show.html.erb
+ # -> app/views/admin/application/show.html.erb
 
 rails generate administrate:views:edit
- # -> app/views/administrate/application/edit.html.erb
- # -> app/views/administrate/application/_form.html.erb
+ # -> app/views/admin/application/edit.html.erb
+ # -> app/views/admin/application/_form.html.erb
 
 rails generate administrate:views:new
- # -> app/views/administrate/application/new.html.erb
- # -> app/views/administrate/application/_form.html.erb
+ # -> app/views/admin/application/new.html.erb
+ # -> app/views/admin/application/_form.html.erb
 
 rails generate administrate:views
  # -> all of the above
@@ -42,19 +42,19 @@ pass in the resource name to the view generators.
 
 ```bash
 rails generate administrate:views:index User
- # -> app/views/administrate/users/index.html.erb
- # -> app/views/administrate/users/_table.html.erb
+ # -> app/views/admin/users/index.html.erb
+ # -> app/views/admin/users/_table.html.erb
 
 rails generate administrate:views:show User
- # -> app/views/administrate/users/show.html.erb
+ # -> app/views/admin/users/show.html.erb
 
 rails generate administrate:views:edit User
- # -> app/views/administrate/users/edit.html.erb
- # -> app/views/administrate/users/_form.html.erb
+ # -> app/views/admin/users/edit.html.erb
+ # -> app/views/admin/users/_form.html.erb
 
 rails generate administrate:views:new User
- # -> app/views/administrate/users/new.html.erb
- # -> app/views/administrate/users/_form.html.erb
+ # -> app/views/admin/users/new.html.erb
+ # -> app/views/admin/users/_form.html.erb
 
 rails generate administrate:views User
  # -> all of the above


### PR DESCRIPTION
Closes #202

## Problem:

The documentation states that views will be generated in the `app/views/administrate/` directory, but they are actually generated in `app/views/admin/`.

## Solution:

(as stated in #202)

In fact, both paths work correctly for overriding views.

Rails looks up views based on the inheritance tree of your controllers. In this case, our inheritance tree looks like:

```
Administrate::ApplicationController
Admin::ApplicationController
Admin::CustomersController # base level
```

... so Rails will look for views in:

`app/views/admin/customers`,
THEN `app/views/admin/application`, THEN
`app/views/administrate/application`.

In the future, we'd like to support multiple admin dashboards in the same application, by nesting them under different namespaces (e.g. `app/views/admin` and `app/views/super_admin`). In that case, views under `app/views/administrate` would apply to *all* of the admin dashboards. Views under `app/views/admin` would only apply to the dashboard at the `/admin` route, and wouldn't affect the dashboard at `/super_admin`.

Because of this, we'd prefer to keep the generated views in `/admin`. We'll keep the current implementation, and update the documentation.