### PR TITLE
Cancel click event when it comes from an input

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -2,6 +2,8 @@ $(function() {
   var keycodes = { space: 32, enter: 13 };
 
   var visitDataUrl = function(event) {
+    if ($(event.target).is('input')) { return }
+
     if (event.type=="click" ||
         event.keyCode == keycodes.space ||
         event.keyCode == keycodes.enter) {


### PR DESCRIPTION
When you want to add batch edit features (with checkboxes in table rows), the click event propagates and navigates to resource show page. 
Expected is to stay on the page.
