### PR TITLE
Upgrade to Rails 5.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---format Fuubar

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github){ |repo_name| "https://github.com/#{repo_name}" } if respond_to?(:git_source)
 
 ruby "2.2.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,15 +23,32 @@ group :development, :test do
   gem "faker"
   gem "i18n-tasks"
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.1.0"
+
+  # Using edge rspec to get rid of deprecation warnings about
+  # fixtures and compatibility with rails-controller-testing.
+  %w(core support expectations mocks rails).each do |part|
+    gem "rspec-#{part}", github: "rspec/rspec-#{part}"
+  end
 end
 
 group :test do
+  # Rails 5 requires unreleased fixes in capybara
+  # see https://github.com/jnicklas/capybara/issues/1592
+  gem "capybara", github: "jnicklas/capybara"
+
+  # We need unreleased Kaminari 0.17 for Rails 5 support
+  # see https://github.com/amatsuda/kaminari/issues/759
+  gem "kaminari", github: "amatsuda/kaminari", ref: "0-17-stable"
+
+  # We also need master of rails-controller-testing for Rails 5
+  gem "rails-controller-testing", github: "rails/rails-controller-testing"
+
   gem "ammeter"
   gem "database_cleaner"
   gem "formulaic"
-  gem "fuubar"
   gem "launchy"
+  # Fuubar requires rspec ~> 3.0
+  # gem "fuubar"
   gem "percy-capybara"
   gem "poltergeist"
   gem "shoulda-matchers", "~> 2.8.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/amatsuda/kaminari.git
+  remote: https://github.com/amatsuda/kaminari
   revision: 1002b14aee62d4360c383ae1f14f5b5b72e76e2a
   ref: 0-17-stable
   specs:
@@ -8,7 +8,7 @@ GIT
       activesupport (>= 3.0.0)
 
 GIT
-  remote: git://github.com/jnicklas/capybara.git
+  remote: https://github.com/jnicklas/capybara
   revision: 4b3093f4bd12a682b41d8e88d3958d33e70f4662
   specs:
     capybara (2.6.0.dev)
@@ -19,7 +19,7 @@ GIT
       xpath (~> 2.0)
 
 GIT
-  remote: git://github.com/rails/rails-controller-testing.git
+  remote: https://github.com/rails/rails-controller-testing
   revision: 838b7e30d742cae8b3c7697f1a2970916e6b2f35
   specs:
     rails-controller-testing (0.0.3)
@@ -28,14 +28,14 @@ GIT
       activesupport (>= 4.2)
 
 GIT
-  remote: git://github.com/rspec/rspec-core.git
+  remote: https://github.com/rspec/rspec-core
   revision: 5800249ae9f15056f8457dfd257f778096b550a9
   specs:
     rspec-core (3.5.0.pre)
       rspec-support (= 3.5.0.pre)
 
 GIT
-  remote: git://github.com/rspec/rspec-expectations.git
+  remote: https://github.com/rspec/rspec-expectations
   revision: d17110bdd0dca2e8daa3339c0fcfafcc5dc31a9c
   specs:
     rspec-expectations (3.5.0.pre)
@@ -43,7 +43,7 @@ GIT
       rspec-support (= 3.5.0.pre)
 
 GIT
-  remote: git://github.com/rspec/rspec-mocks.git
+  remote: https://github.com/rspec/rspec-mocks
   revision: 7369e6b949585114bc1e9f20885d64a65f95cc31
   specs:
     rspec-mocks (3.5.0.pre)
@@ -51,7 +51,7 @@ GIT
       rspec-support (= 3.5.0.pre)
 
 GIT
-  remote: git://github.com/rspec/rspec-rails.git
+  remote: https://github.com/rspec/rspec-rails
   revision: b2ac99c4202245598f3a15f14aa22ae3cd1b66b7
   specs:
     rspec-rails (3.5.0.pre)
@@ -64,7 +64,7 @@ GIT
       rspec-support (= 3.5.0.pre)
 
 GIT
