### PR TITLE
Applies a margin-bottom to attribute labels

### DIFF
--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -4,7 +4,6 @@
   clear: left;
   margin-top: 0;
   text-align: right;
-  clear: left;
   margin-bottom: $base-spacing;
 }
 

--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -4,6 +4,8 @@
   clear: left;
   margin-top: 0;
   text-align: right;
+  clear: left;
+  margin-bottom: $base-spacing;
 }
 
 .preserve-whitespace {


### PR DESCRIPTION
P.S.: Even with the known issues I present below, I still prefer this over the current version, which is why I chose to propose this. No hard feelings if it doesn't go through :smile: 

Why:
- When a `nil` attribute exists, the data element takes no height, which
  results in the row being too close to the next attribute.

This change addresses the need by:
- The spacing between each attribute was previously given by the
  `attribute-data` field. But when it has no height, that margin gets
  swallowed by the label. Applying the same margin to it helps
  to fix this

Known issues:
- `$spacing-base` is measured in `em`s. And since the label has a
  different font-size, this results in a slightly different margin, which
  will be noticeable in the same cases as in the original issue, but I
  guess a different margin is better than no margin.
- When the label spans multiple lines, an even larger spacing gets created

Before:
![screenshot from 2016-01-08 10-46-17](https://cloud.githubusercontent.com/assets/283819/12202402/8fa18116-b621-11e5-8ffd-2252ee9ced5c.png)

After:
![screenshot from 2016-01-08 16-07-41](https://cloud.githubusercontent.com/assets/283819/12202487/0b750fb0-b622-11e5-8459-f8171860efea.png)
