### PR TITLE
Release version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 ### Upcoming Release
 
+### 0.2.1 (May 18, 2016)
+
+* [#573] [FEATURE] Render custom javascripts and stylesheets to the page
+  by registering them with Administrate in an initializer.
+  For example, you can create `config/initializers/administrate.rb`
+  with the contents:
+    ```
+    Administrate::Engine.add_javascript "my_plugin/script"
+    Administrate::Engine.add_stylesheet "my_plugin/styles"
+    ```
 * [#567] [FEATURE] Add a partial for rendering HTML links to stylesheets.
   This is useful for plugin developers,
   as well as people who want to add custom stylesheets on a page-by-page basis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    administrate (0.2.0)
+    administrate (0.2.1)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate", "~> 0.2.0"
+gem "administrate", "~> 0.2.1"
 ```
 
 Re-bundle, then run the installer:

--- a/lib/administrate/version.rb
+++ b/lib/administrate/version.rb
@@ -1,3 +1,3 @@
 module Administrate
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end


### PR DESCRIPTION
Changes:

* [#573] [FEATURE] Render custom javascripts and stylesheets to the page
  by registering them with Administrate in an initializer.
  For example, you can create `config/initializers/administrate.rb`
  with the contents:
    ```
    Administrate::Engine.add_javascript "my_plugin/script"
    Administrate::Engine.add_stylesheet "my_plugin/styles"
    ```
* [#567] [FEATURE] Add a partial for rendering HTML links to stylesheets.
  This is useful for plugin developers,
  as well as people who want to add custom stylesheets on a page-by-page basis
  using `content_for(:stylesheet)`.
* [#492] [FEATURE] Translate attribute labels on show and index pages.
  To customize an attribute label, add translations according to the structure:
    ```
    en:
      helpers:
        label:
          customer:
            name: Full Name
    ```