### PR TITLE
Fix translations for show.html and index.html

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -28,7 +28,7 @@ to display a collection of resources in an HTML table.
         <%= link_to(params.merge(
           collection_presenter.order_params_for(attr_name)
         )) do %>
-            <%= attr_name.to_s.titleize %>
+            <%= t("activerecord.attributes.#{collection_presenter.resource_name}.#{attr_name.to_s}").titleize %>
 
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -31,8 +31,7 @@ as well as a link to its edit page.
 
 <dl>
   <% page.attributes.each do |attribute| %>
-    <dt class="attribute-label"><%= attribute.name.titleize %></dt>
-
+    <dt class="attribute-label"><%= t("activerecord.attributes.#{page.resource_name}.#{attribute.name}").titleize %></dt>
     <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
         ><%= render_field attribute %></dd>
   <% end %>


### PR DESCRIPTION
I found missing translations for model attributes at show.html and index.html. This pull request fix that.
I bet that could be better ways of doing that, but this will do the trick! 

While not merged I'm using a forked version from my own repo. If anyone need this translations fell free to get the gem from:

`gem 'administrate', :git => 'git://github.com/pvbraga/administrate.git'`
