### PR TITLE
Fix I18n translation for attributes in has_many collections

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -32,7 +32,7 @@ to display a collection of resources in an HTML table.
           collection_presenter.order_params_for(attr_name)
         )) do %>
         <%= t(
-          "helpers.label.#{resource_name}.#{attr_name}",
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
           default: attr_name.to_s,
         ).titleize %>
 

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -123,6 +123,35 @@ RSpec.describe "customer show page" do
     end
   end
 
+  it "displays translated labels in has_many collection partials" do
+    custom_label = "Time Shipped"
+    customer = create(:customer)
+    create(:order, customer: customer)
+
+    translations = {
+      administrate: {
+        actions: {
+          edit: "Edit",
+          destroy: "Destroy",
+          confirm: "Are you sure?",
+        },
+      },
+      helpers: {
+        label: {
+          order: {
+            shipped_at: custom_label,
+          },
+        },
+      },
+    }
+
+    with_translations(:en, translations) do
+      visit admin_customer_path(customer)
+
+      expect(page).to have_css(".cell-label", text: custom_label)
+    end
+  end
+
   def have_order_row(id)
     have_css('tr td:first-child', text: id)
   end


### PR DESCRIPTION
# Problem:

Following on from changes in #492... 

When collection partials are rendered in the context of a `has_many` field, translations for the attribute labels are currently being looked up under the parent model's scope. For example, label for `shipped_at` attribute on `Order` model is looking in `en: helpers: label: customer: shipped_at:`, rather than `en: helpers: label: order: shipped_at:`
# Solution:

Use `collection_presenter.resource_name`, which is scoped to the field being rendered, instead of `resource_name`. 
