### PR TITLE
Add support for selectable strings on edit pages

### DIFF
--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -1,0 +1,26 @@
+<%#
+# Select Index Partial
+
+This partial renders a selectable text attribute,
+to be displayed on a resource's edit form page.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Select][1].
+  A wrapper around the attribute pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
+%>
+
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.select(
+    field.attribute,
+    options_from_collection_for_select(field.selectable_options, :to_s, :to_s)
+  ) %>
+</div>

--- a/app/views/fields/select/_index.html.erb
+++ b/app/views/fields/select/_index.html.erb
@@ -1,0 +1,16 @@
+<%#
+# Select Index Partial
+
+This partial renders a selectable text attribute,
+to be displayed on a resource's index page.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Select][1].
+  A wrapper around the attribute pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
+%>
+
+<%= field.data.presence %>

--- a/app/views/fields/select/_show.html.erb
+++ b/app/views/fields/select/_show.html.erb
@@ -1,0 +1,16 @@
+<%#
+# Select Show Partial
+
+This partial renders a selectable text attribute,
+to be displayed on a resource's show page.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Select][1].
+  A wrapper around the attribute pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
+%>
+
+<%= field.data.presence %>

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -7,6 +7,7 @@ require "administrate/fields/has_one"
 require "administrate/fields/image"
 require "administrate/fields/number"
 require "administrate/fields/polymorphic"
+require "administrate/fields/select"
 require "administrate/fields/string"
 require "administrate/fields/text"
 

--- a/lib/administrate/fields/select.rb
+++ b/lib/administrate/fields/select.rb
@@ -1,0 +1,21 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class Select < Field::Base
+      def self.searchable?
+        true
+      end
+
+      def selectable_options
+        collection
+      end
+
+      private
+
+      def collection
+        @collection ||= options.fetch(:collection, [])
+      end
+    end
+  end
+end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -9,11 +9,12 @@ class CustomerDashboard < Administrate::BaseDashboard
     name: Field::String,
     orders: Field::HasMany,
     updated_at: Field::DateTime,
+    kind: Field::Select.with_options(collection: Customer::KINDS),
   }
 
   COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys - [:name]
-  FORM_ATTRIBUTES = [:name, :email, :email_subscriber]
+  FORM_ATTRIBUTES = [:name, :email, :email_subscriber, :kind]
 
   def display_resource(customer)
     customer.name

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -4,6 +4,11 @@ class Customer < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true
 
+  KINDS = [
+    :standard,
+    :vip,
+  ]
+
   def lifetime_value
     orders.map(&:total_price).reduce(0, :+)
   end

--- a/spec/example_app/db/migrate/20160119024340_add_kind_to_customer.rb
+++ b/spec/example_app/db/migrate/20160119024340_add_kind_to_customer.rb
@@ -1,0 +1,5 @@
+class AddKindToCustomer < ActiveRecord::Migration
+  def change
+    add_column :customers, :kind, :string, null: false, default: "standard"
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150916011117) do
+ActiveRecord::Schema.define(version: 20160119024340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20150916011117) do
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.boolean  "email_subscriber"
+    t.string   "kind",             default: "standard", null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -35,4 +35,26 @@ describe "customer edit page" do
 
     expect(page).to have_content("true")
   end
+
+  it "displays selectable strings as dropdowns", :js do
+    customer = create(:customer, kind: :standard)
+
+    visit edit_admin_customer_path(customer)
+
+    select "vip", from: "Kind"
+
+    click_on "Update Customer"
+
+    expect(page).to have_content("KIND")
+    expect(page).to have_content("vip")
+
+    click_on "Edit"
+
+    select "standard", from: "Kind"
+
+    click_on "Update Customer"
+
+    expect(page).to have_content("KIND")
+    expect(page).to have_content("standard")
+  end
 end


### PR DESCRIPTION
This pull request adds support for collection select fields, much like `simple_form`'s `collection: [:foo, :bar]` option. This also provides a base field that will be helpful in implementing the `HasOne` field that is currently pending implementation.

**Example User Story**

**As a** developer
**I want** to allow administrative users to select values from a drop-down rather than enter them free-form
**So that** I don't need to worry quite as much about data integrity in my administrative interface.