### PR TITLE
Use `count(:all)` for associations in HasMany field

### DIFF
--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -30,7 +30,7 @@ from the associated resource class's dashboard.
       <%= t(
         'administrate.fields.has_many.more',
         count: field.limit,
-        total_count: field.data.count,
+        total_count: field.data.count(:all),
       ) %>
     </span>
   <% end %>

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -41,7 +41,7 @@ module Administrate
       end
 
       def more_than_limit?
-        data.count > limit
+        data.count(:all) > limit
       end
 
       private

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -3,9 +3,14 @@ class MockRelation
     @data = data
   end
 
-  delegate :==, :count, to: :@data
+  delegate :==, to: :@data
 
   def limit(n)
     @data.first(n)
+  end
+
+  def count(column = nil)
+    return @data.count if column == :all
+    @data.count(column)
   end
 end


### PR DESCRIPTION
Problem: Calling `count` on an association can cause invalid SQL queries to be created where the `SELECT COUNT(a, b, c)` function receives multiple  columns. This will cause a `StatementInvalid` exception later on.

Solution: Use `count(:all)`, which generates a `SELECT COUNT(*)...` query independently of the association. The test's `MockRelation` helper is also patched to make it follow how the actual association works.

Background: This appears to be an known problem, see https://github.com/rails/rails/issues/15138 and https://github.com/rails/rails/issues/13648.

Hit me with your feedback! 👍 