### PR TITLE
[Rails 5] Fix search partial

### DIFF
--- a/app/views/administrate/application/_search.html.erb
+++ b/app/views/administrate/application/_search.html.erb
@@ -14,7 +14,7 @@
     Press enter to search
   </span>
   <span class="search__clear">
-    <%= link_to params.except(:search) do %>
+    <%= link_to sanitized_order_params.except(:search) do %>
       <%= svg_tag "administrate/cancel.svg", "cancel-search", width: 16, height: 16 %>
     <% end %>
   </span>


### PR DESCRIPTION
Getting this exception with Rails 5 otherwise:

> Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.
