### PR TITLE
Add instructions on how to add dashboards

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -39,3 +39,22 @@ Each `Admin::FooController` can be overwritten to specify custom behavior.
 
 Once you have Administrate installed,
 visit <http://localhost:3000/admin> to see your new dashboard in action.
+
+## Create Additional Dashboards
+
+In order to create additional dashboards, pass in the resource name to 
+the dashboard generator. A dashboard and controller will be created.
+
+```bash
+$ rails generate administrate:dashboard Foo
+```
+
+Add a route for the new dashboard.
+
+```ruby
+# config/routes.rb
+
+namespace :admin do
+  resources :foos
+end
+```


### PR DESCRIPTION
Added a section to docs that explains how to create a additional dashboards. I had to search the pull requests in order figure out how to add a new dashboard. That [PR #426](https://github.com/thoughtbot/administrate/pull/426 ) has outdated info.