### PR TITLE
Normalize resource params

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -100,11 +100,15 @@ module Administrate
     end
 
     def resource_params
-      params.require(resource_name).permit(*permitted_attributes)
+      normalize params.require(resource_name).permit(*permitted_attributes)
     end
 
     def permitted_attributes
       dashboard.permitted_attributes
+    end
+
+    def normalize(params)
+      params.map { |attr, value| [attr, dashboard.normalize(attr, value)] }.to_h
     end
 
     delegate :resource_class, :resource_name, :namespace, to: :resource_resolver

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -52,6 +52,10 @@ module Administrate
       "#{resource.class} ##{resource.id}"
     end
 
+    def normalize(attr, value)
+      attribute_types[attr.to_sym] ? attribute_types[attr.to_sym].normalize(value) : value
+    end
+
     private
 
     def attribute_not_found_message(attr)

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -53,7 +53,7 @@ module Administrate
     end
 
     def normalize(attr, value)
-      if attribute_types[attr.to_sym]
+      if attribute_types.include? attr.to_sym
         attribute_types[attr.to_sym].normalize(value)
       else
         value

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -53,7 +53,11 @@ module Administrate
     end
 
     def normalize(attr, value)
-      attribute_types[attr.to_sym] ? attribute_types[attr.to_sym].normalize(value) : value
+      if attribute_types[attr.to_sym]
+        attribute_types[attr.to_sym].normalize(value)
+      else
+        value
+      end
     end
 
     private

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -23,6 +23,12 @@ module Administrate
         @options = options
       end
 
+      def self.normalize(value, options = {})
+        return options.fetch(:empty_value, value) if value.empty?
+
+        value
+      end
+
       def self.permitted_attribute(attr)
         attr
       end

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -24,9 +24,11 @@ module Administrate
       end
 
       def self.normalize(value, options = {})
-        return options.fetch(:empty_value, value) if value.empty?
-
-        value
+        if value.empty?
+          options.fetch(:empty_value, value)
+        else
+          value
+        end
       end
 
       def self.permitted_attribute(attr)

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -20,6 +20,10 @@ module Administrate
           options == other.options
       end
 
+      def normalize(value)
+        deferred_class.normalize(value, options)
+      end
+
       def searchable?
         options.fetch(:searchable, deferred_class.searchable?)
       end

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -116,12 +116,13 @@ describe Admin::CustomersController, type: :controller do
       it "updates the requested customer" do
         customer = create(:customer)
         new_name = "new name"
-        new_attributes = { name: new_name }
+        new_attributes = { name: new_name, email_subscriber: "" }
 
         put :update, id: customer.to_param, customer: new_attributes
 
         customer.reload
         expect(customer.name).to eq new_name
+        expect(customer.email_subscriber).to be(false)
       end
 
       it "redirects to the customer" do

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -4,7 +4,7 @@ class CustomerDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     created_at: Field::DateTime,
     email: Field::Email,
-    email_subscriber: Field::Boolean,
+    email_subscriber: Field::Boolean.with_options(empty_value: false),
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
     orders: Field::HasMany,


### PR DESCRIPTION
This provides a solution for issues like these: https://github.com/thoughtbot/administrate/issues/441

The solution is provided by allowing each field class to decide how to handle empty values via a normalize class method. A substitute value can be specified with an `empty_value` option when initializing a field using `with_options`.

This PR should probably have a little more test coverage, but first I want to see what adjustments might need to be made to the implementation to make it acceptable.  
