### PR TITLE
Fix broken specs on `master`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "administrate-field-image",
   git: "https://github.com/thoughtbot/administrate-field-image.git",
-  branch: "rails-5"
+  branch: "jq-rails-5"
 gem "bourbon", "~> 4.2"
 gem "delayed_job_active_record"
 gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/thoughtbot/administrate-field-image.git
-  revision: f07523253a5629048c7b395571207b619b32c862
-  branch: rails-5
+  revision: faf7a9b3ce1dcab0695af7f51e225ad208d7777b
+  branch: jq-rails-5
   specs:
     administrate-field-image (0.0.2)
       administrate (>= 0.2.0.rc1, < 0.3.0)
@@ -324,3 +324,6 @@ DEPENDENCIES
   unicorn
   web-console (>= 2.1.3)
   webmock
+
+BUNDLED WITH
+   1.13.5

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 dependencies:
+  pre:
+    - gem install bundler --version "1.13.5"
   post:
     - bundle exec appraisal install
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "rails-5"
+gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "jq-rails-5"
 gem "bourbon", "~> 4.2"
 gem "delayed_job_active_record"
 gem "faker"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "rails-5"
+gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "jq-rails-5"
 gem "bourbon", "~> 4.2"
 gem "delayed_job_active_record"
 gem "faker"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "rails-5"
+gem "administrate-field-image", :git => "https://github.com/thoughtbot/administrate-field-image.git", :branch => "jq-rails-5"
 gem "bourbon", "~> 4.2"
 gem "delayed_job_active_record"
 gem "faker"


### PR DESCRIPTION
Tests were broken on the `master` branch due to issues in loading the
[administrate-field-image] gem. The gem had some dependency ordering
issues in its `.gemspec` so I made some quick fixes and pointed the
administrate core to the branch with those fixes.

We also needed to update the version of Bundler used both locally and on
CI.

[administrate-field-image]: https://github.com/thoughtbot/administrate-field-image