### PR TITLE
Orm adapters

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -14,7 +14,7 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+<%= form_for([namespace, page.resource.to_model], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -12,7 +12,7 @@ as defined by the DashboardManifest.
     <li>
       <%= link_to(
         display_resource_name(resource),
-        [namespace, resource],
+        url_for(action: 'index', controller: "#{namespace}/#{resource}"),
         class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
       ) %>
     </li>

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -1,4 +1,29 @@
 require "administrate/engine"
+require "administrate/orm_adapters/active_record_pattern/base"
+require "administrate/orm_adapters/active_record_pattern/model"
+require "administrate/orm_adapters/active_record_pattern/record"
+require "administrate/orm_adapters/active_record_pattern/relation"
 
 module Administrate
+  if defined?(Sequel::Model)
+    %w(base model record relation).each do |file|
+      require "administrate/orm_adapters/sequel/#{file}"
+    end
+
+    def self.orm_namespace
+      OrmAdapters::Sequel
+    end
+  else
+    %w(base model record relation).each do |file|
+      require "administrate/orm_adapters/active_record/#{file}"
+    end
+
+    def self.orm_namespace
+      OrmAdapters::ActiveRecord
+    end
+  end
+
+  def self.orm
+    @orm ||= orm_namespace::Base.new
+  end
 end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -49,7 +49,8 @@ module Administrate
     end
 
     def display_resource(resource)
-      "#{resource.class} ##{resource.id}"
+      resource = Administrate.orm.wrap_record(resource)
+      "#{resource.model_class.name} ##{resource.id}"
     end
 
     private

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -35,7 +35,7 @@ module Administrate
     end
 
     def permitted_attributes
-      form_attributes.map do |attr|
+      form_attributes.flat_map do |attr|
         attribute_types[attr].permitted_attribute(attr)
       end.uniq
     end

--- a/lib/administrate/fields/associative.rb
+++ b/lib/administrate/fields/associative.rb
@@ -14,7 +14,7 @@ module Administrate
       end
 
       def associated_class
-        associated_class_name.constantize
+        Administrate.orm.find_model(associated_class_name)
       end
 
       def associated_class_name

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -6,7 +6,7 @@ module Administrate
     end
 
     def apply(relation)
-      if relation.columns_hash.keys.include?(attribute.to_s)
+      if relation.can_order_by?(attribute)
         relation.order(attribute => direction)
       else
         relation

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -7,7 +7,7 @@ module Administrate
 
     def apply(relation)
       if relation.can_order_by?(attribute)
-        relation.order(attribute => direction)
+        relation.order(attribute => direction.to_sym)
       else
         relation
       end

--- a/lib/administrate/orm_adapters/active_record/base.rb
+++ b/lib/administrate/orm_adapters/active_record/base.rb
@@ -1,0 +1,39 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecord
+      class Base < ActiveRecordPattern::Base
+        def model_class
+          ::ActiveRecord::Base
+        end
+
+        def relation_class
+          ::ActiveRecord::Relation
+        end
+
+        def wrap_record(record)
+          if record.kind_of?(model_class)
+            Record.new(wrap_model(record.class), record)
+          else
+            record
+          end
+        end
+
+        def wrap_relation(relation)
+          if relation.kind_of?(relation_class)
+            Relation.new(relation)
+          else
+            relation
+          end
+        end
+
+        def wrap_model(model)
+          if has_ancestor?(model, model_class)
+            Model.new(model)
+          else
+            model
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record/model.rb
+++ b/lib/administrate/orm_adapters/active_record/model.rb
@@ -1,11 +1,13 @@
+require "active_support/core_ext/module/delegation"
+
 module Administrate
   module OrmAdapters
     module ActiveRecord
       class Model < ActiveRecordPattern::Model
-        delegate :table_exists?, to: :@model
+        delegate :table_exists?, :defined_enums, to: :@model
 
         def find(param)
-          Record.new(@model.find(param))
+          Record.new(self, @model.find(param))
         end
 
         def all
@@ -20,12 +22,12 @@ module Administrate
                   :has_one
                 elsif v.collection?
                   :collection
-                end
+                end,
               polymorphic: v.polymorphic?,
               class_name: v.class_name,
               name: v.name
             }
