### PR TITLE
Fix broken sort arrow svg in the resource table

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -20,13 +20,15 @@ module Administrate
     def svg_tag(asset, svg_id, options = {})
       svg_attributes = {
         "xlink:href".freeze => "#{asset_url(asset)}##{svg_id}",
-        height: options[:height],
-        width: options[:width],
-      }.delete_if { |_key, value| value.nil? }
+        height: "100%",
+        width: "100%",
+      }
       xml_attributes = {
         "xmlns".freeze => "http://www.w3.org/2000/svg".freeze,
         "xmlns:xlink".freeze => "http://www.w3.org/1999/xlink".freeze,
-      }
+        height: options[:height],
+        width: options[:width],
+      }.delete_if { |_key, value| value.nil? }
 
       content_tag :svg, xml_attributes do
         content_tag :use, nil, svg_attributes

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -50,18 +50,34 @@ RSpec.describe Administrate::ApplicationHelper do
       expect(use_tag[0].attributes["xlink:href"].value).to eq("/logo.svg#logo")
     end
 
+    it "returns use tag with 100% height" do
+      svg_tag = build_svg_tag
+      use_tag = svg_tag.xpath("//svg//use['height']")
+      attribute = use_tag[0].attributes["height"]
+
+      expect(attribute.value).to eq("100%")
+    end
+
+    it "returns use tag with 100% width" do
+      svg_tag = build_svg_tag
+      use_tag = svg_tag.xpath("//svg//use['width']")
+      attribute = use_tag[0].attributes["width"]
+
+      expect(attribute.value).to eq("100%")
+    end
+
     context "with size attributes" do
-      it "returns use tag with height" do
+      it "returns svg tag with height" do
         svg_tag = build_svg_tag(height: 15)
-        use_tag = svg_tag.xpath("//svg//use['height']")
+        use_tag = svg_tag.xpath("//svg")
         attribute = use_tag[0].attributes["height"]
 
         expect(attribute.value).to eq("15")
       end
 
-      it "returns use tag with width" do
+      it "returns svg tag with width" do
         svg_tag = build_svg_tag(width: 20)
-        use_tag = svg_tag.xpath("//svg//use['width']")
+        use_tag = svg_tag.xpath("//svg")
         attribute = use_tag[0].attributes["width"]
 
         expect(attribute.value).to eq("20")


### PR DESCRIPTION
- Summary:
Fix issue: https://github.com/thoughtbot/administrate/issues/686

I found that, the svg tag isn't set the width and height, so it occupies the parent tag. This is the quick screenshot for this issue:
<img width="1110" alt="screen shot 2016-11-06 at 5 58 11 pm" src="https://cloud.githubusercontent.com/assets/9639873/20037015/d33ee144-a44a-11e6-9f64-d10efbb99b2b.png">





- Result:
The result after apply the patch:
<img width="1116" alt="screen shot 2016-11-06 at 5 57 30 pm" src="https://cloud.githubusercontent.com/assets/9639873/20037001/8a0ffc9c-a44a-11e6-82ab-deb9db8c0e05.png">
