### PR TITLE
Allow preloading has_many records

### DIFF
--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -47,7 +47,12 @@ module Administrate
       private
 
       def candidate_resources
-        associated_class.all
+        if options.key?(:includes)
+          includes = options.fetch(:includes)
+          associated_class.includes(*includes).all
+        else
+          associated_class.all
+        end
       end
 
       def display_candidate_resource(resource)


### PR DESCRIPTION
Let's say an `Author` has_many `Book`s.

`Field::HasMany` loads each Book record and calls `display_resource` on each one. If the `Book` dashboard defines `display_resource` to call `book.author.name`, N `Author` records will be loaded, one for each book.

This can significantly slow down load time.

To fix this, Administrate users can now tell Administrate to preload associated records using Rails' `includes` option. Example usage:

```
Field::HasMany.with_options(includes: [:author])
```
