### PR TITLE
administrate engine requires bourbon. fixes #615

### DIFF
--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -1,3 +1,4 @@
+require "bourbon"
 require "datetime_picker_rails"
 require "jquery-rails"
 require "kaminari"


### PR DESCRIPTION
Continued from https://github.com/thoughtbot/administrate/pull/673
