### PR TITLE
Handle case where `Field::HasMany` data is nil

### DIFF
--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -25,7 +25,9 @@ module Administrate
       end
 
       def selected_options
-        data && data.map { |object| object.send(primary_key) }
+        return if data.empty?
+
+        data.map { |object| object.send(primary_key) }
       end
 
       def limit
@@ -42,6 +44,10 @@ module Administrate
 
       def more_than_limit?
         data.count(:all) > limit
+      end
+
+      def data
+        @data ||= associated_class.none 
       end
 
       private

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -101,6 +101,17 @@ describe Administrate::Field::HasMany do
 
       expect(field.more_than_limit?).to eq(false)
     end
+
+    context "when there are no records" do
+      it "returns false" do
+        resources = nil
+
+        association = Administrate::Field::HasMany
+        field = association.new(:customers, resources, :show)
+
+        expect(field.more_than_limit?).to eq(false)
+      end
+    end
   end
 
   describe "#resources" do
@@ -114,6 +125,17 @@ describe Administrate::Field::HasMany do
       expect(field.resources).to eq([:a] * limit)
     end
 
+    context "when there are no records" do
+      it "returns an empty collection" do
+        resources = nil
+
+        association = Administrate::Field::HasMany
+        field = association.new(:customers, resources, :show)
+
+        expect(field.resources).to eq([])
+      end
+    end
+
     context "with `limit` option" do
       it "limits the number of items returned" do
         resources = MockRelation.new([:a, :b, :c])
@@ -122,6 +144,29 @@ describe Administrate::Field::HasMany do
         field = association.new(:customers, resources, :show)
 
         expect(field.resources).to eq([:a])
+      end
+    end
+  end
+
+  describe "#selected_options" do
+    it "returns a collection of primary keys" do
+      model = double("model", id: 123)
+      resources = MockRelation.new([model])
+
+      association = Administrate::Field::HasMany
+      field = association.new(:customers, resources, :show)
+
+      expect(field.selected_options).to eq([123])
+    end
+
+    context "when there are no records" do
+      it "returns an empty collection" do
+        resources = nil
+
+        association = Administrate::Field::HasMany
+        field = association.new(:customers, resources, :show)
+
+        expect(field.selected_options).to be_nil
       end
     end
   end

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -3,7 +3,7 @@ class MockRelation
     @data = data
   end
 
-  delegate :==, to: :@data
+  delegate :==, :empty?, :map, to: :@data
 
   def page(n)
     self


### PR DESCRIPTION
When an association has no records, the field is being created with no
data, and when methods are called on that data, undefined method errors
occur.

To fix, use the Null Object Pattern to ensure the data is always
present. Use Active Record's NullRelation as the null object.

Addresses #599