### PR TITLE
Use tabular figures in table cells

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -125,7 +125,8 @@ linters:
 
   PropertySpelling:
     enabled: true
-    extra_properties: []
+    extra_properties:
+      - font-variant-numeric
     disabled_properties: []
 
   PropertyUnits:

--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -16,6 +16,10 @@ td {
 
 td {
   border-bottom: $base-border;
+  font-feature-settings: "kern", "liga", "clig", "calt", "lnum", "tnum";
+  font-kerning: normal;
+  font-variant-ligatures: common-ligatures, contextual;
+  font-variant-numeric: lining-nums, tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
Tab­u­lar fig­ures are set on a fixed width, so that every fig­ure oc­cu­pies the same
amount of hor­i­zon­tal space.

Reference: http://practice.typekit.com/lesson/caring-about-opentype-features/

Take a look at the “Lifetime Value” column in the GIF below and notice how after enabling this features, all of the numbers align horizontally making for a more readable experience.

![table-type](https://cloud.githubusercontent.com/assets/903327/12374575/7b1f298a-bc6d-11e5-9fb5-ee7b5ad7ffc1.gif)