### PR TITLE
Ignore routes marked `administrate: false`

### DIFF
--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -21,7 +21,13 @@ module Administrate
     end
 
     def all_controller_paths
-      Rails.application.routes.routes.map do |route|
+      Rails.application.routes.routes.select do |route|
+        if route.defaults[:administrate].nil?
+          true
+        else
+          route.defaults[:administrate]
+        end
+      end.map do |route|
         route.defaults[:controller].to_s
       end
     end

--- a/spec/administrate/namespace_spec.rb
+++ b/spec/administrate/namespace_spec.rb
@@ -5,12 +5,30 @@ describe Administrate::Namespace do
   describe "#resources" do
     it "searches the routes for resources in the namespace" do
       begin
-        namespace = Administrate::Namespace.new(:admin)
         Rails.application.routes.draw do
           namespace(:admin) { resources :customers }
         end
 
+        namespace = Administrate::Namespace.new(:admin)
+
         expect(namespace.resources).to eq [:customers]
+      ensure
+        reset_routes
+      end
+    end
+
+    it "leaves out resources marked administrate: false" do
+      begin
+        Rails.application.routes.draw do
+          namespace(:admin) do
+            resources :customers, administrate: false
+            resources :products, administrate: true
+          end
+        end
+
+        namespace = Administrate::Namespace.new(:admin)
+
+        expect(namespace.resources).to eq [:products]
       ensure
         reset_routes
       end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :customers
     resources :line_items
     resources :orders
-    resources :products
+    resources :products, administrate: false
 
     root to: "customers#index"
   end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :customers
     resources :line_items
     resources :orders
-    resources :products, administrate: false
+    resources :products
 
     root to: "customers#index"
   end


### PR DESCRIPTION
Possibly fixes #511
## Problem:

Users often define routes in the `admin` namespace
that they don't want to show up in the sidebar.
At the moment, Administrate creates a sidebar link
for all routes in the `admin` namepsace,
without a way to ignore them.
## Solution:

Add an `administrate: false` option for dashboard routes
that will prevent Administrate
from creating a sidebar link for the resource.
