### PR TITLE
Javascript: Fix row-click handler

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -6,10 +6,13 @@ $(function() {
         event.keyCode == keycodes.space ||
         event.keyCode == keycodes.enter) {
 
-      if (!event.target.href) {
-        var url = $(event.target).closest("tr").data("url");
+      if (event.target.href) {
+        return;
+      }
 
-        if (url) { window.location = url; }
+      var dataUrl = $(event.target).closest("tr").data("url");
+      if (dataUrl) {
+        window.location = dataUrl;
       }
     }
   };


### PR DESCRIPTION
Only enable entire row clicking if data-url is present, otherwise it triggers an error if you've customised the view and removed the data-url on the `tr` elements.
