### PR TITLE
Update changelog for v0.1.4 with breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
 
 * [#464] [CHANGE] Replace the DashboardManifest with explicit Rails routes.
   * Run `rails generate administrate:routes` to generate the default routes.
+* [#467] [CHANGE] Update the internal field path to fit Ruby conventions
+  ```ruby
+  # Change any instances of this...
+  require "administrate/fields/base"
+  # ...to this:
+  require "administrate/field/base"
+  ```
 
 ### 0.1.3 (January 22, 2016)
 


### PR DESCRIPTION
## Problem:

As discussed in https://github.com/thoughtbot/administrate/issues/489, essential update notes were left out of the changelog for v0.1.4.

The release contained breaking changes, but users were not appropriately notified about how to fix the change.

## Solution:

Add more detail to the v0.1.4 CHANGELOG notes.