-  remote: git://github.com/rspec/rspec-support.git
+  remote: https://github.com/rspec/rspec-support
   revision: 4b938ec512d2fbee945913afbb957b510244ecb3
   specs:
     rspec-support (3.5.0.pre)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,74 @@
+GIT
+  remote: git://github.com/amatsuda/kaminari.git
+  revision: 1002b14aee62d4360c383ae1f14f5b5b72e76e2a
+  ref: 0-17-stable
+  specs:
+    kaminari (0.17.0.alpha)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
+
+GIT
+  remote: git://github.com/jnicklas/capybara.git
+  revision: 4b3093f4bd12a682b41d8e88d3958d33e70f4662
+  specs:
+    capybara (2.6.0.dev)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+
+GIT
+  remote: git://github.com/rails/rails-controller-testing.git
+  revision: 838b7e30d742cae8b3c7697f1a2970916e6b2f35
+  specs:
+    rails-controller-testing (0.0.3)
+      actionpack (>= 4.2)
+      actionview (>= 4.2)
+      activesupport (>= 4.2)
+
+GIT
+  remote: git://github.com/rspec/rspec-core.git
+  revision: 5800249ae9f15056f8457dfd257f778096b550a9
+  specs:
+    rspec-core (3.5.0.pre)
+      rspec-support (= 3.5.0.pre)
+
+GIT
+  remote: git://github.com/rspec/rspec-expectations.git
+  revision: d17110bdd0dca2e8daa3339c0fcfafcc5dc31a9c
+  specs:
+    rspec-expectations (3.5.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.5.0.pre)
+
+GIT
+  remote: git://github.com/rspec/rspec-mocks.git
+  revision: 7369e6b949585114bc1e9f20885d64a65f95cc31
+  specs:
+    rspec-mocks (3.5.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.5.0.pre)
+
+GIT
+  remote: git://github.com/rspec/rspec-rails.git
+  revision: b2ac99c4202245598f3a15f14aa22ae3cd1b66b7
+  specs:
+    rspec-rails (3.5.0.pre)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (= 3.5.0.pre)
+      rspec-expectations (= 3.5.0.pre)
+      rspec-mocks (= 3.5.0.pre)
+      rspec-support (= 3.5.0.pre)
+
+GIT
+  remote: git://github.com/rspec/rspec-support.git
+  revision: 4b938ec512d2fbee945913afbb957b510244ecb3
+  specs:
+    rspec-support (3.5.0.pre)
+
 PATH
   remote: .
   specs:
@@ -10,49 +81,58 @@ PATH
       momentjs-rails (~> 2.8)
       neat (~> 1.1)
       normalize-rails (~> 3.0)
-      rails (~> 4.2)
+      rails (>= 5.0.0.beta1)
       sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.2.2)
