### PR TITLE
Updating has_many label to titleize as per other fields in form view.

### DIFF
--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -20,7 +20,7 @@ and is augmented with [Selectize].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute_key, field.attribute %>
+  <%= f.label field.attribute_key, field.attribute.to_s.titleize %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -20,7 +20,7 @@ describe "fields/has_many/_form", type: :view do
   def fake_form_builder
     double("Form Builder").as_null_object.tap do |form_builder|
       allow(form_builder).to receive(:label) do |*args|
-        args.second.to_s.titleize
+        args.second.to_s
       end
     end
   end


### PR DESCRIPTION
Also updated the spec form double to behave the same as Rails label, in that it doesn't automatically titleize.
