### PR TITLE
Add extension point for custom styles.

### DIFF
--- a/app/assets/stylesheets/administrate/_customizations.scss
+++ b/app/assets/stylesheets/administrate/_customizations.scss
@@ -1,0 +1,1 @@
+// Place custom css in app/assets/stylesheets/administrate/customizations.scss

--- a/app/assets/stylesheets/administrate/application.scss
+++ b/app/assets/stylesheets/administrate/application.scss
@@ -10,3 +10,5 @@
 @import "library/**/*";
 @import "base/**/*";
 @import "components/**/*";
+
+@import "administrate/customizations";

--- a/spec/example_app/app/assets/stylesheets/administrate/_customizations.scss
+++ b/spec/example_app/app/assets/stylesheets/administrate/_customizations.scss
@@ -1,0 +1,3 @@
+.custom-administrate-css-hidden {
+  display: none;
+}

--- a/spec/example_app/app/views/admin/application/_flashes.html.erb
+++ b/spec/example_app/app/views/admin/application/_flashes.html.erb
@@ -1,0 +1,24 @@
+<%#
+# Flash Partial
+
+This partial renders flash messages on every page.
+
+## Relevant Helpers:
+
+- `flash`:
+  Returns a hash,
+  where the keys are the type of flash (alert, error, notice, etc)
+  and the values are the message to be displayed.
+%>
+
+<% if flash.any? %>
+  <div class="flashes">
+    <% flash.each do |key, value| -%>
+      <div class="flash flash--<%= key %>"><%= value %></div>
+    <% end -%>
+  </div>
+<% end %>
+
+<div class="custom-administrate-css-hidden">
+  If you can read this, something's wrong.
+</div>

--- a/spec/features/custom_styles_spec.rb
+++ b/spec/features/custom_styles_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Custom style" do
+  it "is applied", :js do
+    visit admin_customers_path
+    expect(page).to_not have_css(".custom-administrate-css-hidden")
+    page.execute_script("$('.custom-administrate-css-hidden').show()")
+    expect(page).to have_css(".custom-administrate-css-hidden")
+  end
+end


### PR DESCRIPTION
This PR addresses #349.  

Notes:
- Behavior seemed inconsistent when `app/assets/stylesheets/administrate/customize.scss` was empty, but seemed to work as expected with only a comment
- Testing this was weird.  I tried to come up with something that wouldn't break the example app, but still reliably demonstrate behavior.
- Capybara gave me unintuitive results - checking visibility didn't seem to work at all, `display:none` seemed to make the div totally invisible to Capybara.

This seems too simple to screw up, but if I missed something please let me know.
