### PR TITLE
Let users undo the `administrate:views` generator

### DIFF
--- a/lib/administrate/generator_helpers.rb
+++ b/lib/administrate/generator_helpers.rb
@@ -1,0 +1,13 @@
+module Administrate
+  module GeneratorHelpers
+    def call_generator(generator, *args)
+      Rails::Generators.invoke(generator, args, generator_options)
+    end
+
+    private
+
+    def generator_options
+      { behavior: behavior }
+    end
+  end
+end

--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -1,7 +1,10 @@
 require "rails/generators/base"
+require "administrate/generator_helpers"
 
 module Administrate
   class ViewGenerator < Rails::Generators::Base
+    include Administrate::GeneratorHelpers
+
     private
 
     def self.template_source_path

--- a/lib/generators/administrate/assets/assets_generator.rb
+++ b/lib/generators/administrate/assets/assets_generator.rb
@@ -4,9 +4,9 @@ module Administrate
   module Generators
     class AssetsGenerator < Administrate::ViewGenerator
       def copy_assets
-        Rails::Generators.invoke("administrate:assets:images")
-        Rails::Generators.invoke("administrate:assets:javascripts")
-        Rails::Generators.invoke("administrate:assets:stylesheets")
+        call_generator("administrate:assets:images")
+        call_generator("administrate:assets:javascripts")
+        call_generator("administrate:assets:stylesheets")
       end
     end
   end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -1,8 +1,10 @@
 require "rails/generators/base"
+require "administrate/generator_helpers"
 
 module Administrate
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
 
       def create_dashboard_controller
@@ -20,7 +22,7 @@ module Administrate
 
       def run_dashboard_generators
         singular_dashboard_resources.each do |resource|
-          Rails::Generators.invoke("administrate:dashboard", [resource])
+          call_generator("administrate:dashboard", resource)
         end
       end
 
@@ -36,7 +38,7 @@ module Administrate
 
       def manifest
         unless defined?(DashboardManifest)
-          Rails::Generators.invoke("administrate:manifest")
+          call_generator("administrate:manifest")
         end
 
         DashboardManifest

--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -12,7 +12,7 @@ module Administrate
             "app/views/layouts/admin/application.html.erb",
           )
 
-          Rails::Generators.invoke("administrate:views:sidebar")
+          call_generator("administrate:views:sidebar")
           copy_resource_template("_javascript")
           copy_resource_template("_flashes")
         end

--- a/lib/generators/administrate/views/views_generator.rb
+++ b/lib/generators/administrate/views/views_generator.rb
@@ -4,10 +4,10 @@ module Administrate
   module Generators
     class ViewsGenerator < Administrate::ViewGenerator
       def copy_templates
-        Rails::Generators.invoke("administrate:views:index", [resource_path])
-        Rails::Generators.invoke("administrate:views:show", [resource_path])
-        Rails::Generators.invoke("administrate:views:new", [resource_path])
-        Rails::Generators.invoke("administrate:views:edit", [resource_path])
+        call_generator("administrate:views:index", resource_path)
+        call_generator("administrate:views:show", resource_path)
+        call_generator("administrate:views:new", resource_path)
+        call_generator("administrate:views:edit", resource_path)
       end
     end
   end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -89,8 +89,8 @@ describe Administrate::Generators::InstallGenerator, :generator do
       run_generator
 
       %w[customer order product line_item].each do |resource|
-        expect(Rails::Generators).to have_received(:invoke).
-          with("administrate:dashboard", [resource])
+        expect(Rails::Generators).
+          to invoke_generator("administrate:dashboard", [resource])
       end
     end
   end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 require "generators/administrate/views/views_generator"
 require "support/generator_spec_helpers"
 
@@ -11,9 +11,22 @@ describe Administrate::Generators::ViewsGenerator, :generator do
       run_generator [resource]
 
       %w[index show new edit].each do |generator|
-        expect(Rails::Generators).to have_received(:invoke).
-          with("administrate:views:#{generator}", [resource])
+        expect(Rails::Generators).
+          to invoke_generator("administrate:views:#{generator}", [resource])
       end
+    end
+
+    it "revokes sub-generators if run through `rails destroy`" do
+      allow(Rails::Generators).to receive(:invoke)
+      resource = "users"
+
+      run_generator [resource], behavior: :revoke
+
+      expect(Rails::Generators).to invoke_generator(
+        "administrate:views:index",
+        [resource],
+        behavior: :revoke,
+      )
     end
   end
 end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -15,8 +15,8 @@ module GeneratorSpecHelpers
     )
   end
 
-  def invoke_generator(*args)
-    have_received(:invoke).with(*args)
+  def invoke_generator(generator, args = [], options = { behavior: :invoke })
+    have_received(:invoke).with(generator, args, options)
   end
 
   def each_file_in(path)


### PR DESCRIPTION
Fixes #310

## Problem:

Rails provides a way to undo the effects of generators,
by running the command `rails destroy GENERATOR_NAME`.

With the way that we had set up our hierarchy of generators,
Rails did not know how to undo the effects of sub-generators.

For example, with the `administrate:views` generator,
we were calling `Rails::Generators.invoke("administrate:views:index")`.

Whether the generator was run with the `generate` or `destroy` command
did not make a difference -
the index generator would always be invoked
as if it were run with `generate`.

## Solution:

Rails generators use the `@behavior` instance variable to keep track of
how the generator was run.
This variable can be either `:invoke` or `:revoke`.

Pass this variable as an option to the sub-generators
to ensure they have the same behavior as the parent.

## Minor changes:

Extract `Administrate::GeneratorHelpers` to store common
generator-related methods.