### PR TITLE
Dependent destroy demo app models.

### DIFF
--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -1,5 +1,5 @@
 class Customer < ActiveRecord::Base
-  has_many :orders
+  has_many :orders, dependent: :destroy
 
   validates :name, presence: true
   validates :email, presence: true

--- a/spec/example_app/app/models/order.rb
+++ b/spec/example_app/app/models/order.rb
@@ -2,7 +2,7 @@ class Order < ActiveRecord::Base
   belongs_to :customer
 
   validates :customer, presence: true
-  has_many :line_items
+  has_many :line_items, dependent: :destroy
 
   validates :address_line_one, presence: true
   validates :address_line_two, presence: true

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe Customer, :type => :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:email) }
 
+  it "deletes associated orders when deleted itself" do
+    customer = create(:customer)
+    create(:order, customer: customer)
+
+    puts customer.destroy
+
+    expect(Order.all).to be_empty
+  end
+
   describe "#lifetime_value" do
     it "returns 0 for no orders" do
       customer = Customer.new

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Order do
     it { should validate_presence_of(:address_zip) }
   end
 
+  it "deletes associated line_items when deleted itself" do
+    product = create(:product)
+    customer = create(:customer)
+    order = create(:order, customer: customer)
+    create(:line_item, product: product, order: order)
+
+    order.destroy
+
+    expect(LineItem.all).to be_empty
+  end
+
   describe "#total_price" do
     it "returns 0 when there are no line items" do
       order = build(:order)


### PR DESCRIPTION
This fixes #738, where foreign key constrains were violated trying out
the deletion in the demo app.