### PR TITLE
Allow specifying scope in with_options for a belongs_to field.

### DIFF
--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -24,7 +24,11 @@ module Administrate
       private
 
       def candidate_resources
-        associated_class.all
+        associated_class.public_send candidate_scope
+      end
+
+      def candidate_scope
+        options.fetch(:scope, :all)
       end
 
       def display_candidate_resource(resource)

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -37,4 +37,26 @@ describe Administrate::Field::BelongsTo do
       end
     end
   end
+
+  describe "scope option" do
+    it "determines which method is called to find candidate resources" do
+      begin
+        Foo = Class.new
+        allow(Foo).to receive(:all).and_return([])
+        allow(Foo).to receive(:widgets).and_return([])
+
+        association = Administrate::Field::BelongsTo.
+          with_options(class_name: "Foo", scope: :widgets)
+        field = association.new(:customers, [], :show)
+        candidates = field.associated_resource_options
+
+        expect(Foo).not_to have_received(:all)
+        expect(Foo).to have_received(:widgets)
+        expect(candidates).to eq([nil])
+      ensure
+        remove_constants :Foo
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Addresses #563. 

It's now possible to do:

``` ruby
class WidgetDashboard < Administrate::Dashboard
  ATTRIBUTE_TYPES = [
    manager: Field::BelongsTo.with_options(class_name: "User", scope: :managers)
  ]
end
```

where the `User` model has a scope named `managers`. If not specified, defaults to `all`, so no change in behaviour.
