### PR TITLE
Release version 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Upcoming Release
 
+### 0.1.4 (February 20, 2016)
+
 * [#464] [CHANGE] Replace the DashboardManifest with explicit Rails routes.
   * Run `rails generate administrate:routes` to generate the default routes.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    administrate (0.1.3)
+    administrate (0.1.4)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate", "~> 0.1.3"
+gem "administrate", "~> 0.1.4"
 ```
 
 Re-bundle, then run the installer:

--- a/lib/administrate/version.rb
+++ b/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.1.3"
+  VERSION = "0.1.4".freeze
 end


### PR DESCRIPTION
## Problem:

v0.1.3 contained a breaking change
that made the first-run generators fail.

## Solution:

v0.1.4 fixes the issue by deprecating the `DashboardManifest`.

## Changes

* #464 [CHANGE] Replace the DashboardManifest with explicit Rails routes.
  * Run `rails generate administrate:routes` to generate the default routes.