### PR TITLE
Redefine base resource path

### DIFF
--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -24,7 +24,13 @@ module Administrate
     end
 
     def resource_path
-      args.first.try(:underscore).try(:pluralize) || "application"
+      args.first.try(:underscore).try(:pluralize) || BaseResourcePath.new
+    end
+
+    class BaseResourcePath
+      def to_s
+        "application"
+      end
     end
   end
 end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -28,5 +28,23 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         behavior: :revoke,
       )
     end
+
+    context "when run without any arguments" do
+      it "calls the sub-generators without any arguments" do
+        application_resource_path = instance_double("BaseResourcePath")
+        allow(Administrate::ViewGenerator::BaseResourcePath).to receive(:new).
+          and_return(application_resource_path)
+        allow(Rails::Generators).to receive(:invoke)
+
+        run_generator
+
+        %w[index show new edit].each do |generator|
+          expect(Rails::Generators). to invoke_generator(
+            "administrate:views:#{generator}",
+            [application_resource_path],
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Before, the base resource path for view generators was a hard-coded string. This was causing issues for some generators.  When called without an argument, their sub-generators had the wrong resource path. Replaced the base resource path string with a value object.

* Fixes https://github.com/thoughtbot/administrate/issues/645

![](http://i.giphy.com/l3q2N1sUbyoffNl0A.gif)