### PR TITLE
Add a short section about how to report vulnerabilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ of an optimization's overall impact.
 Tools like [Rack MiniProfiler] are helpful
 for generating request-level performance profiles.
 
+## Security
+
+For security inquiries or vulnerability reports, please email
+<security@thoughtbot.com>.
+If you'd like, you can use our [PGP key] when reporting vulnerabilities.
+
 [code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
 [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [Rack MiniProfiler]: https://github.com/MiniProfiler/rack-mini-profiler
+[PGP key]: https://thoughtbot.com/thoughtbot.asc
+


### PR DESCRIPTION
I initially reported the CSRF [vulnerability](https://github.com/thoughtbot/administrate/commit/be738a54b866191bf49664d8c6116587fb971759) to @graysonwright's email in the gemspec but the email got bounced back. We probably should fix that.

Also, the repository doesn't include instructions about reporting vulnerabilities so I thought maybe we should include one. :wink:
