### PR TITLE
Fix UI regressions

### DIFF
--- a/app/assets/stylesheets/administrate/components/_header.scss
+++ b/app/assets/stylesheets/administrate/components/_header.scss
@@ -1,5 +1,5 @@
 .header {
-  align-items: baseline;
+  align-items: flex-start;
   display: flex;
   justify-content: space-between;
   margin-bottom: $base-spacing * 2;

--- a/app/assets/stylesheets/administrate/components/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/components/_sidebar.scss
@@ -2,17 +2,13 @@
   flex: 0 0 auto;
   max-width: 12em;
   overflow-y: auto;
-  padding: 0 $base-spacing;
+  padding: 0 $base-spacing $base-spacing;
 
   &__link {
     color: $base-font-color;
     display: block;
     padding-top: $base-spacing;
     transition: color 0.05s linear;
-
-    &:last-child {
-      padding-bottom: $base-spacing;
-    }
 
     &--active {
       color: $blue;


### PR DESCRIPTION
When merging in #198 and #214,
the Percy.io visual regression tests weren't run
because our quota for the month had been used up.

Without the visual regression tests,
we failed to notice two visual regressions that were introduced.

The two commits in this PR fix the visual regressions that were introduced.
See the commit descriptions for more information.