### PR TITLE
Allow primary_key option on relationships instead of hard coding id

### DIFF
--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -20,6 +20,10 @@ module Administrate
       def associated_class_name
         options.fetch(:class_name, attribute.to_s.singularize.camelcase)
       end
+
+      def primary_key
+        options.fetch(:primary_key, :id)
+      end
     end
   end
 end

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -13,12 +13,12 @@ module Administrate
 
       def associated_resource_options
         [nil] + candidate_resources.map do |resource|
-          [display_candidate_resource(resource), resource.id]
+          [display_candidate_resource(resource), resource.send(primary_key)]
         end
       end
 
       def selected_option
-        data && data.id
+        data && data.send(primary_key)
       end
 
       private

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -20,12 +20,12 @@ module Administrate
 
       def associated_resource_options
         candidate_resources.map do |resource|
-          [display_candidate_resource(resource), resource.id]
+          [display_candidate_resource(resource), resource.send(primary_key)]
         end
       end
 
       def selected_options
-        data && data.map(&:id)
+        data && data.map { |object| object.send(primary_key) }
       end
 
       def limit

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -37,4 +37,33 @@ describe Administrate::Field::BelongsTo do
       end
     end
   end
+
+  describe "primary_key option" do
+    it "determines what primary key is used on the relationship for the form" do
+      begin
+        Foo = Class.new
+        FooDashboard = Class.new
+        uuid = SecureRandom.uuid
+        allow(Foo).to receive(:all).and_return([Foo])
+        allow(Foo).to receive(:uuid).and_return(uuid)
+        allow(Foo).to receive(:id).and_return(1)
+        allow_any_instance_of(FooDashboard).to(
+          receive(:display_resource).and_return(uuid)
+        )
+
+        association =
+          Administrate::Field::BelongsTo.with_options(
+            primary_key: "uuid", class_name: "Foo"
+          )
+        field = association.new(:customers, [], :show)
+        field.associated_resource_options
+
+        expect(Foo).to have_received(:all)
+        expect(Foo).to have_received(:uuid)
+        expect(Foo).not_to have_received(:id)
+      ensure
+        remove_constants :Foo, :FooDashboard
+      end
+    end
+  end
 end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -52,6 +52,35 @@ describe Administrate::Field::HasMany do
     end
   end
 
+  describe "primary_key option" do
+    it "determines what primary key is used on the relationship for the form" do
+      begin
+        Foo = Class.new
+        FooDashboard = Class.new
+        uuid = SecureRandom.uuid
+        allow(Foo).to receive(:all).and_return([Foo])
+        allow(Foo).to receive(:uuid).and_return(uuid)
+        allow(Foo).to receive(:id).and_return(1)
+        allow_any_instance_of(FooDashboard).to(
+          receive(:display_resource).and_return(uuid)
+        )
+
+        association =
+          Administrate::Field::HasMany.with_options(
+            primary_key: "uuid", class_name: "Foo"
+          )
+        field = association.new(:customers, [], :show)
+        field.associated_resource_options
+
+        expect(Foo).to have_received(:all)
+        expect(Foo).to have_received(:uuid)
+        expect(Foo).not_to have_received(:id)
+      ensure
+        remove_constants :Foo, :FooDashboard
+      end
+    end
+  end
+
   describe "#more_than_limit?" do
     it "returns true if record count > limit" do
       limit = Administrate::Field::HasMany::DEFAULT_LIMIT


### PR DESCRIPTION
Currently BelongsTo and HasMany default to using #id of the
related records. This will allow you to pass the option of primary_key
and use that fields' value in the form.