### PR TITLE
Fix `bin/release` script for pushing to rubygems

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -2,18 +2,19 @@
 set -e
 
 VERSION=$(ruby -r ./lib/administrate/version.rb -e "puts Administrate::VERSION")
+echo "Version $VERSION"
 gem build administrate.gemspec
-gem install administrate-$(VERSION).gem
+gem install administrate-${VERSION}.gem
 
-
-GEMFILE=$(cat Gemfile | sed "s/^gemspec$/gem \"administrate\", \"$VERSION\"/")
-echo $GEMFILE > Gemfile
+sed -i.bak "s/^gemspec$/gem \"administrate\", \"`echo $VERSION`\"/g" Gemfile
+rm Gemfile.bak
 bundle
 
 bundle exec rake
 bundle exec appraisal rake
 
 gem uninstall administrate -v $VERSION
+echo "Gem is verified and ready to go."
 gem push administrate-$VERSION.gem
 
 bundle
@@ -21,3 +22,12 @@ bundle exec rake
 bundle exec appraisal rake
 
 echo "Administrate version $VERSION was released successfully."
+
+git checkout -- Gemfile*
+
+echo
+echo "Finish up by merging the branch and tagging the commit:"
+echo "bin/merge"
+echo "git tag v$VERSION"
+echo "git push --tags"
+echo "https://github.com/thoughtbot/administrate/releases/new"


### PR DESCRIPTION
CC @jberlinsky

## Problem:

There were a few bugs in the `bin/release` script
that prevented a successful push to rubygems

## Solution:

Update the script to successfully push a release to rubygems.

## TODO:

- it's still getting hung up on the `appraisal install` step.