### PR TITLE
Fix format for datetimepicker

### DIFF
--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,6 +1,6 @@
 $(function () {
   $(".datetimepicker").datetimepicker({
     debug: false,
-    format: "YYYY-MM-DD HH:mm:ss",
+    format: "Y-M-D H:m:s",
   });
 });


### PR DESCRIPTION
`format` option uses the same syntax as PHP date function.
http://xdsoft.net/jqplugins/datetimepicker/#format