### PR TITLE
Default all labels to human_attribute_name instead of raw attr_name

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -110,6 +110,7 @@ module Administrate
     delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
     helper_method :namespace
     helper_method :resource_name
+    helper_method :resource_class
 
     def resource_resolver
       @_resource_resolver ||=

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -31,7 +31,7 @@ to display a collection of resources in an HTML table.
         )) do %>
         <%= t(
           "helpers.label.#{resource_name}.#{attr_name}",
-          default: attr_name.to_s,
+          default: resource_class.human_attribute_name(attr_name),
         ).titleize %>
 
             <% if collection_presenter.ordered_by?(attr_name) %>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -34,7 +34,7 @@ as well as a link to its edit page.
     <dt class="attribute-label">
     <%= t(
       "helpers.label.#{resource_name}.#{attribute.name}",
-      default: attribute.name.titleize,
+      default: page.resource.class.human_attribute_name(attribute.name),
     ) %>
     </dt>
 


### PR DESCRIPTION
Administrate is inconsistent about the default human-visible attribute name. It uses Rails’s attr name localization for form labels, but defaults to showing the raw Ruby attribute name in other views.

This PR brings the collection & show views into line with what the form shows.

There is also a collection/show discrepancy in how `titleize` gets applied — to the localized version in collection, only the default in show — but I’ve left that in place for now.
