### PR TITLE
Wrap table cell contents instead of CSS truncation

### DIFF
--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -20,6 +20,4 @@ td {
   font-kerning: normal;
   font-variant-ligatures: common-ligatures, contextual;
   font-variant-numeric: lining-nums, tabular-nums;
-  white-space: normal;
-  word-wrap: break-word;
 }

--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -20,8 +20,6 @@ td {
   font-kerning: normal;
   font-variant-ligatures: common-ligatures, contextual;
   font-variant-numeric: lining-nums, tabular-nums;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  word-wrap: normal;
+  white-space: normal;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
I'm not sure what discussion led to this being added since the ticket referenced in ae61171e isn't public. However, I don't like the existing solution because:
- It [doesn't work](https://administrate-prototype.herokuapp.com/admin/customers?direction=desc&order=updated_at)
- The `Field::Text` type already offers truncation with ellipsis, so it duplicates logic to also perform that here. If someone sets a truncation value in their dashboard, they shouldn't have to fiddle with the CSS to have their chosen length respected.

This changes table cells to wrap normally, and to force line breaks on super long strings that don't have a natural break.
