### PR TITLE
Add binstubs for merging PRs and releasing the gem

### DIFF
--- a/bin/merge
+++ b/bin/merge
@@ -1,0 +1,28 @@
+#!/usr/bin/env zsh
+
+CURRENT_BRANCH="$(git symbolic-ref HEAD --short)"
+BRANCH_NAME=${1-$CURRENT_BRANCH}
+echo "Merging branch: $BRANCH_NAME"
+
+git fetch &&\
+echo 'git checkout $BRANCH_NAME' &&\
+git checkout $BRANCH_NAME &&\
+echo 'git rebase -i origin/master' &&\
+git rebase -i origin/master &&\
+echo 'git push -f' &&\
+git push --force-with-lease &&\
+echo 'bundle exec rake' &&\
+bundle exec rake &&\
+appraisal rake &&\
+echo 'git checkout master' &&\
+git checkout master &&\
+echo 'git pull' &&\
+git pull &&\
+echo 'git merge --ff-only $BRANCH_NAME' &&\
+git merge --ff-only $BRANCH_NAME &&\
+echo 'git push' &&\
+git push &&\
+echo 'git branch -d $BRANCH_NAME ' &&\
+git branch -d $BRANCH_NAME && \
+echo 'git push -f origin :$BRANCH_NAME' &&\
+git push --force-with-lease origin :$BRANCH_NAME; \

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,23 @@
+# Exit if any subcommand fails
+set -e
+
+VERSION=$(ruby -r ./lib/administrate/version.rb -e "puts Administrate::VERSION")
+gem build administrate.gemspec
+gem install administrate-$(VERSION).gem
+
+
+GEMFILE=$(cat Gemfile | sed "s/^gemspec$/gem \"administrate\", \"$VERSION\"/")
+echo $GEMFILE > Gemfile
+bundle
+
+bundle exec rake
+bundle exec appraisal rake
+
+gem uninstall administrate -v $VERSION
+gem push administrate-$VERSION.gem
+
+bundle
+bundle exec rake
+bundle exec appraisal rake
+
+echo "Administrate version $VERSION was released successfully."


### PR DESCRIPTION
As a maintainer,
I want to automate the processes of merging PRs
and releasing new versions of the gem
so I don't have to remember and repeat the steps in those processes.