-      actionpack (= 4.2.2)
-      actionview (= 4.2.2)
-      activejob (= 4.2.2)
+    actioncable (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      celluloid (~> 0.17.2)
+      coffee-rails (~> 4.1.0)
+      em-hiredis (~> 0.3.0)
+      faye-websocket (~> 0.10.0)
+      redis (~> 3.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activejob (= 5.0.0.beta1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.2)
-      actionview (= 4.2.2)
-      activesupport (= 4.2.2)
-      rack (~> 1.6)
-      rack-test (~> 0.6.2)
+    actionpack (5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      rack (~> 2.x)
+      rack-test (~> 0.6.3)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    actionview (4.2.2)
-      activesupport (= 4.2.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    activejob (4.2.2)
-      activesupport (= 4.2.2)
-      globalid (>= 0.3.0)
-    activemodel (4.2.2)
-      activesupport (= 4.2.2)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      globalid (>= 0.3.6)
+    activemodel (5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       builder (~> 3.1)
-    activerecord (4.2.2)
-      activemodel (= 4.2.2)
-      activesupport (= 4.2.2)
-      arel (~> 6.0)
-    activesupport (4.2.2)
+    activerecord (5.0.0.beta1)
+      activemodel (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      arel (~> 7.0)
+    activesupport (5.0.0.beta1)
+      concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
+      method_source
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     ammeter (1.1.3)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -61,13 +141,12 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    arel (6.0.3)
-    autoprefixer-rails (6.1.2)
+    arel (7.0.0)
+    ast (2.2.0)
+    autoprefixer-rails (6.2.3)
       execjs
       json
     awesome_print (1.6.1)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bourbon (4.2.6)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -75,16 +154,35 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (6.0.2)
-    capybara (2.5.0)
-      mime-types (>= 1.16)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+    byebug (8.2.1)
+    celluloid (0.17.2)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.5)
+      timers (>= 4.1.1)
     cliver (0.3.2)
     coderay (1.1.0)
-    crack (0.4.2)
+    coffee-rails (4.1.1)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0, < 5.1.x)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.10.0)
+    concurrent-ruby (1.0.0)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
     datetime_picker_rails (0.0.6)
@@ -96,45 +194,52 @@ GEM
       activerecord (>= 3.0, < 5)
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.2.5)
-    dotenv (2.0.2)
-    dotenv-rails (2.0.2)
-      dotenv (= 2.0.2)
-      railties (~> 4.0)
+    dotenv (2.0.1)
+    dotenv-rails (2.0.1)
+      dotenv (= 2.0.1)
     easy_translate (0.5.0)
       json
       thread
       thread_safe
+    em-hiredis (0.3.0)
+      eventmachine (~> 1.0)
+      hiredis (~> 0.5.0)
     erubis (2.7.0)
+    eventmachine (1.0.8)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.5.0)
+    faker (1.6.1)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faye-websocket (0.10.2)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     formulaic (0.3.0)
       activesupport
       capybara
       i18n
-    fuubar (2.0.0)
-      rspec (~> 3.0)
-      ruby-progressbar (~> 1.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    hashdiff (0.2.2)
+    hashdiff (0.2.3)
     high_voltage (2.4.0)
     highline (1.7.8)
-    httpclient (2.7.0)
+    hiredis (0.5.2)
+    hitimes (1.2.3)
+    httpclient (2.7.1)
     i18n (0.7.0)
-    i18n-tasks (0.8.7)
-      activesupport (>= 2.3.18)
+    i18n-tasks (0.9.2)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
       easy_translate (>= 0.5.0)
       erubis
       highline (>= 1.7.3)
       i18n
+      parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
     inline_svg (0.6.1)
@@ -146,9 +251,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    kaminari (0.16.3)
-      actionpack (>= 3.0.0)
-      activesupport (>= 3.0.0)
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -157,10 +259,10 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.2)
+    mime-types (2.99)
     mini_portile2 (2.0.0)
-    minitest (5.8.1)
-    momentjs-rails (2.10.6)
+    minitest (5.8.3)
+    momentjs-rails (2.11.0)
       railties (>= 3.1)
     multi_json (1.11.2)
     multipart-post (2.0.0)
@@ -170,13 +272,15 @@ GEM
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
-    percy-capybara (1.0.0)
-      percy-client (>= 1.0.0)
-    percy-client (1.2.0)
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
+    percy-capybara (1.1.0)
+      percy-client (>= 1.3.0)
+    percy-client (1.3.0)
       faraday (>= 0.9)
       httpclient (>= 2.6)
-    pg (0.18.3)
-    poltergeist (1.7.0)
+    pg (0.18.4)
+    poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -187,21 +291,23 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    rack (1.6.4)
+    rack (2.0.0.alpha)
+      json
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.3.2)
-    rails (4.2.2)
-      actionmailer (= 4.2.2)
-      actionpack (= 4.2.2)
-      actionview (= 4.2.2)
-      activejob (= 4.2.2)
-      activemodel (= 4.2.2)
-      activerecord (= 4.2.2)
-      activesupport (= 4.2.2)
+    rails (5.0.0.beta1)
+      actioncable (= 5.0.0.beta1)
+      actionmailer (= 5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      actionview (= 5.0.0.beta1)
+      activejob (= 5.0.0.beta1)
+      activemodel (= 5.0.0.beta1)
+      activerecord (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.2)
-      sprockets-rails
+      railties (= 5.0.0.beta1)
+      sprockets-rails (>= 2.0.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -211,36 +317,17 @@ GEM
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
     rails_stdout_logging (0.0.4)
-    railties (4.2.2)
-      actionpack (= 4.2.2)
-      activesupport (= 4.2.2)
+    railties (5.0.0.beta1)
+      actionpack (= 5.0.0.beta1)
+      activesupport (= 5.0.0.beta1)
+      method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.4.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-rails (3.1.0)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
-    ruby-progressbar (1.7.5)
+    redis (3.2.2)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -251,36 +338,38 @@ GEM
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     slop (3.6.0)
-    sprockets (3.4.0)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     terminal-table (1.5.2)
     thor (0.19.1)
     thread (0.2.2)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (2.0.2)
     timecop (0.8.0)
-    tins (1.6.0)
+    timers (4.1.1)
+      hitimes
+    tins (1.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    unicorn (4.9.0)
+    unicorn (5.0.1)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    web-console (2.2.1)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-    webmock (1.22.1)
+    web-console (3.0.0)
+      activemodel (>= 4.2)
+      debug_inspector
+      railties (>= 4.2)
+    webmock (1.22.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -300,23 +389,29 @@ DEPENDENCIES
   awesome_print
   bundler-audit
   byebug
+  capybara!
   database_cleaner
   delayed_job_active_record
   dotenv-rails
   factory_girl_rails
   faker
   formulaic
-  fuubar
   high_voltage
   i18n-tasks
+  kaminari!
   launchy
   percy-capybara
   pg
   poltergeist
   pry-rails
   rack-timeout
+  rails-controller-testing!
   rails_stdout_logging
-  rspec-rails (~> 3.1.0)
+  rspec-core!
+  rspec-expectations!
+  rspec-mocks!
+  rspec-rails!
+  rspec-support!
   shoulda-matchers (~> 2.8.0)
   timecop
   uglifier

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "momentjs-rails", "~> 2.8"
   s.add_dependency "neat", "~> 1.1"
   s.add_dependency "normalize-rails", "~> 3.0"
-  s.add_dependency "rails", "~> 4.2"
+  s.add_dependency "rails", ">= 5.0.0.beta1"
   s.add_dependency "sass-rails", "~> 5.0"
   s.add_dependency "selectize-rails", "~> 0.6"
 

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -27,7 +27,7 @@ to display a collection of resources in an HTML table.
         ">
         <%= link_to(params.merge(
           collection_presenter.order_params_for(attr_name)
-        )) do %>
+        ).permit!) do %>
             <%= attr_name.to_s.titleize %>
 
             <% if collection_presenter.ordered_by?(attr_name) %>

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -81,7 +81,7 @@ module Administrate
         if enum_column?(attr)
           :enum
         else
-          klass.column_types[attr].type
+          klass.columns_hash[attr].try(:type)
         end
       end
 

--- a/spec/example_app/.rspec
+++ b/spec/example_app/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---format Fuubar

--- a/spec/example_app/config/initializers/disable_xml_params.rb
+++ b/spec/example_app/config/initializers/disable_xml_params.rb
@@ -1,3 +1,0 @@
-# Protect against injection attacks
-# http://www.kb.cert.org/vuls/id/380039
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)


### PR DESCRIPTION
It might be a little early, but I wanted to use Rails 5 w/ Administrate.

Probably not a candidate for merging right away as it depends on a couple of unreleased gem versions (see Gemfile for notes.) But I wanted to get the process kicked off here.

This is backwards-compatible w/ Rails 4.2+, so for a merge we should swap the gemspec back to >= 4.2

No major complications to report.