### PR TITLE
Allow links to resources to be hidden from the sidebar

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -5,6 +5,10 @@ module Administrate
       render locals: locals, partial: field.to_partial_path
     end
 
+    def include_resource_in_sidebar?(resource_name)
+      "#{resource_name.to_s.classify}Dashboard".constantize.new.show_in_sidebar?
+    end
+
     def display_resource_name(resource_name)
       resource_name.
         to_s.

--- a/app/views/administrate/application/_sidebar.html.erb
+++ b/app/views/administrate/application/_sidebar.html.erb
@@ -8,7 +8,9 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <ul class="sidebar__list">
-  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+  <% Administrate::Namespace.new(namespace).resources.select {|resource|
+  	  include_resource_in_sidebar?(resource)
+  	}.each do |resource| %>
     <li>
       <%= link_to(
         display_resource_name(resource),

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -53,6 +53,10 @@ module Administrate
       "#{resource.class} ##{resource.id}"
     end
 
+    def show_in_sidebar?
+      true
+    end
+
     private
 
     def attribute_not_found_message(attr)

--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -53,4 +53,11 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # def display_resource(<%= file_name %>)
   #   "<%= class_name %> ##{<%= file_name %>.id}"
   # end
+
+  # Overwrite this method to customize whether the index page for <%= file_name.pluralize.humanize.downcase %> 
+  # is included in the sidebar.
+  #
+  # def show_in_sidebar?
+  #   true
+  # end
 end

--- a/spec/example_app/app/dashboards/line_item_dashboard.rb
+++ b/spec/example_app/app/dashboards/line_item_dashboard.rb
@@ -25,4 +25,8 @@ class LineItemDashboard < Administrate::BaseDashboard
   def display_resource(line_item)
     "Line Item #%04d" % line_item.id
   end
+
+  def show_in_sidebar?
+    false
+  end
 end

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "line item index page" do
+  it "is hidden from sidebar" do
+    visit admin_root_path
+
+    expect(page).not_to have_link("Line Items")
+  end
+
   it "displays line items' information" do
     line_item = create(:line_item)
 


### PR DESCRIPTION
As per #536, I've found that the default behaviour of showing links to all resources' index pages in the sidebar is rarely desirable. 

I understand that it's possible to generate the sidebar and then put some logic in there - exclusions and the like. However, my experience from all use cases thus far (current project is the third time I'm using Administrate) tells me that this should be immediately available and obvious functionality. Thus this PR.
