### PR TITLE
Update Nokogiri for a security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    nokogiri (1.6.7.1)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
     percy-capybara (1.0.0)
@@ -327,4 +327,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Problem:

`bundle-audit` detected a security vulnerability in Nokogiri:

```
$ bundle-audit
Name: nokogiri
Version: 1.6.7.1
Advisory: CVE-2015-7499
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/Dy7YiKb_pMM
Title: Nokogiri gem contains a heap-based buffer overflow vulnerability in libxml2
Solution: upgrade to >= 1.6.7.2

Vulnerabilities found!
```

Solution:

Run `bundle update nokogiri && appraisal update nokogiri`