### PR TITLE
bug:  rails g  administrate:install -  shouldn't fill in config/route…

### DIFF
--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -9,7 +9,7 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       def run_routes_generator
-        if dashboard_resources.none?
+        if not dashboard_resources.none?
           call_generator("administrate:routes")
           load Rails.root.join("config/routes.rb")
         end


### PR DESCRIPTION
 rails g  administrate:install -  shouldn't write garbage in config/routes.rb when  no valid resources
