### PR TITLE
Add engine class methods for registering assets

### DIFF
--- a/app/views/administrate/application/_javascript.html.erb
+++ b/app/views/administrate/application/_javascript.html.erb
@@ -7,7 +7,9 @@ but each page can define additional JS sources
 by providing a `content_for(:javascript)` block.
 %>
 
-<%= javascript_include_tag "administrate/application" %>
+<% Administrate::Engine.javascripts.each do |js_path| %>
+  <%= javascript_include_tag js_path %>
+<% end %>
 
 <%= yield :javascript %>
 

--- a/app/views/administrate/application/_stylesheet.html.erb
+++ b/app/views/administrate/application/_stylesheet.html.erb
@@ -7,6 +7,8 @@ but each page can define additional CSS sources
 by providing a `content_for(:stylesheet)` block.
 %>
 
-<%= stylesheet_link_tag "administrate/application", media: "all" %>
+<% Administrate::Engine.stylesheets.each do |css_path| %>
+  <%= stylesheet_link_tag css_path %>
+<% end %>
 
 <%= yield :stylesheet %>

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -20,6 +20,28 @@ module Administrate
   class Engine < ::Rails::Engine
     isolate_namespace Administrate
 
+    @@javascripts = []
+    @@stylesheets = []
+
     Engine.config.assets.precompile << /\.(?:svg)\z/
+
+    def self.add_javascript(script)
+      @@javascripts << script
+    end
+
+    def self.add_stylesheet(stylesheet)
+      @@stylesheets << stylesheet
+    end
+
+    def self.stylesheets
+      @@stylesheets
+    end
+
+    def self.javascripts
+      @@javascripts
+    end
+
+    add_javascript "administrate/application"
+    add_stylesheet "administrate/application"
   end
 end


### PR DESCRIPTION
See https://github.com/thoughtbot/administrate/issues/566

## Problem:

When developing a plugin for Administrate,
there is not a good way to define custom javascripts or stylesheets
to be included on admin pages.

Existing solutions either use `content_for` at the field level,
or require the end user to override Administrate's javascript partial.

## Solution:

Add methods to `Administrate::Engine` to keep track of the assets
that need to be loaded on each admin page.

Plugin developers can now use these helpers in their engine definition:

```ruby
Administrate::Engine.add_javascript "my_plugin/script"
Administrate::Engine.add_stylesheet "my_plugin/styles"
```