### PR TITLE
Namespace Regex Refactor

### DIFF
--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -12,7 +12,7 @@ module Administrate
       @routes ||= all_routes.select do |controller, _action|
         controller.starts_with?(namespace.to_s)
       end.map do |controller, action|
-        [controller.gsub(/^#{namespace}\//, ""), action]
+        [controller.gsub(namespace_regex, ""), action]
       end
     end
 
@@ -24,6 +24,10 @@ module Administrate
       Rails.application.routes.routes.map do |route|
         route.defaults.values_at(:controller, :action).map(&:to_s)
       end
+    end
+
+    def namespace_regex
+      %r{^#{namespace}/}
     end
   end
 end

--- a/spec/administrate/namespace_spec.rb
+++ b/spec/administrate/namespace_spec.rb
@@ -15,5 +15,18 @@ describe Administrate::Namespace do
         reset_routes
       end
     end
+
+    it "matches a trailing slash" do
+      begin
+        namespace = Administrate::Namespace.new(:admin)
+        Rails.application.routes.draw do
+          namespace(:admin) { resources :customers }
+        end
+
+        expect(namespace.resources).to eq [:customers]
+      ensure
+        reset_routes
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm having trouble coming up with a spec that reproduces your error @clthck, maybe you could contribute one?

Changes:

- Factor out a `namespace_regex` method to use consistently across the `Namespace` class.

Addresses https://github.com/thoughtbot/administrate/issues/758