### PR TITLE
Change dashboard USAGE to README

### DIFF
--- a/lib/generators/administrate/dashboard/README.md
+++ b/lib/generators/administrate/dashboard/README.md
@@ -1,0 +1,11 @@
+# Dashboard generators
+
+## Description:
+Generates a Dashboard object for a model,
+pulling the attributes from database columns.
+
+## Example:
+`rails generate administrate:dashboard FooBar`
+
+This will create:
+`app/dashboards/foo_bar_dashboard.rb`

--- a/lib/generators/administrate/dashboard/USAGE
+++ b/lib/generators/administrate/dashboard/USAGE
@@ -1,9 +1,0 @@
-Description:
-    Generates a Dashboard object for a model,
-    pulling the attributes from database columns.
-
-Example:
-    rails generate administrate:dashboard FooBar
-
-    This will create:
-        app/dashboards/foo_bar_dashboard.rb


### PR DESCRIPTION
Changed `USAGE` to `README.md` so that Github can pick up the file when browsing the dashboard generators and present the content.

![649989e2f74d0773ce9266ed3be0a900](https://cloud.githubusercontent.com/assets/4217826/15267767/1bf48fb6-19cb-11e6-9f33-860fb0a25e31.png)
