### PR TITLE
Update Field::BelongsTo to accept limit option

### DIFF
--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -24,7 +24,11 @@ module Administrate
       private
 
       def candidate_resources
-        associated_class.all
+        if options[:limit]
+          associated_class.where(options[:limit])
+        else
+          associated_class.all
+        end
       end
 
       def display_candidate_resource(resource)


### PR DESCRIPTION
I am using Field::BelongsTo.with_options and noticed on the edit page that it will always populate the drop down field with every model from the whole DB.  In my application there are certain cases where we want the drop down to only display some models, so I made a slight tweak to the gem that I think could be helpful to others.

`Field::BelongsTo.with_options(class_name: "Model", limit: { foo: "bar" })`
will now populate the dropdown with the result of Model.where(foo: "bar")
