### PR TITLE
Release version 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Upcoming Release
 
+### 0.1.3 (January 22, 2016)
+
 * [#269] [FEATURE] Add a generator for copying default layout files
 * [#328] [FEATURE] Add a generator for copying default sidebar partial
 * [#362] [FEATURE] Add a generator for only the dashboard manifest.
@@ -26,12 +28,19 @@
 * [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
 * [#364] [FEATURE] Improve dashboard generator by explicitly listing out the
   generated `SHOW_PAGE_ATTRIBUTES` array elements.
+* [#416] [UI] Add an accessibility label to the search input
+* [#411] [UI] Use tabular figures in table cells
+* [#409] [UI] Use default system fonts
+* [#424] [BUGFIX] Fix a bug where running `rails destroy GENERATOR_NAME`
+  would not work for several of the generators
 * [#390] [BUGFIX] Fix timestamp deprecation warnings
+* [#365] [COMPAT] Remove dependency on `inline_svg`
 * [#396] [I18n] Ukrainian
-* [#297] [I18n] Add Italian translations
+* [#297] [I18n] Italian
 * [#307] [I18n] Fix German grammatical errors
 * [#363] [DOC] Move documentation into main repository, at the root URL
 * [#395] [DOC] Update inline documentation for collection partial
+* [#387] [DOC] Fix incorrect path for generators in the docs
 
 ### 0.1.2 (December 09, 2015)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    administrate (0.1.2)
+    administrate (0.1.3)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)
@@ -61,7 +61,7 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.3)
-    autoprefixer-rails (6.1.2)
+    autoprefixer-rails (6.3.1)
       execjs
       json
     awesome_print (1.6.1)
@@ -136,7 +136,7 @@ GEM
       i18n
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
-    jquery-rails (4.0.5)
+    jquery-rails (4.1.0)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -158,7 +158,7 @@ GEM
     mime-types (2.6.2)
     mini_portile2 (2.0.0)
     minitest (5.8.1)
-    momentjs-rails (2.10.6)
+    momentjs-rails (2.11.0)
       railties (>= 3.1)
     multi_json (1.11.2)
     multipart-post (2.0.0)
@@ -240,7 +240,7 @@ GEM
     rspec-support (3.1.2)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -263,7 +263,7 @@ GEM
     thor (0.19.1)
     thread (0.2.2)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (2.0.2)
     timecop (0.8.0)
     tins (1.6.0)
     tzinfo (1.2.2)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate", "~> 0.1.2"
+gem "administrate", "~> 0.1.3"
 ```
 
 Re-bundle, then run the installer:

--- a/lib/administrate/version.rb
+++ b/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Changes:


* [#269] [FEATURE] Add a generator for copying default layout files
* [#328] [FEATURE] Add a generator for copying default sidebar partial
* [#362] [FEATURE] Add a generator for only the dashboard manifest.
  Customizing this manifest before running the `administrate:install` generator
  will change which dashboards get generated.
* [#295] [FEATURE] Add dashboard detection for ActiveRecord::Enum fields.
* [#364] [FEATURE] Improve dashboard generator by explicitly listing out the
  generated `SHOW_PAGE_ATTRIBUTES` array elements.
* [#416] [UI] Add an accessibility label to the search input
* [#411] [UI] Use tabular figures in table cells
* [#409] [UI] Use default system fonts
* [#424] [BUGFIX] Fix a bug where running `rails destroy GENERATOR_NAME`
  would not work for several of the generators
* [#390] [BUGFIX] Fix timestamp deprecation warnings
* [#365] [COMPAT] Remove dependency on `inline_svg`
* [#396] [I18n] Ukrainian
* [#297] [I18n] Italian
* [#307] [I18n] Fix German grammatical errors
* [#363] [DOC] Move documentation into main repository, at the root URL
* [#395] [DOC] Update inline documentation for collection partial
* [#387] [DOC] Fix incorrect path for generators in the docs
