### PR TITLE
Add spacing below form buttons

### DIFF
--- a/app/assets/stylesheets/administrate/components/_form-actions.scss
+++ b/app/assets/stylesheets/administrate/components/_form-actions.scss
@@ -1,3 +1,4 @@
 .form-actions {
   @include shift(2);
+  margin-bottom: $base-spacing * 4;
 }


### PR DESCRIPTION
Right now, if you have a longer form the submit button butts right up against the bottom edge of the viewport. This PR add some spacing below the form to alleviate this.