### PR TITLE
Add autoprefixer-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "administrate-field-image"
+gem "autoprefixer-rails"
 gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,7 @@ DEPENDENCIES
   administrate-field-image
   ammeter
   appraisal
+  autoprefixer-rails
   awesome_print
   bourbon (~> 5.0.0.beta.7)
   bundler-audit


### PR DESCRIPTION
As mentioned in https://github.com/thoughtbot/administrate/issues/766, `autoprefixer` isn't currently running on this project, and since we aren't prefixing things by hand this means that selectors that need prefixing aren't getting it.

Changes:

- Add the `autoprefixer-rails` gem

Also related:

- #372 
- #366 