### PR TITLE
Update instances of bourbon to 5.0.0.beta.7; sass to ~>3.4

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
 appraise "sass-3-4" do
-  gem "sass", "3.4.0"
+  gem "sass", "~> 3.4"
   gem "rails-controller-testing"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "administrate-field-image"
-gem "bourbon", "~> 4.2"
+gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     administrate (0.4.0)
       autoprefixer-rails (~> 6.0)
-      bourbon (~> 4.2)
+      bourbon (~> 5.0.0.beta.7)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)
       kaminari (~> 0.16)
@@ -65,14 +65,14 @@ GEM
       rake
       thor (>= 0.14.0)
     arel (6.0.3)
-    autoprefixer-rails (6.6.1)
+    autoprefixer-rails (6.7.6)
       execjs
     awesome_print (1.6.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bourbon (4.2.7)
-      sass (~> 3.4)
-      thor (~> 0.19)
+    bourbon (5.0.0.beta.7)
+      sass (~> 3.4.22)
+      thor (~> 0.19.1)
     builder (3.2.2)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
@@ -229,7 +229,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     safe_yaml (1.0.4)
-    sass (3.4.22)
+    sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -253,7 +253,7 @@ GEM
     thor (0.19.1)
     thread (0.2.2)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.6)
     timecop (0.8.0)
     tins (1.6.0)
     tzinfo (1.2.2)
@@ -289,7 +289,7 @@ DEPENDENCIES
   ammeter
   appraisal
   awesome_print
-  bourbon (~> 4.2)
+  bourbon (~> 5.0.0.beta.7)
   bundler-audit
   byebug
   database_cleaner

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "autoprefixer-rails", "~> 6.0"
-  s.add_dependency "bourbon", "~> 4.2"
+  s.add_dependency "bourbon", "~> 5.0.0.beta.7"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "kaminari", "~> 0.16"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "bourbon", "~> 4.2"
+gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
 gem "high_voltage"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "bourbon", "~> 4.2"
+gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
 gem "high_voltage"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "bourbon", "~> 4.2"
+gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
 gem "high_voltage"
@@ -11,7 +11,7 @@ gem "markdown-rails"
 gem "pg"
 gem "redcarpet"
 gem "unicorn"
-gem "sass", "3.4.0"
+gem "sass", "~> 3.4"
 gem "rails-controller-testing"
 
 group :development do


### PR DESCRIPTION
As requested in [this issue comment](https://github.com/thoughtbot/administrate/pull/104#issuecomment-274096057) This updates `administrate` to use bourbon 5 properly, I hope. Along the way it seemed the `sass` gem dependency needed to be updated as well.

I have to admit these layered dependencies and Appraisal tests are slightly out of my depth, but as far as I can tell all tests pass and a skeleton sample app I set up using Rails 5.0.2 and Ruby 2.3.1 and including these two gems, verbatim:

```ruby
gem 'bourbon'
gem "administrate", :git => 'https://github.com/vcavallo/administrate.git', :branch => 'bourbon-5-beta-7'
```

does work just fine, whereas when trying to use `administrate` on its own I got bundler errors like so:

<img width="671" alt="screen shot 2017-03-03 at 11 53 55 am" src="https://cloud.githubusercontent.com/assets/3201135/23561972/90508246-000e-11e7-9e0f-6c57a6ef520a.png">

Also, I'm not sure of the larger implications of requiring all Administrate users to upgrade to bourbon 5, especially since it seems there may be [other issues](https://github.com/thoughtbot/bourbon/issues/972#issuecomment-283997731) with bourbon 5 dependencies?

Let me know if anything needs to change or be updated.
Thanks!