### PR TITLE
Only list resources if they're in the manifest

### DIFF
--- a/spec/administrate/namespace_spec.rb
+++ b/spec/administrate/namespace_spec.rb
@@ -15,5 +15,27 @@ describe Administrate::Namespace do
         reset_routes
       end
     end
+
+    it "excludes routes that are not defined in the dashboard manifest" do
+      begin
+        class DashboardManifest
+          DASHBOARDS = [:customers].freeze
+        end
+
+        namespace = Administrate::Namespace.new(:admin)
+
+        Rails.application.routes.draw do
+          namespace(:admin) do
+            resources :customers
+            resources :purchases
+          end
+        end
+
+        expect(namespace.resources).to eq [:customers]
+      ensure
+        reset_routes
+        remove_constants :DashboardManifest
+      end
+    end
   end
 end


### PR DESCRIPTION
If the dashboard manifest lists out the resources `administrate` is
working with, then the links in the sidebar should only link to those
resources.

As of this commit `Administrate::Namespace` was inferring which resources
to list based on what routes had `"#{namespace}/"` in the path. If you add
a route in the namespace for a resource you do NOT want to show up, it
is possible that it would break.