### PR TITLE
Allow resource to be accessed from field (alternative implementation)

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -20,6 +20,7 @@ module Administrate
         @attribute = attribute
         @data = data
         @page = page
+        @resource = options.delete(:resource)
         @options = options
       end
 
@@ -39,7 +40,7 @@ module Administrate
         "/fields/#{self.class.field_type}/#{page}"
       end
 
-      attr_reader :attribute, :data, :page
+      attr_reader :attribute, :data, :page, :resource
 
       protected
 

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -11,7 +11,8 @@ module Administrate
       attr_reader :deferred_class, :options
 
       def new(*args)
-        deferred_class.new(*args, options)
+        new_options = if args.last.is_a? Hash then args.last else {} end
+        deferred_class.new(*args, options.merge(new_options))
       end
 
       def ==(other)

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -11,7 +11,7 @@ module Administrate
       attr_reader :deferred_class, :options
 
       def new(*args)
-        new_options = if args.last.is_a? Hash then args.last else {} end
+        new_options = if args.last.is_a? Hash then args.pop else {} end
         deferred_class.new(*args, options.merge(new_options))
       end
 

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -11,7 +11,6 @@ module Administrate
       attr_reader :deferred_class, :options
 
       def new(*args)
-        # If the args already end with a "keyword hash", merge it with options
         new_options = args.last.respond_to?(:merge) ? args.pop : {}
         deferred_class.new(*args, options.merge(new_options))
       end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -11,7 +11,8 @@ module Administrate
       attr_reader :deferred_class, :options
 
       def new(*args)
-        new_options = if args.last.is_a? Hash then args.pop else {} end
+        # If the args already end with a "keyword hash", merge it with options
+        new_options = args.last.respond_to?(:merge) ? args.pop : {}
         deferred_class.new(*args, options.merge(new_options))
       end
 

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -16,7 +16,7 @@ module Administrate
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)
         field = dashboard.attribute_type_for(attribute_name)
-        field.new(attribute_name, value, page)
+        field.new(attribute_name, value, page, resource: resource)
       end
 
       def get_attribute_value(resource, attribute_name)

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -9,4 +9,15 @@ describe Administrate::Page::Show do
       expect(page.page_title).to eq("Worf")
     end
   end
+  
+  describe '#attributes' do
+    it 'passes the resource to the field object' do
+      customer = double(name: "Worf").as_null_object
+      page = Administrate::Page::Show.new(CustomerDashboard.new, customer)
+      
+      expect(page.attributes.first.resource).to eq(customer)
+      expect(page.attributes.first.resource.name).to eq('Worf')
+    end
+  end
+  
 end

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -9,15 +9,14 @@ describe Administrate::Page::Show do
       expect(page.page_title).to eq("Worf")
     end
   end
-  
-  describe '#attributes' do
-    it 'passes the resource to the field object' do
+
+  describe "#attributes" do
+    it "passes the resource to the field object" do
       customer = double(name: "Worf").as_null_object
       page = Administrate::Page::Show.new(CustomerDashboard.new, customer)
-      
+
       expect(page.attributes.first.resource).to eq(customer)
-      expect(page.attributes.first.resource.name).to eq('Worf')
+      expect(page.attributes.first.resource.name).to eq("Worf")
     end
   end
-  
 end


### PR DESCRIPTION
I was taking a look at @dts's excellent #706, and hoping something similar would be accepted upstream soon as I needed support for accessing the resource too.

This is a much more lightweight implementation that achieves the same effect - the resource is available as `field.resource`. However, this one degrades gracefully in case people have overridden the constructor in their own field implementations, and as a consequence the tests (hopefully) don't need changing.

I wasn't able to run the tests because they seem to depend on a running Postgres instance. Let me know if anything fails and I can take a look!