-            a[k.to_s] = obj if obj[:type]
+            a[k.to_s] = obj
           end
         end
 

--- a/lib/administrate/orm_adapters/active_record/model.rb
+++ b/lib/administrate/orm_adapters/active_record/model.rb
@@ -1,0 +1,44 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecord
+      class Model < ActiveRecordPattern::Model
+        delegate :table_exists?, to: :@model
+
+        def find(param)
+          Record.new(@model.find(param))
+        end
+
+        def all
+          Relation.new(@model.all)
+        end
+
+        def reflections
+          @model.reflections.each_with_object({}) do |(k,v), a|
+            obj = {
+              type:
+                if v.has_one?
+                  :has_one
+                elsif v.collection?
+                  :collection
+                end
+              polymorphic: v.polymorphic?,
+              class_name: v.class_name,
+              name: v.name
+            }
+            a[k.to_s] = obj if obj[:type]
+          end
+        end
+
+        def attribute_names
+          @model.attribute_names
+        end
+
+        def column_types
+          @model.column_types.each_with_object({}) do |(k,v), a|
+            a[k.to_s] = { type: v.type }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record/record.rb
+++ b/lib/administrate/orm_adapters/active_record/record.rb
@@ -1,0 +1,17 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecord
+      class Record < ActiveRecordPattern::Record
+        def id
+          @record.send(@model.primary_key)
+        end
+
+        def get_attribute_value(attribute_name, field_type)
+          @record.public_send(attribute_name)
+        rescue NameError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record/record.rb
+++ b/lib/administrate/orm_adapters/active_record/record.rb
@@ -3,11 +3,11 @@ module Administrate
     module ActiveRecord
       class Record < ActiveRecordPattern::Record
         def id
-          @record.send(@model.primary_key)
+          @record.send(@model.unwrap.primary_key)
         end
 
         def get_attribute_value(attribute_name, field_type)
-          @record.public_send(attribute_name)
+          Administrate.orm.wrap_any(@record.public_send(attribute_name))
         rescue NameError
           nil
         end

--- a/lib/administrate/orm_adapters/active_record/relation.rb
+++ b/lib/administrate/orm_adapters/active_record/relation.rb
@@ -1,0 +1,21 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecord
+      class Relation < ActiveRecordPattern::Relation
+        def can_order_by?(attr_name)
+          @relation.columns_hash.keys.include?(attr_name.to_s)
+        end
+
+        def order(options)
+          fail ArgumentError, "expected a Hash" unless options.kind_of?(Hash)
+
+          Relation.new(@relation.order(options))
+        end
+
+        def paginate(page, per)
+          Relation.new(@relation.page(page).per(per))
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record_pattern/base.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/base.rb
@@ -1,0 +1,60 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecordPattern
+      class Base
+        def find_models
+          model_class.descendants.map do |model|
+            wrap_model(model)
+          end
+        end
+
+        def find_model(name)
+          wrap_model(Object.const_get(name))
+        end
+
+        def has_ancestor?(klass, ancestor)
+          return false unless klass.respond_to?(:ancestors)
+          klass.ancestors.include?(ancestor)
+        end
+
+        def wrap_record(record)
+          if record.kind_of?(model_class)
+            Administrate.orm_namespace::Record.new(wrap_model(record.class), record)
+          else
+            record
+          end
+        end
+
+        def wrap_relation(relation)
+          if relation.kind_of?(relation_class)
+            Administrate.orm_namespace::Relation.new(relation)
+          else
+            relation
+          end
+        end
+
+        def wrap_model(model)
+          if has_ancestor?(model, model_class)
+            Administrate.orm_namespace::Model.new(model)
+          else
+            model
+          end
+        end
+
+        def wrap_any(object)
+          return unless object
+
+          if object.kind_of?(model_class)
+            wrap_record(object)
+          elsif object.kind_of?(relation_class)
+            wrap_relation(object)
+          elsif has_ancestor?(object, model_class)
+            wrap_model(object)
+          else
+            object
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record_pattern/model.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/model.rb
@@ -1,0 +1,33 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecordPattern
+      class Model
+        delegate :where, to: :all
+
+        def initialize(model)
+          @model = model
+        end
+
+        def plural_name
+          name.pluralize.underscore if name
+        end
+
+        def name
+          @model.name
+        end
+
+        def model_inspect
+          @model.inspect
+        end
+
+        def unwrap
+          @model
+        end
+
+        def new(params = {})
+          Administrate.orm_namespace::Record.new(self, @model.new(params))
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record_pattern/model.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/model.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/module/delegation"
+
 module Administrate
   module OrmAdapters
     module ActiveRecordPattern

