### PR TITLE
Better use of i18n for field names

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -5,6 +5,18 @@ module Administrate
       render locals: locals, partial: field.to_partial_path
     end
 
+    def field_label_text(resource_name, field_name, alternate = nil)
+      resource_class = resource_name.to_s.classify.constantize
+
+      I18n.t(
+        "helpers.label.#{resource_name}.#{field_name}",
+        default: [
+          (:"helpers.label.#{resource_name}.#{alternate}" if alternate),
+          resource_class.human_attribute_name(field_name)
+        ].compact
+      )
+    end
+
     def display_resource_name(resource_name)
       resource_name.
         to_s.

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -29,10 +29,7 @@ to display a collection of resources in an HTML table.
         <%= link_to(params.merge(
           collection_presenter.order_params_for(attr_name)
         )) do %>
-        <%= t(
-          "helpers.label.#{resource_name}.#{attr_name}",
-          default: attr_name.to_s,
-        ).titleize %>
+            <%= field_label_text(resource_name, attr_name).titleize %>
 
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">

--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -32,7 +32,7 @@ and renders all form fields for a resource's editable attributes.
 
   <% page.attributes.each do |attribute| -%>
     <div class="field-unit field-unit--<%= attribute.html_class %>">
-      <%= render_field attribute, f: f %>
+      <%= render_field attribute, f: f, resource_name: page.resource_name %>
     </div>
   <% end -%>
 

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -32,10 +32,7 @@ as well as a link to its edit page.
 <dl>
   <% page.attributes.each do |attribute| %>
     <dt class="attribute-label">
-    <%= t(
-      "helpers.label.#{resource_name}.#{attribute.name}",
-      default: attribute.name.titleize,
-    ) %>
+      <%= field_label_text resource_name, attribute.name %>
     </dt>
 
     <dd class="attribute-data attribute-data--<%=attribute.html_class%>"

--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -17,7 +17,7 @@ that displays all possible records to associate with.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.permitted_attribute %>
+  <%= f.label field.permitted_attribute, field_label_text(resource_name, field.permitted_attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.permitted_attribute) do %>

--- a/app/views/fields/boolean/_form.html.erb
+++ b/app/views/fields/boolean/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a checkbox.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.check_box field.attribute %>

--- a/app/views/fields/date_time/_form.html.erb
+++ b/app/views/fields/date_time/_form.html.erb
@@ -17,7 +17,7 @@ By default, the input is a text field that is augmented with [DateTimePicker].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute, class: "datetimepicker" %>

--- a/app/views/fields/email/_form.html.erb
+++ b/app/views/fields/email/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text box.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.email_field field.attribute %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -20,7 +20,7 @@ and is augmented with [Selectize].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute_key, field.attribute %>
+  <%= f.label field.attribute_key, field_label_text(resource_name, field.attribute, field.attribute_key) %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>

--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -18,7 +18,7 @@ so this partial renders a message to that effect.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 
 <%= t("administrate.fields.has_one.not_supported") %>

--- a/app/views/fields/number/_form.html.erb
+++ b/app/views/fields/number/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text field.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute %>

--- a/app/views/fields/polymorphic/_form.html.erb
+++ b/app/views/fields/polymorphic/_form.html.erb
@@ -19,7 +19,7 @@ so this partial renders a message to that effect.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.name %>
+  <%= f.label field.name, field_label_text(resource_name, field.attribute) %>
 </div>
 
 <%= t("administrate.fields.polymorphic.not_supported") %>

--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -16,7 +16,7 @@ to be displayed on a resource's edit form page.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.select(

--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text field.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute %>

--- a/app/views/fields/text/_form.html.erb
+++ b/app/views/fields/text/_form.html.erb
@@ -15,7 +15,7 @@ This partial renders a textarea element for a text attribute.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field_label_text(resource_name, field.attribute) %>
 </div>
 <div class="field-unit__field">
   <%= f.text_area field.attribute %>

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe "fields/has_many/_form", type: :view do
+  include_context "fake_field_label"
+
   describe "the field label" do
     it "displays the association name" do
       has_many = double(
@@ -10,7 +12,9 @@ describe "fields/has_many/_form", type: :view do
 
       render(
         partial: "fields/has_many/form.html.erb",
-        locals: { f: fake_form_builder, field: has_many },
+        locals: { f: fake_form_builder,
+                  field: has_many,
+        }
       )
 
       expect(rendered).to include("Associated Objects")
@@ -24,4 +28,5 @@ describe "fields/has_many/_form", type: :view do
       end
     end
   end
+
 end

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "administrate/field/has_one"
 
 describe "fields/has_one/_form", type: :view do
+  include_context "fake_field_label"
+
   it "displays the field name" do
     has_one = instance_double(
       "Administrate::Field::HasOne",

--- a/spec/administrate/views/fields/polymorphic/_form_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_form_spec.rb
@@ -1,12 +1,16 @@
 require "rails_helper"
 
 describe "fields/polymorphic/_form", type: :view do
+  include_context "fake_field_label"
+
   it "displays the field name" do
     polymorphic = double(name: "Commentable")
+    allow(polymorphic).to receive(:attribute).and_return("commentable")
+    allow(polymorphic).to receive(:attribute_key).and_return("commentable_id")
 
     render(
       partial: "fields/polymorphic/form.html.erb",
-      locals: { field: polymorphic, f: form_builder },
+      locals: { field: polymorphic, f: form_builder }
     )
 
     expect(rendered.strip).to include("Commentable")
@@ -14,10 +18,11 @@ describe "fields/polymorphic/_form", type: :view do
 
   it "does not display a form" do
     polymorphic = double(name: "Commentable")
+    allow(polymorphic).to receive(:attribute).and_return("commentable")
 
     render(
       partial: "fields/polymorphic/form.html.erb",
-      locals: { field: polymorphic, f: form_builder },
+      locals: { field: polymorphic, f: form_builder }
     )
 
     expect(rendered).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,13 @@ RSpec.configure do |config|
   config.order = :random
 end
 
+RSpec.shared_context "fake_field_label" do
+  before do
+    allow(view).to receive(:field_label_text) do |_resource_name, field_name|
+      field_name.to_s
+    end
+    allow(view).to receive(:resource_name).and_return("spec_model")
+  end
+end
+
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Addresses #625 by adding the possibility to use `activerecord.attributes` locale namespace for attribute name translations. Unifies behavior across all places where fields were displayed - index, show and form pages.

As a special fallback, `has_many` fields also lookup their name with `_ids` suffix, if the short one is not present.  This was the original motivation for change, as their render naively used the field name and ignored all translations present.
