### PR TITLE
Requires DashboardManifest after creation

### DIFF
--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -39,6 +39,7 @@ module Administrate
       def manifest
         unless defined?(DashboardManifest)
           call_generator("administrate:manifest")
+          require_relative Rails.root.join("app/dashboards/dashboard_manifest.rb")
         end
 
         DashboardManifest


### PR DESCRIPTION
problem:

`rails g administrate:install` would fail to load the DashboardManifest
unless spring was stopped before running the command.

solution:

Require the DashboardManifest class after it is created to ensure it is
loaded

fixes #448, #431, #453