### PR TITLE
Remove ActionCable and ActionMailer Dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,10 +4,15 @@ appraise "sass-3-4" do
 end
 
 appraise "rails42" do
-  gem "rails", "~> 4.2.0"
+  gem "actionpack", "~> 4.2.0"
+  gem "actionview", "~> 4.2.0"
+  gem "activerecord", "~> 4.2.0"
 end
 
 appraise "rails50" do
-  gem "rails", "~> 5.0.0"
+  gem "actionpack", "~> 5.0.0"
+  gem "actionview", "~> 5.0.0"
+  gem "activerecord", "~> 5.0.0"
+
   gem "rails-controller-testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ PATH
   remote: .
   specs:
     administrate (0.5.0)
+      actionpack (>= 4.2, < 5.1)
+      actionview (>= 4.2, < 5.1)
+      activerecord (>= 4.2, < 5.1)
       autoprefixer-rails (~> 6.0)
       bourbon (>= 5.0.0.beta.6)
       datetime_picker_rails (~> 0.0.7)
@@ -10,19 +13,12 @@ PATH
       momentjs-rails (~> 2.8)
       neat (~> 1.1)
       normalize-rails (>= 3.0)
-      rails (>= 4.2, < 5.1)
       sass-rails (~> 5.0)
       selectize-rails (~> 0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.2.8)
-      actionpack (= 4.2.8)
-      actionview (= 4.2.8)
-      activejob (= 4.2.8)
-      mail (~> 2.5, >= 2.5.4)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
     actionpack (4.2.8)
       actionview (= 4.2.8)
       activesupport (= 4.2.8)
@@ -36,9 +32,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (4.2.8)
-      activesupport (= 4.2.8)
-      globalid (>= 0.3.0)
     activemodel (4.2.8)
       activesupport (= 4.2.8)
       builder (~> 3.1)
@@ -119,8 +112,6 @@ GEM
       activesupport
       capybara
       i18n
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
     hashdiff (0.3.2)
     highline (1.7.8)
     i18n (0.8.1)
@@ -154,8 +145,6 @@ GEM
       addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
-      mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -187,17 +176,6 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.3.2)
-    rails (4.2.8)
-      actionmailer (= 4.2.8)
-      actionpack (= 4.2.8)
-      actionview (= 4.2.8)
-      activejob (= 4.2.8)
-      activemodel (= 4.2.8)
-      activerecord (= 4.2.8)
-      activesupport (= 4.2.8)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.2.8)
-      sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.8)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,docs}/**/*", "LICENSE", "Rakefile"]
   s.test_files = Dir["test/**/*"]
 
+  s.add_dependency "actionpack", ">= 4.2", "< 5.1"
+  s.add_dependency "actionview", ">= 4.2", "< 5.1"
+  s.add_dependency "activerecord", ">= 4.2", "< 5.1"
+
   s.add_dependency "autoprefixer-rails", "~> 6.0"
   s.add_dependency "bourbon", ">= 5.0.0.beta.6"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
@@ -22,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency "momentjs-rails", "~> 2.8"
   s.add_dependency "neat", "~> 1.1"
   s.add_dependency "normalize-rails", ">= 3.0"
-  s.add_dependency "rails", ">= 4.2", "< 5.1"
   s.add_dependency "sass-rails", "~> 5.0"
   s.add_dependency "selectize-rails", "~> 0.6"
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -11,7 +11,9 @@ gem "pg"
 gem "redcarpet"
 gem "sentry-raven"
 gem "unicorn"
-gem "rails", "~> 4.2.0"
+gem "actionpack", "~> 4.2.0"
+gem "actionview", "~> 4.2.0"
+gem "activerecord", "~> 4.2.0"
 
 group :development, :test do
   gem "appraisal"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -11,7 +11,9 @@ gem "pg"
 gem "redcarpet"
 gem "sentry-raven"
 gem "unicorn"
-gem "rails", "~> 5.0.0"
+gem "actionpack", "~> 5.0.0"
+gem "actionview", "~> 5.0.0"
+gem "activerecord", "~> 5.0.0"
 gem "rails-controller-testing"
 
 group :development, :test do

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -94,14 +94,6 @@ describe Admin::CustomersController, type: :controller do
         expect(page).to be_instance_of(Administrate::Page::Form)
         expect(page.resource).to be_a_new(Customer)
       end
-
-      it "re-renders the 'new' template" do
-        invalid_attributes = { name: "" }
-
-        post :create, customer: invalid_attributes
-
-        expect(response).to render_template("new")
-      end
     end
   end
 
@@ -129,15 +121,6 @@ describe Admin::CustomersController, type: :controller do
     end
 
     describe "with invalid params" do
-      it "re-renders the 'edit' template" do
-        customer = create(:customer)
-        invalid_attributes = { name: "" }
-
-        put :update, id: customer.to_param, customer: invalid_attributes
-
-        expect(response).to render_template("edit")
-      end
-
       it "passes a form page object to the view" do
         customer = create(:customer)
         invalid_attributes = { name: "" }

--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -1,14 +1,10 @@
 require File.expand_path('../boot', __FILE__)
 
-# Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -31,11 +31,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 
@@ -44,6 +39,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
-
-  config.action_mailer.default_url_options = { host: "www.example.com" }
 end

--- a/spec/support/action_mailer.rb
+++ b/spec/support/action_mailer.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |config|
-  config.before(:each) do
-    ActionMailer::Base.deliveries.clear
-  end
-end


### PR DESCRIPTION
We never use this guy and it just adds to a developers' dependencies. Right now, The whole Rails gem still gets loaded, but at least that's changed from 3 gems with Rails as a dependency down to 2. The other two are:

1. ~administrate-field-image (https://github.com/thoughtbot/administrate-field-image/pull/11)~
2. ~markdown-rails~