### PR TITLE
Abstract model classes should be skipped without warning.

### DIFF
--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -43,7 +43,7 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants.reject { |klass| klass.abstract_class? }
+        ActiveRecord::Base.descendants.reject(&:abstract_class?)
       end
 
       def invalid_database_models

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -43,7 +43,7 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants
+        ActiveRecord::Base.descendants.reject { |klass| klass.abstract_class? }
       end
 
       def invalid_database_models

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -56,11 +56,11 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       routes = file("config/routes.rb")
       expect(routes).to have_correct_syntax
     end
-    
-    it 'skips abstract models without a warning' do
+
+    it "skips abstract models without a warning" do
       stub_generator_dependencies
       routes = file("config/routes.rb")
-      
+
       begin
         class AbstractModel < ActiveRecord::Base
           self.abstract_class = true

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -21,20 +21,22 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       stub_generator_dependencies
       routes = file("config/routes.rb")
 
-      run_generator
+      output = run_generator
 
       expect(routes).not_to contain("delayed/backend/active_record/jobs")
+      expect(output).to include("WARNING: Unable to generate a dashboard for Delayed::Backend::ActiveRecord::Job")
     end
 
-    it "skips models that aren't backed by the database" do
+    it "skips models that aren't backed by the database with a warning" do
       begin
         class ModelWithoutDBTable < ActiveRecord::Base; end
         stub_generator_dependencies
         routes = file("config/routes.rb")
 
-        run_generator
+        output = run_generator
 
         expect(routes).not_to contain("model_without_db_table")
+        expect(output).to include("WARNING: Unable to generate a dashboard for ModelWithoutDBTable")
       ensure
         remove_constants :ModelWithoutDBTable
       end
@@ -53,6 +55,22 @@ describe Administrate::Generators::RoutesGenerator, :generator do
 
       routes = file("config/routes.rb")
       expect(routes).to have_correct_syntax
+    end
+    
+    it 'skips abstract models without a warning' do
+      stub_generator_dependencies
+      routes = file("config/routes.rb")
+      
+      begin
+        class AbstractModel < ActiveRecord::Base
+          self.abstract_class = true
+        end
+
+        output = run_generator
+
+        expect(routes).not_to contain("abstract_model")
+        expect(output).not_to include("WARNING: Unable to generate a dashboard for AbstractModel")
+      end
     end
   end
 


### PR DESCRIPTION
I’ve also clarified the existing specs by including an assertion against the presence of a warning, so the name of the spec matches what is actually being tested.

I'm not 100% happy with checking against an exact match on the warning text but it seemed important to check for the presence (or absence) of a warning.

This is related to #581 but I'm not sure its the only issue I'm having with this generator on Rails 5.
