### PR TITLE
Products also need to destroy dependent models.

### DIFF
--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -1,4 +1,6 @@
 class Product < ActiveRecord::Base
+  has_many :line_items, dependent: :destroy
+
   validates :description, presence: true
   validates :image_url, presence: true
   validates :name, presence: true

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe Product do
       it { should validate_uniqueness_of(:slug) }
     end
   end
+
+  it "deletes associated line_items when deleted itself" do
+    product = create(:product)
+    customer = create(:customer)
+    order = create(:order, customer: customer)
+    create(:line_item, product: product, order: order)
+
+    product.destroy
+
+    expect(Product.all).to be_empty
+  end
+
 end


### PR DESCRIPTION
This is related to #739 and #738.