### PR TITLE
Loosen normalize-rails required version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       kaminari (>= 1.0)
       momentjs-rails (~> 2.8)
       neat (~> 1.1)
-      normalize-rails (~> 3.0)
+      normalize-rails (>= 3.0)
       rails (>= 4.2, < 5.1)
       sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
@@ -178,7 +178,7 @@ GEM
       thor (~> 0.19)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-    normalize-rails (3.0.3)
+    normalize-rails (4.1.1)
     pg (0.18.3)
     poltergeist (1.12.0)
       capybara (~> 2.1)
@@ -333,4 +333,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.4
+   1.14.5

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", ">= 1.0"
   s.add_dependency "momentjs-rails", "~> 2.8"
   s.add_dependency "neat", "~> 1.1"
-  s.add_dependency "normalize-rails", "~> 3.0"
+  s.add_dependency "normalize-rails", ">= 3.0"
   s.add_dependency "rails", ">= 4.2", "< 5.1"
   s.add_dependency "sass-rails", "~> 5.0"
   s.add_dependency "selectize-rails", "~> 0.6"


### PR DESCRIPTION
Normalize 4.x has been released a couple weeks ago ([changelog](https://github.com/necolas/normalize.css/blob/master/CHANGELOG.md))
Administrate was locking normalize-rails version to 3.x, that forces any
recent Rails app to stick with Normalize 3.x.
Instead of locking 4.x, this commit suggests to loosen the required
version for Administrate to run as it shouldn't have an impact on it's base styles.

Do you agree, or prefer requiring `~> 4.0` which may force existing apps relaying on 3.x to upgrade before upgrading Administrate.
