### PR TITLE
Update the Appraisal Gemfiles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "sentry-raven"
 gem "unicorn"
 
 group :development do
-  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,6 @@ GEM
     rake (11.2.2)
     rdiscount (1.6.8)
     redcarpet (3.3.3)
-    refills (0.2.0)
     rspec-core (3.5.1)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -324,7 +323,6 @@ DEPENDENCIES
   rack-timeout
   rails_stdout_logging
   redcarpet
-  refills
   rspec-rails (~> 3.5.0)
   sentry-raven
   shoulda-matchers (~> 2.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     administrate (0.4.0)
       autoprefixer-rails (~> 6.0)
-      bourbon (~> 5.0.0.beta.7)
+      bourbon (>= 5.0.0.beta.6)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)
       kaminari (>= 1.0)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "autoprefixer-rails", "~> 6.0"
-  s.add_dependency "bourbon", "~> 5.0.0.beta.7"
+  s.add_dependency "bourbon", ">= 5.0.0.beta.6"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "kaminari", ">= 1.0"

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -16,7 +16,6 @@ gem "unicorn"
 gem "rails", "~> 4.2.0"
 
 group :development do
-  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
+gem "autoprefixer-rails"
 gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
@@ -10,10 +11,12 @@ gem "high_voltage"
 gem "markdown-rails"
 gem "pg"
 gem "redcarpet"
+gem "sentry-raven"
 gem "unicorn"
 gem "rails", "~> 4.2.0"
 
 group :development do
+  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
+gem "autoprefixer-rails"
 gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
@@ -10,11 +11,13 @@ gem "high_voltage"
 gem "markdown-rails"
 gem "pg"
 gem "redcarpet"
+gem "sentry-raven"
 gem "unicorn"
 gem "rails", "~> 5.0.0"
 gem "rails-controller-testing"
 
 group :development do
+  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -17,7 +17,6 @@ gem "rails", "~> 5.0.0"
 gem "rails-controller-testing"
 
 group :development do
-  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
+gem "autoprefixer-rails"
 gem "bourbon", "~> 5.0.0.beta.7"
 gem "delayed_job_active_record"
 gem "faker"
@@ -10,11 +11,13 @@ gem "high_voltage"
 gem "markdown-rails"
 gem "pg"
 gem "redcarpet"
+gem "sentry-raven"
 gem "unicorn"
 gem "sass", "~> 3.4"
 gem "rails-controller-testing"
 
 group :development do
+  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -17,7 +17,6 @@ gem "sass", "~> 3.4"
 gem "rails-controller-testing"
 
 group :development do
-  gem "refills"
   gem "web-console", ">= 2.1.3"
 end
 


### PR DESCRIPTION
* Reduce the bourbon requirement slightly (7 to 6) so we can avoid updating Sass.
* Adds refills, autoprefixer-rails, sentry-raven which were previously merged.