### PR TITLE
Allow nil in list of dashboards to create a space for grouping items

### DIFF
--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -10,11 +10,15 @@ as defined by the routes in the `admin/` namespace
 <ul class="sidebar__list">
   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
     <li>
-      <%= link_to(
-        display_resource_name(resource),
-        [namespace, resource],
-        class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
-      ) %>
+      <%= if resource 
+        link_to(
+          display_resource_name(resource),
+          [namespace, resource],
+          class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"
+      ) 
+      else
+        "&nbsp;".html_safe
+      end  %>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
In the DashboardManifest::DASHBOARDS allow nil to render an empty <li></li> to insert a space to help in grouping items.