### PR TITLE
Fix timestamp deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
 * [#364] [FEATURE] Improve dashboard generator by explicitly listing out the
   generated `SHOW_PAGE_ATTRIBUTES` array elements.
+* [#390] [BUGFIX] Fix timestamp deprecation warnings
 * [#396] [I18n] Ukrainian
 * [#297] [I18n] Add Italian translations
 * [#307] [I18n] Fix German grammatical errors

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -377,7 +377,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           ActiveRecord::Schema.define do
             create_table :foos do |t|
               t.string :name
-              t.timestamps
+              t.timestamps null: true
             end
           end
 
@@ -403,7 +403,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         ActiveRecord::Schema.define do
           create_table :foos do |t|
             t.string :name
-            t.timestamps
+            t.timestamps null: true
           end
         end
 


### PR DESCRIPTION
Tiny PR to fix the deprecation warning when specs are run.