### PR TITLE
Update dashboard_generator.rb

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -92,7 +92,7 @@ module Administrate
 
       def association_type(attribute)
         relationship = klass.reflections[attribute.to_s]
-        if relationship.has_one?
+        if relationship?
           "Field::HasOne"
         elsif relationship.collection?
           "Field::HasMany" + relationship_options_string(relationship)


### PR DESCRIPTION
I keep getting this error: 
On this specific line. 

/Users/laurosilva/.rvm/gems/ruby-2.3.0@rails426/gems/administrate-0.2.2/lib/generators/administrate/dashboard/dashboard_generator.rb:95:in `association_type': undefined method `has_one?' for nil:NilClass (NoMethodError)