### PR TITLE
Remove bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gemspec
 
 gem "administrate-field-image"
 gem "autoprefixer-rails"
-gem "bourbon", "~> 5.0.0.beta.7"
 gem "faker"
 gem "pg"
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       actionview (>= 4.2, < 5.1)
       activerecord (>= 4.2, < 5.1)
       autoprefixer-rails (~> 6.0)
-      bourbon (>= 5.0.0.beta.6)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
@@ -59,9 +58,6 @@ GEM
     autoprefixer-rails (6.7.7.1)
       execjs
     awesome_print (1.6.1)
-    bourbon (5.0.0.beta.7)
-      sass (~> 3.4.22)
-      thor (~> 0.19.1)
     builder (3.2.3)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
@@ -260,7 +256,6 @@ DEPENDENCIES
   appraisal
   autoprefixer-rails
   awesome_print
-  bourbon (~> 5.0.0.beta.7)
   bundler-audit
   byebug
   database_cleaner

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 4.2", "< 5.1"
 
   s.add_dependency "autoprefixer-rails", "~> 6.0"
-  s.add_dependency "bourbon", ">= 5.0.0.beta.6"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"

--- a/app/assets/stylesheets/administrate/application.scss
+++ b/app/assets/stylesheets/administrate/application.scss
@@ -1,11 +1,11 @@
 @charset "utf-8";
 
 @import "normalize-rails";
-@import "bourbon";
 
 @import "selectize";
 @import "datetime_picker";
 
+@import "library/clearfix";
 @import "library/data-label";
 @import "library/variables";
 

