### PR TITLE
Add authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Restart your server, and visit http://localhost:3000/admin
 to see your new dashboard in action.
 
 To customize the appearance, behavior, and contents of the dashboard,
-see the guides at http://administrate-docs.herokuapp.com.
+see the guides at https://administrate-prototype.herokuapp.com.
 
 ## Repository Structure
 

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version = Administrate::VERSION
   s.authors = ["Grayson Wright"]
   s.email = ["grayson@thoughtbot.com"]
-  s.homepage = "https://administrate-docs.herokuapp.com/"
+  s.homepage = "https://administrate-prototype.herokuapp.com/"
   s.summary = "A Rails engine for creating super-flexible admin dashboards"
   s.license = "MIT"
 

--- a/app/views/layouts/docs.html.erb
+++ b/app/views/layouts/docs.html.erb
@@ -25,6 +25,7 @@
         <li><a href="/customizing_attribute_partials">Customizing Attribute Partials</a></li>
         <li><a href="/adding_custom_field_types">Adding Custom Field Types</a></li>
         <li><a href="/customizing_controller_actions">Customizing Controller Actions</a></li>
+        <li><a href="/authentication">Authentication</a></li>
       </ul>
     </div>
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,60 @@
+# Authenticating admin users
+
+Authentication is left for you to implement after you install Administrate into
+your app. You can easily plugin your existing authentication system.
+
+The base `Admin::ApplicationController` has a `TODO` to be completed:
+
+```ruby
+class Admin::ApplicationController < Administrate::ApplicationController
+  before_action :authenticate_admin
+
+  def authenticate_admin
+    # TODO Add authentication logic here.
+  end
+end
+```
+
+## Using Clearance
+
+[Clearance][clearance] provides Rails authentication with email & password.
+
+```ruby
+class Admin::ApplicationController < Administrate::ApplicationController
+  include Clearance::Controller
+  before_action :require_login
+end
+```
+
+## Using Devise
+
+[Devise][devise] is an authentication solution for Rails with Warden. Include
+the authentication method for your model as a `before_action`:
+
+```ruby
+class Admin::ApplicationController < Administrate::ApplicationController
+  before_action :authenticate_user!
+end
+```
+
+## Using HTTP Basic authentication
+
+Rails includes the [`http_basic_authenticate_with`][rails-http-basic-auth]
+method which can be added to your base admin controller:
+
+```ruby
+class Admin::ApplicationController < Administrate::ApplicationController
+  http_basic_authenticate_with(
+    name: ENV.fetch("ADMIN_NAME"),
+    password: ENV.fetch("ADMIN_PASSWORD")
+  )
+end
+```
+
+With this approach consider using [dotenv][dotenv] to setup your environment and
+avoid committing secrets in your repository.
+
+[clearance]: https://github.com/thoughtbot/clearance
+[devise]: https://github.com/plataformatec/devise
+[rails-http-basic-auth]: http://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic.html
+[dotenv]: https://github.com/bkeepers/dotenv

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -13,7 +13,7 @@ module Admin
     #   <%= class_name %>.find_by!(slug: param)
     # end
 
-    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
   end
 end


### PR DESCRIPTION
Includes examples for Clearance, Devise and HTTP basic auth.

Also tidies up references to the old docs app which redirects to the prototype.