### PR TITLE
Add support for changing form field labels.

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -17,7 +17,7 @@ that displays all possible records to associate with.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.permitted_attribute %>
+  <%= f.label field.permitted_attribute, field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.permitted_attribute) do %>

--- a/app/views/fields/boolean/_form.html.erb
+++ b/app/views/fields/boolean/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a checkbox.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute , field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.check_box field.attribute %>

--- a/app/views/fields/date_time/_form.html.erb
+++ b/app/views/fields/date_time/_form.html.erb
@@ -17,7 +17,7 @@ By default, the input is a text field that is augmented with [DateTimePicker].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute , field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute, class: "datetimepicker" %>

--- a/app/views/fields/email/_form.html.erb
+++ b/app/views/fields/email/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text box.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label  %>
 </div>
 <div class="field-unit__field">
   <%= f.email_field field.attribute %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -20,7 +20,7 @@ and is augmented with [Selectize].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute_key, field.attribute %>
+  <%= f.label field.attribute_key, field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>

--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -18,7 +18,7 @@ so this partial renders a message to that effect.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label  %>
 </div>
 
 <%= t("administrate.fields.has_one.not_supported") %>

--- a/app/views/fields/number/_form.html.erb
+++ b/app/views/fields/number/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text field.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label  %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute %>

--- a/app/views/fields/polymorphic/_form.html.erb
+++ b/app/views/fields/polymorphic/_form.html.erb
@@ -19,7 +19,7 @@ so this partial renders a message to that effect.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.name %>
+  <%= f.label field.name, field.label  %>
 </div>
 
 <%= t("administrate.fields.polymorphic.not_supported") %>

--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -16,7 +16,7 @@ to be displayed on a resource's edit form page.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label  %>
 </div>
 <div class="field-unit__field">
   <%= f.select(

--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -16,7 +16,7 @@ By default, the input is a text field.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute %>

--- a/app/views/fields/text/_form.html.erb
+++ b/app/views/fields/text/_form.html.erb
@@ -15,7 +15,7 @@ This partial renders a textarea element for a text attribute.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label  %>
 </div>
 <div class="field-unit__field">
   <%= f.text_area field.attribute %>

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -27,6 +27,10 @@ module Administrate
         attr
       end
 
+      def label
+        options[:label] || attribute.to_s.humanize.capitalize
+      end
+
       def html_class
         self.class.html_class
       end

--- a/lib/generators/administrate/field/templates/_form.html.erb
+++ b/lib/generators/administrate/field/templates/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="field-unit__label">
-  <%= f.label field.attribute %>
+  <%= f.label field.attribute, field.label %>
 </div>
 <div class="field-unit__field">
   <%= f.text_field field.attribute %>


### PR DESCRIPTION
I found myself wanting to change the labels associated with form fields, which are often good for programmers and maybe not so good for administrators.  The syntax looks like so:

```
subject: Field::String(label: "Model or Vehicle"),
```