### PR TITLE
Add example of how to use a custom field

### DIFF
--- a/docs/adding_custom_field_types.md
+++ b/docs/adding_custom_field_types.md
@@ -56,16 +56,24 @@ Since we want to display an image, we can change it to:
 You can customize the other generated partials in the same way
 for custom behavior on the index and form pages.
 
-To use your custom field types, change the type of an attribute in one of the Dashboard-Files (e.g. `app/dashboard/user_dashboard.rb`) to your new field type:
+## Using your custom field
 
-```eruby
-ATTRIBUTE_TYPES = {
-  id: Field::Number,
-  name: Field::String,
-  created_at: Field::DateTime,
-  updated_at: Field::DateTime,
-  gravatar: GravatarField
-}
+We need to tell Administrate which attributes we'd like to be displayed as a
+gravatar image.
+
+Open up a dashboard file, and add the gravatar field into the `ATTRIBUTE_TYPES`
+hash. It should look something like:
+
+```ruby
+class UserDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    name: Field::String,
+    email: GravatarField,    # Update this email to use your new field class
+    # ...
+  }
+end
 ```
 
 [Customizing Attribute Partials]: /customizing_attribute_partials


### PR DESCRIPTION
## Problem:

The documentation for creating custom field types does not tell the user how to use the custom field.

This gap in documentation was brought up by @estiens in https://github.com/thoughtbot/administrate/issues/164.
## Solution:

Add a note about how to use custom fields.
