### PR TITLE
Add link to show resource from collection table

### DIFF
--- a/app/assets/stylesheets/administrate/components/_table.scss
+++ b/app/assets/stylesheets/administrate/components/_table.scss
@@ -21,3 +21,11 @@
 .table__action--destroy {
   color: $light-red;
 }
+
+.table__link-plain {
+  color: inherit;
+
+  &:hover {
+    color: inherit;
+  }
+}

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -60,7 +60,11 @@ to display a collection of resources in an HTML table.
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <%= render_field attribute %>
+            <a href="<%= polymorphic_path([namespace, resource]) -%>"
+               class="action-show table__link-plain"
+               >
+              <%= render_field attribute %>
+            </a>
           </td>
         <% end %>
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -22,6 +22,15 @@ describe "customer index page" do
     expect(page).to have_content(customer.email)
   end
 
+  it "links to the customer show page without javascript", js: false do
+    customer = create(:customer)
+
+    visit admin_customers_path
+    click_show_link_for(customer)
+
+    expect(page).to have_header(displayed(customer))
+  end
+
   it "links to the edit page" do
     customer = create(:customer)
 

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -5,6 +5,12 @@ module Features
     end
   end
 
+  def click_show_link_for(model)
+    within(row_css_for(model)) do
+      all(show_link_elements).first.click
+    end
+  end
+
   private
 
   def row_css_for(model)
@@ -13,6 +19,10 @@ module Features
 
   def clickable_table_elements
     ".cell-data--string, .cell-data--number"
+  end
+
+  def show_link_elements
+    ".action-show"
   end
 
   def url_for(model)


### PR DESCRIPTION
Adds a link to show the resource within each cell of the collection table, as an alternative to the `data-url` on the `tr`. The link is styled with the default text colour so there's no visual change.

This allows a resource to be shown without javascript enabled (and also facilitates faster tests using RackTest).

On my machine running the same test comparing:

- `click_show_link_for` (+ no JS)
- `click_row_for` (+ with JS) 

is a lot faster, as expected:

| Run     | no JS  | JS     |
|---------|--------|--------|
| 1       | 0.88   | 2.04   |
| 2       | 0.85   | 1.93   |
| 3       | 0.85   | 1.96   |
| 4       | 0.84   | 2.02   |
| 5       | 0.82   | 2.04   |
| *Avg*     | *0.85* | *2.00* |
| *Std.Dev* | *0.02* | *0.05* |

(in seconds, running each test independently, excluding file load times)