### PR TITLE
Search Bar Display Logic

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -125,17 +125,9 @@ module Administrate
     end
 
     def show_search_bar?
-      show_search_bar = false
       dashboard.attribute_types_for(
         dashboard.collection_attributes
-      ).each do |name, attribute|
-        if attribute.searchable?
-          show_search_bar = true
-          break
-        end
-      end
-
-      show_search_bar
+      ).any? { |_name, attribute| attribute.searchable? }
     end
   end
 end

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -13,7 +13,7 @@ module Administrate
         resources: resources,
         search_term: search_term,
         page: page,
-        show_search_bar: show_search_bar?(page)
+        show_search_bar: show_search_bar?
       }
     end
 
@@ -124,9 +124,11 @@ module Administrate
       )
     end
 
-    def show_search_bar?(page)
+    def show_search_bar?
       show_search_bar = false
-      page.attribute_types.each do |name, attribute|
+      dashboard.attribute_types_for(
+        dashboard.collection_attributes
+      ).each do |name, attribute|
         if attribute.searchable?
           show_search_bar = true
           break

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -13,6 +13,7 @@ module Administrate
         resources: resources,
         search_term: search_term,
         page: page,
+        show_search_bar: show_search_bar?(page)
       }
     end
 
@@ -121,6 +122,18 @@ module Administrate
         "administrate.controller.#{key}",
         resource: resource_resolver.resource_title,
       )
+    end
+
+    def show_search_bar?(page)
+      show_search_bar = false
+      page.attribute_types.each do |name, attribute|
+        if attribute.searchable?
+          show_search_bar = true
+          break
+        end
+      end
+
+      show_search_bar
     end
   end
 end

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -17,6 +17,8 @@ It renders the `_table` partial to display details about the resources.
   By default, these resources are passed to the table partial to be displayed.
 - `search_term`:
   A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
@@ -26,7 +28,9 @@ It renders the `_table` partial to display details about the resources.
 <% end %>
 
 <% content_for(:search) do %>
-  <%= render "search", search_term: search_term %>
+  <% if show_search_bar %>
+    <%= render "search", search_term: search_term %>
+  <% end %>
 <% end %>
 
 <header class="header">

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -22,6 +22,13 @@ describe Admin::CustomersController, type: :controller do
 
       expect(locals[:page]).to be_instance_of(Administrate::Page::Collection)
     end
+
+    it "shows the search bar" do
+      customer = create(:customer)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:show_search_bar]).to be_truthy
+    end
   end
 
   describe "GET show" do
@@ -162,18 +169,5 @@ describe Admin::CustomersController, type: :controller do
 
       expect(response).to redirect_to(admin_customers_url)
     end
-  end
-
-  def capture_view_locals
-    allow(@controller).to receive(:render)
-    yield
-
-    locals = nil
-    expect(@controller).to have_received(:render).at_least(1).times do |*args|
-      args.each do |arg|
-        locals ||= arg.try(:fetch, :locals, nil)
-      end
-    end
-    locals
   end
 end

--- a/spec/controllers/admin/line_item_controller_spec.rb
+++ b/spec/controllers/admin/line_item_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Admin::LineItemsController, type: :controller do
+  describe "GET index" do
+    it "hides the search bar" do
+      line_item = create(:line_item)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:show_search_bar]).to be_falsey
+    end
+  end
+end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ end
 RSpec.configure do |config|
   config.include Features, type: :feature
   config.include DashboardHelpers
+  config.include ControllerHelpers
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -1,0 +1,14 @@
+module ControllerHelpers
+  def capture_view_locals
+    allow(@controller).to receive(:render)
+    yield
+
+    locals = nil
+    expect(@controller).to have_received(:render).at_least(1).times do |*args|
+      args.each do |arg|
+        locals ||= arg.try(:fetch, :locals, nil)
+      end
+    end
+    locals
+  end
+end


### PR DESCRIPTION
Currently the search bar is shown regardless of whether or not a resource contains searchable attributes.  This PR adds a method to the `Administrate::ApplicationController` that checks whether any attributes are searchable and passes a new local variable (`show_search_bar`) to the view which is then used to determine whether or not to render the search partial.