### PR TITLE
let routes generator indent all routes (#505).

### DIFF
--- a/lib/generators/administrate/routes/templates/routes.rb.erb
+++ b/lib/generators/administrate/routes/templates/routes.rb.erb
@@ -1,5 +1,5 @@
 namespace :admin do
-    <% dashboard_resources.each do |resource| %>resources :<%= resource %>
-<% end %>
+<% dashboard_resources.each do |resource| %>    resources :<%= resource %>
+<%end%>
     root to: "<%= dashboard_resources.first %>#index"
   end


### PR DESCRIPTION
Routes generated before:

```
  namespace :admin do
    resources :departments
resources :services
resources :service_types
resources :usages

    root to: "departments#index"
  end
```

and after:

```
  namespace :admin do
    resources :departments
    resources :services
    resources :service_types
    resources :usages

    root to: "departments#index"
  end
```

Unfortunately, no spec for that (spec just checks occurence of routes).