--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -52,7 +52,7 @@ select[multiple] {
   width: 100%;
 
   &:hover {
-    border-color: shade($base-border-color, 20%);
+    border-color: mix($black, $base-border-color, 20%);
   }
 
   &:focus {
@@ -62,7 +62,7 @@ select[multiple] {
   }
 
   &:disabled {
-    background-color: shade($base-background-color, 5%);
+    background-color: mix($black, $base-background-color, 5%);
     cursor: not-allowed;
 
     &:hover {

--- a/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/app/assets/stylesheets/administrate/base/_typography.scss
@@ -27,7 +27,7 @@ a {
   transition: color $base-duration $base-timing;
 
   &:hover {
-    color: shade($action-color, 25%);
+    color: mix($black, $action-color, 25%);
   }
 
   &:focus {

--- a/app/assets/stylesheets/administrate/components/_app-container.scss
+++ b/app/assets/stylesheets/administrate/components/_app-container.scss
@@ -1,7 +1,8 @@
 .app-container {
-  @include margin(null auto);
   align-items: stretch;
   display: flex;
+  margin-left: auto;
+  margin-right: auto;
   max-width: 100rem;
   min-height: 100vh;
   padding: $base-spacing;

--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -1,4 +1,7 @@
-#{$all-buttons},
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
 .button {
   appearance: none;
   background-color: $action-color;
@@ -20,7 +23,7 @@
   white-space: nowrap;
 
   &:hover {
-    background-color: shade($action-color, 20%);
+    background-color: mix($black, $action-color, 20%);
     color: $white;
   }
 

--- a/app/assets/stylesheets/administrate/components/_field-unit.scss
+++ b/app/assets/stylesheets/administrate/components/_field-unit.scss
@@ -1,5 +1,5 @@
 .field-unit {
-  @include clearfix;
+  @include administrate-clearfix;
   align-items: center;
   display: flex;
   margin-bottom: $base-spacing;

--- a/app/assets/stylesheets/administrate/components/_flashes.scss
+++ b/app/assets/stylesheets/administrate/components/_flashes.scss
@@ -9,19 +9,19 @@ $flashes: (
 @each $flash-type, $color in $flashes {
   .flash-#{$flash-type} {
     background-color: $color;
-    color: shade($color, 60%);
+    color: mix($black, $color, 60%);
     display: block;
     margin-bottom: $base-spacing / 2;
     padding: $base-spacing / 2;
     text-align: center;
 
     a {
-      color: shade($color, 70%);
+      color: mix($black, $color, 70%);
       text-decoration: underline;
 
       &:focus,
       &:hover {
-        color: shade($color, 90%);
+        color: mix($black, $color, 90%);
       }
     }
   }

--- a/app/assets/stylesheets/administrate/components/_navigation.scss
+++ b/app/assets/stylesheets/administrate/components/_navigation.scss
@@ -22,7 +22,7 @@ $_navigation-link-padding: 0.6em;
   }
 
   &:hover {
-    background-color: shade($base-background-color, 5%);
+    background-color: mix($black, $base-background-color, 5%);
     border-radius: $base-border-radius;
     color: $base-font-color;
   }

--- a/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -1,6 +1,7 @@
 .pagination {
-  @include padding(null $base-spacing);
   margin-top: $base-spacing;
+  padding-left: $base-spacing;
+  padding-right: $base-spacing;
   text-align: center;
 
   .first,

--- a/app/assets/stylesheets/administrate/components/_search.scss
+++ b/app/assets/stylesheets/administrate/components/_search.scss
@@ -1,10 +1,11 @@
 .search {
-  @include padding(null $base-spacing);
   align-items: center;
   border-bottom: $base-border;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  padding-left: $base-spacing;
+  padding-right: $base-spacing;
   position: relative;
   width: 100%;
 }
@@ -12,7 +13,8 @@
 .search__clear,
 .search__icon {
   svg {
-    @include size(1em);
+    height: 1em;
+    width: 1em;
   }
 }
 
@@ -55,14 +57,17 @@
 }
 
 .search__hint {
-  @include position(absolute, 1em 0 null null);
   color: $hint-grey;
+  left: 0;
   opacity: 0;
+  position: absolute;
+  top: 1em;
   transition: opacity $base-duration $base-timing;
   z-index: 1;
 
   svg {
-    @include size(100%);
+    height: 100%;
+    width: 100%;
   }
 
   path,

--- a/app/assets/stylesheets/administrate/library/_clearfix.scss
+++ b/app/assets/stylesheets/administrate/library/_clearfix.scss
@@ -1,0 +1,7 @@
+@mixin administrate-clearfix {
+  &::after {
+    clear: both;
+    content: "";
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/administrate/library/_data-label.scss
+++ b/app/assets/stylesheets/administrate/library/_data-label.scss
@@ -1,6 +1,6 @@
 @mixin data-label {
   color: $hint-grey;
-  font-size: modular-scale(-1);
+  font-size: 0.8em;
   font-weight: 400;
   letter-spacing: 0.0357em;
   position: relative;

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -12,7 +12,6 @@ $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
 // Other Sizes
-$modular-scale-ratio: $minor-third;
 $base-border-radius: 4px;
 $base-spacing: $base-line-height * 1em;
 $small-spacing: $base-spacing / 2;
@@ -50,7 +49,7 @@ $focus-outline-offset: 1px;
 $flash-colors: (
   alert: $light-yellow,
   error: $red,
-  notice: tint($blue, 50%),
+  notice: mix($white, $blue, 50%),
   success: $light-green
 );
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "administrate-field-image"
 gem "autoprefixer-rails"
-gem "bourbon", "~> 5.0.0.beta.7"
 gem "faker"
 gem "pg"
 gem "redcarpet"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "administrate-field-image"
 gem "autoprefixer-rails"
-gem "bourbon", "~> 5.0.0.beta.7"
 gem "faker"
 gem "pg"
 gem "redcarpet"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "administrate-field-image"
 gem "autoprefixer-rails"
-gem "bourbon", "~> 5.0.0.beta.7"
 gem "faker"
 gem "pg"
 gem "redcarpet"

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -1,4 +1,3 @@
-require "bourbon"
 require "datetime_picker_rails"
 require "jquery-rails"
 require "kaminari"


### PR DESCRIPTION
This might be controversial, but I want to remove bourbon from the administrate codebase. It's not used in many places and inlining the CSS is quite straightforward.

Whenever I update or make changes to administrate, there always seems to be some bourbon-related issue. Either it's the removal of the Railtie in Bourbon 5.x, or the fact that my app won't load in Cucumber any more, everything seems to be related to Bourbon.

What do you think?