### PR TITLE
Fix pagination specs

### DIFF
--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -1,21 +1,46 @@
 require "rails_helper"
 
 RSpec.describe "customer show page" do
+  describe "displays the customers orders paginated" do
+    context "when a page is not specified" do
+      it "displays the first page of results" do
+        customer = create(:customer)
+        orders = create_list(:order, 4, customer: customer)
+        first_page = orders.first(2)
+        second_page = orders.last(2)
 
-  it "displays the customers orders paginated" do
-    customer = create(:customer)
-    first_order, _a, _b, last_order = Array.new(4) { create(:order, customer: customer) }
+        visit admin_customer_path(customer)
 
-    visit admin_customer_path(customer)
-    within('.attribute-data--has-many') do
-      expect(page).to have_content(first_order.id)
-      expect(page).to have_no_content(last_order.id)
+        within('.attribute-data--has-many') do
+          first_page.each do |order|
+            expect(page).to have_order_row(order.id)
+          end
+          second_page.each do |order|
+            expect(page).not_to have_order_row(order.id)
+          end
+        end
+      end
     end
 
-    click_on("Next ›")
-    within('.attribute-data--has-many') do
-      expect(page).to have_content(last_order.id)
-      expect(page).to have_no_content(first_order.id)
+    context "when the second page is specified" do
+      it "displays the second page of results" do
+        customer = create(:customer)
+        orders = create_list(:order, 4, customer: customer)
+        first_page = orders.first(2)
+        second_page = orders.last(2)
+
+        visit admin_customer_path(customer)
+        click_on("Next ›")
+
+        within('.attribute-data--has-many') do
+          first_page.each do |order|
+            expect(page).not_to have_order_row(order.id)
+          end
+          second_page.each do |order|
+            expect(page).to have_order_row(order.id)
+          end
+        end
+      end
     end
   end
 
@@ -96,5 +121,9 @@ RSpec.describe "customer show page" do
 
       expect(page).to have_css(".attribute-label", text: custom_label)
     end
+  end
+
+  def have_order_row(id)
+    have_css('tr td:first-child', text: id)
   end
 end

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -5,6 +5,14 @@ class MockRelation
 
   delegate :==, to: :@data
 
+  def page(n)
+    self
+  end
+
+  def per(n)
+    @data.first(n)
+  end
+
   def limit(n)
     @data.first(n)
   end


### PR DESCRIPTION
The `MockRelation` class did not implement `page` or `per` so some specs
which rely on those methods were failing. Also, some content matchers
were not specific enough, so I've made those more specific and added
some helper methods.

Changes:

- Add some methods to `MockRelation`
- Make content matchers more specific to make spec more resilient to different ID's of related items