### PR TITLE
Inline controller's `permitted_attributes` method

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -98,11 +98,7 @@ module Administrate
     end
 
     def resource_params
-      params.require(resource_name).permit(*permitted_attributes)
-    end
-
-    def permitted_attributes
-      dashboard.permitted_attributes
+      params.require(resource_name).permit(dashboard.permitted_attributes)
     end
 
     delegate :resource_class, :resource_name, :namespace, to: :resource_resolver


### PR DESCRIPTION
Fixes #417
## Problem:

If users include the Pundit gem on an Administrate controller, the controller attempts to call the `permitted_attributes` method defined by pundit instedad of the one defined by Administrate.

Because these methods take different arguments, this results in an `ArgumentError` for the user.
## Solution:

Inline the `permitted_attributes` method to avoid the method name collision.

This narrows the public API a bit, but that's alright.  The user can accomplish all of the removed functionality by overriding the parent `resource_params` method.
