### PR TITLE
Fix typo on pt-BR translation for polymorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ## Changes
 
+### Upcoming Release
+
+* [#704] [I18n] Fix word on pt-BR translation
+
 ### 0.3.0 (Oct 28, 2016)
 
 * [#127] [UI] Add button to clear the search

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -19,6 +19,6 @@ pt-BR:
         more: "Exibindo %{count} de %{total_count}"
         none: Nenhum
       polymorphic:
-        not_supported: Relações polimórmficas nos formulários não são suportadas.
+        not_supported: Relações polimórficas nos formulários não são suportadas.
       has_one:
         not_supported: Relações um para muitos nos formulários não são suportadas.


### PR DESCRIPTION
There is an extra `m` on `polimórficas`.
This PR replaces `polimórmficas` with `polimórficas`.