### PR TITLE
Use correct inflection for has-many counts of 1

### DIFF
--- a/app/views/fields/has_many/_index.html.erb
+++ b/app/views/fields/has_many/_index.html.erb
@@ -16,4 +16,4 @@ as a count of how many objects are associated through the relationship.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
 %>
 
-<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase) %>
+<%= pluralize(field.data.size, field.attribute.to_s.humanize.singularize.downcase) %>

--- a/spec/administrate/views/fields/has_many/_index_spec.rb
+++ b/spec/administrate/views/fields/has_many/_index_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe "fields/has_many/_index", type: :view do
+  context "without an associated record" do
+    it "renders a plural description" do
+      has_many = instance_double(
+        "Administrate::Field::HasMany",
+        attribute: 'products',
+        data: []
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("0 products")
+    end
+  end
+
+  context "with one associated record" do
+    it "renders a singular description" do
+      product = create(:product)
+      has_many = instance_double(
+        "Administrate::Field::HasMany",
+        attribute: :products,
+        data: [product]
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("1 product")
+    end
+  end
+
+  context "with more than one associated record" do
+    it "renders a plural description" do
+      products = create_list(:product, 3)
+      has_many = instance_double(
+        "Administrate::Field::HasMany",
+        attribute: :products,
+        data: products
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("3 products")
+    end
+  end
+end

--- a/spec/administrate/views/fields/has_many/_index_spec.rb
+++ b/spec/administrate/views/fields/has_many/_index_spec.rb
@@ -5,8 +5,8 @@ describe "fields/has_many/_index", type: :view do
     it "renders a plural description" do
       has_many = instance_double(
         "Administrate::Field::HasMany",
-        attribute: 'products',
-        data: []
+        attribute: "products",
+        data: [],
       )
 
       render(
@@ -24,7 +24,7 @@ describe "fields/has_many/_index", type: :view do
       has_many = instance_double(
         "Administrate::Field::HasMany",
         attribute: :products,
-        data: [product]
+        data: [product],
       )
 
       render(
@@ -42,7 +42,7 @@ describe "fields/has_many/_index", type: :view do
       has_many = instance_double(
         "Administrate::Field::HasMany",
         attribute: :products,
-        data: products
+        data: products,
       )
 
       render(


### PR DESCRIPTION
This fixes the issue where a has-many association with one record will be
displayed with a plural on index pages, ex: "1 orders", instead of "1 order".

Rails expects the second argument to the pluralize helper to be the
singular form of the word.