--- a/lib/administrate/orm_adapters/active_record_pattern/record.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/record.rb
@@ -1,0 +1,49 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecordPattern
+      class Record
+        def initialize(model, record)
+          @model = model
+          @record = record
+        end
+
+        def save
+          @record.save
+        end
+
+        def update(params)
+          @record.update(params)
+        end
+
+        def destroy
+          @record.destroy
+        end
+
+        # for polymorphic_url
+        def to_model
+          @record
+        end
+
+        def model_class
+          @model
+        end
+
+        def errors
+          @record.errors
+        end
+
+        def unwrap
+          @record
+        end
+
+        def method_missing(meth, *args, &block)
+          if @record.respond_to?(meth)
+            @record.send(meth, *args, &block)
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record_pattern/relation.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/relation.rb
@@ -1,0 +1,35 @@
+module Administrate
+  module OrmAdapters
+    module ActiveRecordPattern
+      class Relation
+        delegate :count, :size, :total_pages, :current_page, :limit_value,
+                 :any?, to: :@relation
+        delegate :each, :map, to: :to_a
+
+        def initialize(relation)
+          @relation = relation
+        end
+
+        # prepared statement style: where("a = ? OR b = ?", 1, 2)
+        def where(*args)
+          fail ArgumentError, "where must be given arguments in prepared statement style" unless args.first.is_a?(String)
+          Administrate.orm_namespace::Relation.new(@relation.where(*args))
+        end
+
+        def limit(value)
+          Administrate.orm_namespace::Relation.new(@relation.limit(value))
+        end
+
+        def unwrap
+          @relation
+        end
+
+        def to_a
+          @relation.to_a.map do |record|
+            Administrate.orm.wrap_record(record)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/active_record_pattern/relation.rb
+++ b/lib/administrate/orm_adapters/active_record_pattern/relation.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/module/delegation"
+
 module Administrate
   module OrmAdapters
     module ActiveRecordPattern

--- a/lib/administrate/orm_adapters/sequel/base.rb
+++ b/lib/administrate/orm_adapters/sequel/base.rb
@@ -1,0 +1,15 @@
+module Administrate
+  module OrmAdapters
+    module Sequel
+      class Base < ActiveRecordPattern::Base
+        def model_class
+          ::Sequel::Model
+        end
+
+        def relation_class
+          ::Sequel::Dataset
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/sequel/model.rb
+++ b/lib/administrate/orm_adapters/sequel/model.rb
@@ -26,7 +26,7 @@ module Administrate
               class_name: v[:class_name],
               name: v[:name]
             }
-            a[k.to_s] = obj if obj[:type]
+            a[k.to_s] = obj
           end
         end
 

