### PR TITLE
Merge the existing translations before testing.

### DIFF
--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -4,8 +4,10 @@ RSpec.configure do |config|
   def with_translations(locale, translations)
     original_backend = I18n.backend
 
-    I18n.backend = I18n::Backend::KeyValue.new({}, true)
-    I18n.backend.store_translations(locale, translations)
+    new_backend = I18n::Backend::KeyValue.new({}, true)
+    new_backend.store_translations(locale, translations)
+
+    I18n.backend = I18n::Backend::Chain.new(original_backend, new_backend)
 
     yield
   ensure


### PR DESCRIPTION
`with_translations` is used to test that a view does actually implement
a given translation. Previously, we were resetting the known
translations to only use the one under test. We now have many more
translations so this approach will fail when visiting a page because of
"missing translations".

Example: https://git.io/vywpc

This came up when merging #344.