### PR TITLE
Paginate has_many show view

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -34,7 +34,7 @@ module Administrate
     end
 
     def sanitized_order_params
-      params.permit(:search, :id, :order, :page, :per_page, :direction)
+      params.permit(:search, :id, :order, :page, :per_page, :direction, :orders)
     end
 
     def clear_search_params

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -22,17 +22,11 @@ from the associated resource class's dashboard.
   <%= render(
     "collection",
     collection_presenter: field.associated_collection,
-    resources: field.resources
+    resources: field.resources(params[field.name])
   ) %>
 
   <% if field.more_than_limit? %>
-    <span>
-      <%= t(
-        'administrate.fields.has_many.more',
-        count: field.limit,
-        total_count: field.data.count(:all),
-      ) %>
-    </span>
+    <%= paginate field.resources(params[field.name]), param_name: "#{field.name}" %>
   <% end %>
 
 <% else %>

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -36,8 +36,8 @@ module Administrate
         self.class.permitted_attribute(attribute)
       end
 
-      def resources
-        data.limit(limit)
+      def resources(page = 1)
+        data.page(page).per(limit)
       end
 
       def more_than_limit?

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -7,7 +7,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     email_subscriber: Field::Boolean,
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
-    orders: Field::HasMany,
+    orders: Field::HasMany.with_options(limit: 2),
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
   }

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -4,18 +4,19 @@ RSpec.describe "customer show page" do
 
   it "displays the customers orders paginated" do
     customer = create(:customer)
-    orders = []
-    10.times do
-      orders << create(:order, customer: customer)
-    end
+    first_order, _a, _b, last_order = Array.new(4) { create(:order, customer: customer) }
 
     visit admin_customer_path(customer)
+    within('.attribute-data--has-many') do
+      expect(page).to have_content(first_order.id)
+      expect(page).to have_no_content(last_order.id)
+    end
 
-    expect(page).to have_content(orders[3].id)
-    expect(page).to have_no_content(orders[8].id)
     click_on("Next ›")
-    expect(page).to have_content(orders[8].id)
-    expect(page).to have_no_content(orders[3].id)
+    within('.attribute-data--has-many') do
+      expect(page).to have_content(last_order.id)
+      expect(page).to have_no_content(first_order.id)
+    end
   end
 
   it "displays the customer's title attribute as the header" do

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -1,6 +1,23 @@
 require "rails_helper"
 
 RSpec.describe "customer show page" do
+
+  it "displays the customers orders paginated" do
+    customer = create(:customer)
+    orders = []
+    10.times do
+      orders << create(:order, customer: customer)
+    end
+
+    visit admin_customer_path(customer)
+
+    expect(page).to have_content(orders[3].id)
+    expect(page).to have_no_content(orders[8].id)
+    click_on("Next ›")
+    expect(page).to have_content(orders[8].id)
+    expect(page).to have_no_content(orders[3].id)
+  end
+
   it "displays the customer's title attribute as the header" do
     customer = create(:customer)
 


### PR DESCRIPTION
This PR paginates the has_many show and takes into account that the show view can have several has_many fields.

Here you can see how the Attendee model is on page 1 and the User model is on page 2
![screen shot 2017-01-19 at 10 21 19 am](https://cloud.githubusercontent.com/assets/1312687/22115138/956b71cc-de31-11e6-92a6-0b58959dee9c.png)

PS. I blurred some personal information.