### PR TITLE
[#484] Fix views generator should pass args to sub-generator

### DIFF
--- a/lib/generators/administrate/views/views_generator.rb
+++ b/lib/generators/administrate/views/views_generator.rb
@@ -4,10 +4,10 @@ module Administrate
   module Generators
     class ViewsGenerator < Administrate::ViewGenerator
       def copy_templates
-        call_generator("administrate:views:index", resource_path)
-        call_generator("administrate:views:show", resource_path)
-        call_generator("administrate:views:new", resource_path)
-        call_generator("administrate:views:edit", resource_path)
+        call_generator("administrate:views:index", *args)
+        call_generator("administrate:views:show", *args)
+        call_generator("administrate:views:new", *args)
+        call_generator("administrate:views:edit", *args)
       end
     end
   end


### PR DESCRIPTION
I think that administrate:views generator is generating files into incorrect directory /app/views/applications which should be /app/views/application instead (without s).
