### PR TITLE
Add suffix/postfix option to number field

### DIFF
--- a/lib/administrate/field/number.rb
+++ b/lib/administrate/field/number.rb
@@ -14,11 +14,15 @@ module Administrate
       private
 
       def format_string
-        prefix + "%.#{decimals}f"
+        prefix + "%.#{decimals}f" + suffix
       end
 
       def prefix
         options[:prefix].to_s
+      end
+
+      def suffix
+        options[:suffix].to_s
       end
 
       def decimals

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -35,6 +35,14 @@ describe Administrate::Field::Number do
       end
     end
 
+    context "with `suffix` option" do
+      it "displays the given suffix" do
+        number = number_with_options(13, suffix: "h")
+
+        expect(number.to_s).to eq("13h")
+      end
+    end
+
     context "with `decimals` option" do
       it "truncates the number to the given number of decimal places" do
         zero = number_with_options(12.34553, decimals: 0)


### PR DESCRIPTION
This introduces a `suffix` option to append to the display of numbers after the number. Much like the `prefix` option. This could for instance be `hours`, `miles`, `mph` or similar.