--- a/lib/administrate/orm_adapters/sequel/model.rb
+++ b/lib/administrate/orm_adapters/sequel/model.rb
@@ -1,0 +1,45 @@
+module Administrate
+  module OrmAdapters
+    module Sequel
+      class Model < ActiveRecordPattern::Model
+        def table_exists?
+          @model.db.table_exists?(@model.table_name) if @model.table_name
+        end
+
+        def find(param)
+          Record.new(self, @model.where(@model.primary_key => param).first!)
+        end
+
+        def all
+          Relation.new(@model.dataset)
+        end
+
+        def reflections
+          @model.association_reflections.each_with_object({}) do |(k,v), a|
+            obj = {
+              type:
+                case v[:type]
+                when :one_to_one then :has_one
+                when :one_to_many, :many_to_many then :collection
+                end,
+              polymorphic: false,
+              class_name: v[:class_name],
+              name: v[:name]
+            }
+            a[k.to_s] = obj if obj[:type]
+          end
+        end
+
+        def attribute_names
+          @model.columns.map(&:to_s)
+        end
+
+        def column_types
+          @model.db_schema.each_with_object({}) do |(k,v), a|
+            a[k.to_s] = { type: v[:type] || v[:db_type].to_sym || :unknown }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/sequel/record.rb
+++ b/lib/administrate/orm_adapters/sequel/record.rb
@@ -1,0 +1,51 @@
+module Administrate
+  module OrmAdapters
+    module Sequel
+      class Record < ActiveRecordPattern::Record
+        def id
+          @record.pk
+        end
+
+        def save
+          @record.save(raise_on_failure: false)
+        end
+
+        def update(attrs)
+          @record.set(attrs)
+          save
+        end
+
+        def get_attribute_value(attribute_name, field_type)
+          if field_type.kind_of?(Field::Deferred)
+            field_type = field_type.deferred_class
+          end
+
+          if Administrate.orm.has_ancestor?(field_type, Field::Associative)
+            get_association_value(attribute_name, field_type)
+          else
+            Administrate.orm.wrap_any(get_raw_attribute_value(attribute_name))
+          end
+        end
+
+        def get_association_value(attribute_name, field_type)
+          dataset_method = :"#{attribute_name}_dataset"
+          collection = Administrate.orm.has_ancestor?(field_type, Field::HasMany)
+          if @record.respond_to?(dataset_method) && collection
+            Administrate.orm.wrap_any(get_raw_attribute_value(dataset_method))
+          else
+            Administrate.orm.wrap_any(get_raw_attribute_value(attribute_name))
+          end
+        end
+
+        def get_raw_attribute_value(attribute_name)
+          @record.public_send(attribute_name)
+        rescue NameError
+          nil
+        rescue ::Sequel::Error
+          raise unless @record.new?
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/orm_adapters/sequel/relation.rb
+++ b/lib/administrate/orm_adapters/sequel/relation.rb
@@ -1,0 +1,43 @@
+module Administrate
+  module OrmAdapters
+    module Sequel
+      class Relation < ActiveRecordPattern::Relation
+        def can_order_by?(attr_name)
+          return false unless attr_name
+
+          @relation.model.columns.include?(attr_name.to_sym)
+        end
+
+        def order(options)
+          fail ArgumentError, "expected a Hash" unless options.kind_of?(Hash)
+
+          relation = @relation
+          options.each_pair do |k, v|
+            fail ArgumentError, "wrong direction #{v.inspect}" unless
+              [:asc, :desc].include?(v)
+            relation = relation.order_append(::Sequel.send(v, k.to_sym))
+          end
+          Relation.new(relation)
+        end
+
+        def paginate(page, per)
+          Relation.new(@relation.limit(nil).paginate(page, per))
+        end
+
+        def size
+          @relation.count
+        end
+
+        def any?
+          !@relation.empty?
+        end
+
+        def to_a
+          @relation.all.map do |record|
+            Administrate.orm.wrap_record(record)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -14,15 +14,9 @@ module Administrate
       protected
 
       def attribute_field(dashboard, resource, attribute_name, page)
-        value = get_attribute_value(resource, attribute_name)
         field = dashboard.attribute_type_for(attribute_name)
+        value = resource.get_attribute_value(attribute_name, field)
         field.new(attribute_name, value, page)
-      end
-
-      def get_attribute_value(resource, attribute_name)
-        resource.public_send(attribute_name)
-      rescue NameError
-        nil
       end
 
       attr_reader :dashboard, :options

--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -13,7 +13,7 @@ module Administrate
     end
 
     def resource_class
-      Object.const_get(resource_class_name)
+      Administrate.orm.find_model(resource_class_name)
     end
 
     def resource_name

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -81,7 +81,7 @@ module Administrate
         if enum_column?(attr)
           :enum
         else
