### PR TITLE
Use I18n translations for custom labels on dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 ### Upcoming Release
 
+* [#492] [FEATURE] Translate attribute labels on show and index pages.
+  To customize an attribute label, add translations according to the structure:
+    ```
+    en:
+      helpers:
+        label:
+          customer:
+            name: Full Name
+    ```
+
 ### 0.2.0 (April 20, 2016)
 
 * [#476] [CHANGE] Extract `Administrate::Field::Image` into its own gem.

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -109,6 +109,7 @@ module Administrate
 
     delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
     helper_method :namespace
+    helper_method :resource_name
 
     def resource_resolver
       @_resource_resolver ||=

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -22,13 +22,17 @@ to display a collection of resources in an HTML table.
   <thead>
     <tr>
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
-        <th class="cell-label cell-label--<%= attr_type.html_class %>
-          cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
         " scope="col">
         <%= link_to(params.merge(
           collection_presenter.order_params_for(attr_name)
         )) do %>
-            <%= attr_name.to_s.titleize %>
+        <%= t(
+          "helpers.label.#{resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
 
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -31,7 +31,12 @@ as well as a link to its edit page.
 
 <dl>
   <% page.attributes.each do |attribute| %>
-    <dt class="attribute-label"><%= attribute.name.titleize %></dt>
+    <dt class="attribute-label">
+    <%= t(
+      "helpers.label.#{resource_name}.#{attribute.name}",
+      default: attribute.name.titleize,
+    ) %>
+    </dt>
 
     <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
         ><%= render_field attribute %></dd>

--- a/app/views/fields/date_time/_show.html.erb
+++ b/app/views/fields/date_time/_show.html.erb
@@ -17,5 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= l field.data %>
+  <%= l(field.data, default: field.data) %>
 <% end %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -36,5 +36,5 @@ from the associated resource class's dashboard.
   <% end %>
 
 <% else %>
-  <%= t("administrate.fields.has_many.none") %>
+  <%= t("administrate.fields.has_many.none", default: "–") %>
 <% end %>

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -76,4 +76,15 @@ if the value is stored by the number of cents:
   )
 ```
 
+To change the user-facing label for an attribute,
+define a custom I18n translation:
+
+```yaml
+en:
+  helpers:
+    label:
+      customer:
+        name: Full Name
+```
+
 [define your own]: /adding_custom_field_types

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -8,4 +8,24 @@ describe "edit form" do
 
     expect(page).to have_css("form.form")
   end
+
+  it "displays translated labels" do
+    custom_label = "Newsletter Subscriber"
+
+    translations = {
+      helpers: {
+        label: {
+          customer: {
+            email_subscriber: custom_label,
+          },
+        },
+      },
+    }
+
+    with_translations(:en, translations) do
+      visit new_admin_customer_path
+
+      expect(page).to have_label(custom_label)
+    end
+  end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -38,6 +38,26 @@ describe "customer index page" do
     expect(current_path).to eq(new_admin_customer_path)
   end
 
+  it "displays translated labels" do
+    custom_label = "Newsletter Subscriber"
+
+    translations = {
+      helpers: {
+        label: {
+          customer: {
+            email_subscriber: custom_label,
+          },
+        },
+      },
+    }
+
+    with_translations(:en, translations) do
+      visit admin_customers_path
+
+      expect(page).to have_table_header(custom_label)
+    end
+  end
+
   it "paginates records based on a constant" do
     customers = create_list(:customer, 2)
 

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -58,4 +58,25 @@ RSpec.describe "customer show page" do
 
     expect(page).to have_header("Edit #{displayed(customer)}")
   end
+
+  it "displays translated labels" do
+    custom_label = "Newsletter Subscriber"
+    customer = create(:customer)
+
+    translations = {
+      helpers: {
+        label: {
+          customer: {
+            email_subscriber: custom_label,
+          },
+        },
+      },
+    }
+
+    with_translations(:en, translations) do
+      visit admin_customer_path(customer)
+
+      expect(page).to have_css(".attribute-label", text: custom_label)
+    end
+  end
 end

--- a/spec/support/features/page_elements.rb
+++ b/spec/support/features/page_elements.rb
@@ -2,4 +2,12 @@ module Features
   def have_header(title)
     have_css("h1", text: title)
   end
+
+  def have_label(title)
+    have_css("label", text: title)
+  end
+
+  def have_table_header(title)
+    have_css("th", text: title)
+  end
 end


### PR DESCRIPTION
## Problem:

There was uncertainty about how to create custom labels for fields. In https://github.com/thoughtbot/administrate/issues/451, it was suggested that we could use I18n translations to solve the problem.

If we accept that as the standard way to set custom labels, we should have a test for it.

## Solution:

- Add a test to verify that labels can be customized through I18n.
- Add documentation about how to customize labels

## To Do:

- [x] Update view code so the same translation definition applies on the show and collection pages, in addition to the form page.