### PR TITLE
Feature scope option

### DIFF
--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -10,7 +10,8 @@ module Administrate
       protected
 
       def candidate_resources
-        return associated_class.public_send(options[:scope], data) if options[:scope]
+        scope = options[:scope]
+        return associated_class.public_send(scope, data) if scope
         associated_class.all
       end
 

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -9,6 +9,11 @@ module Administrate
 
       protected
 
+      def candidate_resources
+        return associated_class.public_send(options[:scope], data) if options[:scope]
+        associated_class.all
+      end
+
       def associated_dashboard
         "#{associated_class_name}Dashboard".constantize.new
       end

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -23,10 +23,6 @@ module Administrate
 
       private
 
-      def candidate_resources
-        associated_class.all
-      end
-
       def display_candidate_resource(resource)
         associated_dashboard.display_resource(resource)
       end

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -46,10 +46,6 @@ module Administrate
 
       private
 
-      def candidate_resources
-        associated_class.all
-      end
-
       def display_candidate_resource(resource)
         associated_dashboard.display_resource(resource)
       end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -7,6 +7,8 @@ describe Administrate::Field::BelongsTo do
 
   it { should_permit_param(:foo_id, for_attribute: :foo) }
 
+  it_behaves_like "field_with_scope_option", Administrate::Field::BelongsTo
+
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -3,6 +3,8 @@ require "support/constant_helpers"
 require "support/mock_relation"
 
 describe Administrate::Field::HasMany do
+  it_behaves_like "field_with_scope_option", Administrate::Field::HasMany
+
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show

--- a/spec/support/shared_examples/field_with_scope_option.rb
+++ b/spec/support/shared_examples/field_with_scope_option.rb
@@ -1,0 +1,20 @@
+RSpec.shared_examples "field_with_scope_option" do |field_class|
+  describe "scope option" do
+    it "provides resource options through a model scope" do
+      begin
+        ScopeTest = Class.new
+        allow(ScopeTest).to receive(:test_scope).and_return([])
+        allow(ScopeTest).to receive(:all).and_return([])
+
+        association = field_class.with_options(scope: :test_scope)
+        field = association.new(:scope_test, [], :show)
+        candidates = field.associated_resource_options
+
+        expect(ScopeTest).to have_received(:test_scope)
+        expect(ScopeTest).not_to have_received(:all)
+      ensure
+        remove_constants :ScopeTest
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/field_with_scope_option.rb
+++ b/spec/support/shared_examples/field_with_scope_option.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples "field_with_scope_option" do |field_class|
 
         association = field_class.with_options(scope: :test_scope)
         field = association.new(:scope_test, [], :show)
-        candidates = field.associated_resource_options
+        field.associated_resource_options
 
         expect(ScopeTest).to have_received(:test_scope)
         expect(ScopeTest).not_to have_received(:all)


### PR DESCRIPTION
I don't know if the functionality is desirable but I've found myself needing it on more than one occasion, so I figured I'd put this out there for feedback.

Why:
- So a scope can be passed to an association field

This change addresses the need by:
- Moving candidate_resources to the associative class
- Handling when a scope is present
- Passing the current data to the scope as params
