### PR TITLE
Feature/localized dates

### DIFF
--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -17,5 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= l field.data.to_date %>
+  <%= field.date %>
 <% end %>

--- a/app/views/fields/date_time/_show.html.erb
+++ b/app/views/fields/date_time/_show.html.erb
@@ -17,5 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= l(field.data, default: field.data) %>
+  <%= field.datetime %>
 <% end %>

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -3,6 +3,19 @@ require_relative "base"
 module Administrate
   module Field
     class DateTime < Base
+      def date
+        I18n.localize(data.to_date, format: format)
+      end
+
+      def datetime
+        I18n.localize(data, format: format, default: data)
+      end
+
+      private
+
+      def format
+        options.fetch(:format, :default)
+      end
     end
   end
 end

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -1,6 +1,82 @@
-require "spec_helper"
+require "rails_helper"
 require "administrate/field/date_time"
-require "support/field_matchers"
 
 describe Administrate::Field::DateTime do
+  let(:start_date) { DateTime.parse("2015-12-25 10:15:45") }
+  let(:formats) do
+    {
+      date: {
+        formats: { default: "%m/%d/%Y", short: "%b %d" },
+        abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 },
+      },
+      time: {
+        formats: { default: "%a, %b %-d, %Y at %r", short: "%d %b %H:%M" },
+      },
+    }
+  end
+
+  describe "#date" do
+    it "displays the date" do
+      with_translations(:en, formats) do
+        field = Administrate::Field::DateTime.
+          new(:start_date, start_date, :show)
+        expect(field.date).to eq("12/25/2015")
+      end
+    end
+
+    context "with `prefix` option" do
+      it "displays the date in the requested format" do
+        options_field = Administrate::Field::DateTime.
+          with_options(format: :short)
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.date).to eq("Dec 25")
+        end
+      end
+
+      it "displays the date using a format string" do
+        options_field = Administrate::Field::DateTime.
+          with_options(format: "%Y")
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.date).to eq("2015")
+        end
+      end
+    end
+  end
+
+  describe "#datetime" do
+    it "displays the datetime" do
+      field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+
+      with_translations(:en, formats) do
+        expect(field.datetime).to eq("Fri, Dec 25, 2015 at 10:15:45 AM")
+      end
+    end
+
+    context "with `prefix` option" do
+      it "displays the datetime in the requested format" do
+        options_field = Administrate::Field::DateTime.
+          with_options(format: :short)
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.datetime).to eq("25 Dec 10:15")
+        end
+      end
+
+      it "displays the datetime format string" do
+        options_field = Administrate::Field::DateTime.
+          with_options(format: "%H:%M")
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.datetime).to eq("10:15")
+        end
+      end
+    end
+  end
 end

--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     new_backend = I18n::Backend::KeyValue.new({}, true)
     new_backend.store_translations(locale, translations)
 
-    I18n.backend = I18n::Backend::Chain.new(original_backend, new_backend)
+    I18n.backend = I18n::Backend::Chain.new(new_backend, original_backend)
 
     yield
   ensure


### PR DESCRIPTION
Currently there's no control over the display format of the DateTimes in Administrate. This pull request adds a `format` option to a `Field::DateTime` field.
e.g.

``` ruby
created_at: Field::DateTime.with_options(format: :short)
```

By default, if no option is passed the `default` format is used  - which is was is done implicitly currently. 

Alternatively, formats can be added to the in the local `yaml` files and referred to by key
e.g.

``` yaml
en:
   date:
      formats:
         year_only: "%Y"
```

``` ruby
created_at: Field::DateTime.with_options(format: :year_only)
```

Format strings can also be used:

``` ruby
created_at: Field::DateTime.with_options(format: "%Y")
```

I re-used the `with_translations` helper to isolate the formats defined in any `en.yml` files. I moved it into a module to make it easier to reuse. 

Let me know what you think.
