### PR TITLE
Allow linkable element on row and shouldn't go to show page

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -6,10 +6,15 @@ $(function() {
         event.keyCode == keycodes.space ||
         event.keyCode == keycodes.enter) {
 
-      if(!event.target.href) {
+      if(!isLinkableElement(event.target)) {
         window.location = $(event.target).closest("tr").data("url");
       }
     }
+  };
+
+  var isLinkableElement = function(element) {
+    return (event.target.href ||
+            $(element).closest(".cell-data--linkable").length > 0);
   };
 
   $("table").on("click", ".table__row", visitDataUrl);


### PR DESCRIPTION
See https://github.com/thoughtbot/administrate/issues/388

The previous problem that I had when I tried to have a column which is
clickable user's thumbnail that should go to their fecebook profile.
Unfortunately, when user clicks on thumbnail it opens facebook profile
page which is correct, but it also redirects user to show page as always
when user clicks on row.

The solution, whenever the column marks with `cell-data--linkable`, then
we assume content in that column will contain linkable elements which we
don't need to have the behaviour that always go to show page when they
click on that row.
