### PR TITLE
remove the fuubar gem

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---format Fuubar

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ group :test do
   gem "ammeter"
   gem "database_cleaner"
   gem "formulaic"
-  gem "fuubar"
   gem "launchy"
   gem "percy-capybara"
   gem "poltergeist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,9 +118,6 @@ GEM
       activesupport
       capybara
       i18n
-    fuubar (2.0.0)
-      rspec (~> 3.0)
-      ruby-progressbar (~> 1.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashdiff (0.2.2)
@@ -218,10 +215,6 @@ GEM
     rake (11.1.2)
     rdiscount (1.6.8)
     redcarpet (3.3.3)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -239,7 +232,6 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
@@ -308,7 +300,6 @@ DEPENDENCIES
   factory_girl_rails
   faker
   formulaic
-  fuubar
   high_voltage
   i18n-tasks
   launchy

--- a/gemfiles/bourbon_5.gemfile
+++ b/gemfiles/bourbon_5.gemfile
@@ -33,7 +33,6 @@ group :test do
   gem "ammeter"
   gem "database_cleaner"
   gem "formulaic"
-  gem "fuubar"
   gem "launchy"
   gem "percy-capybara"
   gem "poltergeist"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -33,7 +33,6 @@ group :test do
   gem "ammeter"
   gem "database_cleaner"
   gem "formulaic"
-  gem "fuubar"
   gem "launchy"
   gem "percy-capybara"
   gem "poltergeist"


### PR DESCRIPTION
fixes #542 

While doing a Rails 5 update, I had to appraise to a beta version of RSpec (3.5.0.beta3). While doing so, FuuBar was only set up for up to RSpec 3.4. There is currently an open PR to add 3.5.0.beta1 support, but it was back in February which sends a message that the FuuBar gem is not actively maintained. FuuBar may not be the best gem to use in a project which needs to cover multiple versions of Rails and RSpec.