-          klass.column_types[attr].type
+          klass.column_types[attr][:type] if klass.column_types[attr]
         end
       end
 
@@ -92,11 +92,11 @@ module Administrate
 
       def association_type(attribute)
         relationship = klass.reflections[attribute.to_s]
-        if relationship.has_one?
+        if relationship[:type] == :has_one
           "Field::HasOne"
-        elsif relationship.collection?
+        elsif relationship[:type] == :collection
           "Field::HasMany" + relationship_options_string(relationship)
-        elsif relationship.polymorphic?
+        elsif relationship[:polymorphic]
           "Field::Polymorphic"
         else
           "Field::BelongsTo" + relationship_options_string(relationship)
@@ -104,12 +104,12 @@ module Administrate
       end
 
       def klass
-        @klass ||= Object.const_get(class_name)
+        @klass ||= Administrate.orm.find_model(class_name)
       end
 
       def relationship_options_string(relationship)
-        if relationship.class_name != relationship.name.to_s.classify
-          options_string(class_name: relationship.class_name)
+        if relationship[:class_name] != relationship[:name].to_s.classify
+          options_string(class_name: relationship[:class_name])
         else
           ""
         end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -1,3 +1,5 @@
+require "administrate/orm_adapters/active_record_pattern/relation"
+require "administrate/orm_adapters/active_record/relation"
 require "administrate/order"
 
 describe Administrate::Order do
@@ -6,9 +8,10 @@ describe Administrate::Order do
       it "doesn't sort the resources" do
         order = Administrate::Order.new(nil, :desc)
         relation = relation_with_column(:id)
+        allow(relation).to receive(:can_order_by?)
         allow(relation).to receive(:order).and_return(relation)
 
-        ordered = order.apply(relation)
+        ordered = order.apply(wrap_relation(relation))
 
         expect(relation).not_to have_received(:order)
         expect(ordered).to eq(relation)
@@ -21,7 +24,7 @@ describe Administrate::Order do
         relation = relation_with_column(:id)
         allow(relation).to receive(:order).and_return(relation)
 
-        ordered = order.apply(relation)
+        ordered = order.apply(wrap_relation(relation))
 
         expect(relation).not_to have_received(:order)
         expect(ordered).to eq(relation)
@@ -34,7 +37,7 @@ describe Administrate::Order do
         relation = relation_with_column(:name)
         allow(relation).to receive(:order).and_return(relation)
 
-        ordered = order.apply(relation)
+        ordered = order.apply(wrap_relation(relation))
 
         expect(relation).to have_received(:order).with(name: :asc)
         expect(ordered).to eq(relation)
@@ -45,7 +48,7 @@ describe Administrate::Order do
         relation = relation_with_column(:name)
         allow(relation).to receive(:order).and_return(relation)
 
-        ordered = order.apply(relation)
+        ordered = order.apply(wrap_relation(relation))
 
         expect(relation).to have_received(:order).with(name: :desc)
         expect(ordered).to eq(relation)
@@ -139,5 +142,9 @@ describe Administrate::Order do
 
   def relation_with_column(column)
     double(columns_hash: { column.to_s => :column_info })
+  end
+
+  def wrap_relation(relation)
+    Administrate::OrmAdapters::ActiveRecord::Relation.new(relation)
   end
 end


### PR DESCRIPTION
#143 This works well for us with the Sequel adapter.

There is only one concern I still have. Right now I wrap models/records/relations into wrapper objects as soon as possible. This unfortunately means that if the user overrides something (e.g. a view), he will get wrapper objects instead of actual AR records. The wrapper does proxy all methods to the actual record, and it defines to_model so polymorphic_url works properly, but I'm not sure if this is the best solution.

I see 2 possible alternatives:
- include a module into the base classes that adds a method such as `#agnostic`, which returns the wrapper. then go through this method inside administrate
- use class methods ("helpers") instead of wrappers, and use that in administrate instead of calling methods on the records/models/relations

The spec failures are due to equality checks (wrapper object with wrapped object).

Or keep the current approach if it's good enough. What do you think?
