### PR TITLE
Avoid writing to routes.rb when no models exist.

### DIFF
--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -8,7 +8,7 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       def insert_dashboard_routes
-        unless File.read(rails_routes_file_path).include?(dashboard_routes)
+        if should_route_dashboard?
           route(dashboard_routes)
         end
       end
@@ -66,12 +66,20 @@ module Administrate
         ERB.new(File.read(routes_file_path)).result(binding)
       end
 
+      def routes_includes_resources?
+        File.read(rails_routes_file_path).include?(dashboard_routes)
+      end
+
       def rails_routes_file_path
         Rails.root.join("config/routes.rb")
       end
 
       def routes_file_path
         File.expand_path(find_in_source_paths("routes.rb.erb"))
+      end
+
+      def should_route_dashboard?
+        routes_includes_resources? || valid_dashboard_models.any?
       end
     end
   end

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -17,6 +17,16 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       expect(routes).not_to contain("Delayed::Backend::ActiveRecord::Job")
     end
 
+    it "does not populate routes when no models exist" do
+      stub_generator_dependencies
+      routes = file("config/routes.rb")
+      allow(ActiveRecord::Base).to receive(:descendants).and_return([])
+
+      run_generator
+
+      expect(routes).not_to contain("namespace :admin")
+    end
+
     it "skips namespaced models with a warning" do
       stub_generator_dependencies
       routes = file("config/routes.rb")


### PR DESCRIPTION
This closes: #502, #516, #555, #649, #583, #601, #613.