### PR TITLE
Use System Fonts

### DIFF
--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -6,14 +6,14 @@ fieldset {
 }
 
 legend {
-  font-weight: 600;
+  font-weight: $bold-font-weight;
   margin-bottom: $small-spacing / 2;
   padding: 0;
 }
 
 label {
   display: block;
-  font-weight: 600;
+  font-weight: $bold-font-weight;
 }
 
 input,

--- a/app/assets/stylesheets/administrate/base/_lists.scss
+++ b/app/assets/stylesheets/administrate/base/_lists.scss
@@ -9,7 +9,7 @@ dl {
   margin-bottom: $small-spacing;
 
   dt {
-    font-weight: 600;
+    font-weight: $bold-font-weight;
     margin-top: $small-spacing;
   }
 

--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -10,7 +10,7 @@
   font-family: $base-font-family;
   font-size: $base-font-size;
   -webkit-font-smoothing: antialiased;
-  font-weight: 600;
+  font-weight: $bold-font-weight;
   line-height: 1;
   padding: $small-spacing $base-spacing;
   text-decoration: none;

--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -22,7 +22,7 @@
 
 .cell-label--asc,
 .cell-label--desc {
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .cell-label__sort-indicator {

--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -22,7 +22,7 @@
 
 .cell-label--asc,
 .cell-label--desc {
-  font-weight: 600;
+  font-weight: $bold-font-weight;
 }
 
 .cell-label__sort-indicator {

--- a/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -12,6 +12,6 @@
   }
 
   .current {
-    font-weight: 600;
+    font-weight: $bold-font-weight;
   }
 }

--- a/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -12,6 +12,6 @@
   }
 
   .current {
-    font-weight: bold;
+    font-weight: 600;
   }
 }

--- a/app/assets/stylesheets/administrate/components/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/components/_sidebar.scss
@@ -18,5 +18,5 @@
 
 .sidebar__link--active {
   color: $blue;
-  font-weight: 900;
+  font-weight: 600;
 }

--- a/app/assets/stylesheets/administrate/components/_sidebar.scss
+++ b/app/assets/stylesheets/administrate/components/_sidebar.scss
@@ -18,5 +18,5 @@
 
 .sidebar__link--active {
   color: $blue;
-  font-weight: 600;
+  font-weight: $bold-font-weight;
 }

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -4,10 +4,10 @@ $base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
   sans-serif;
 $heading-font-family: $base-font-family;
 
-// Font Sizes
 $base-font-size: 1em;
 
-// Line height
+$bold-font-weight: 600;
+
 $base-line-height: 1.5;
 $heading-line-height: 1.2;
 

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -1,5 +1,7 @@
 // Typography
-$base-font-family: "Lato", $helvetica;
+$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+  "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  sans-serif;
 $heading-font-family: $base-font-family;
 
 // Font Sizes

--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -19,7 +19,6 @@ By default, it renders:
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
   <title><%= content_for(:title) %> | <%= Rails.application.class.parent_name.titlecase %></title>
-  <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Lato:300,400,900", media: "all" %>
   <%= stylesheet_link_tag "administrate/application", media: "all" %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
Lato isn't particularly made for UI uses and I felt it was a little rough around
the edges; almost too friendly and unstructured for Administrate.

Instead, we can just use system fonts, especially now that Apple and Google have
both creating their own typefaces for UI use and are really strong typefaces.
Plus we get the benefit of not having to load web fonts!

Reference: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/

It also means we have one less thing to rely on (Google Fonts)

#### Before (with Lato)

![screen shot 2016-01-16 at 15 26 09](https://cloud.githubusercontent.com/assets/903327/12374313/90e43af6-bc65-11e5-9e35-957eab3efb2d.png)


#### After (with system fonts, rendered as Apple’s San Francisco here)

![screen shot 2016-01-16 at 15 26 20](https://cloud.githubusercontent.com/assets/903327/12374312/90e19490-bc65-11e5-9c8b-e21371cd676c.png)