### PR TITLE
Change README to use `0.4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add Administrate to your Gemfile:
 
 ```ruby
 # Gemfile
-gem "administrate", "~> 0.3.0"
+gem "administrate", "~> 0.4.0"
 ```
 
 Re-bundle, then run the installer:


### PR DESCRIPTION
Changes the getting started section of the readme to use `0.4.0` in the Gemfile.