### PR TITLE
wrap that User in a string

### DIFF
--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -270,7 +270,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           end
           class User < ActiveRecord::Base; end
           class Invitation < ActiveRecord::Base
-            belongs_to :sender, class_name: User
+            belongs_to :sender, class_name: "User"
             belongs_to :recipient, class_name: "User"
           end
 


### PR DESCRIPTION
This is for Rails 5.1:

DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string:  (called from <class:Invitation> at /Users/BenAMorgan/Sites/administrate/spec/generators/dashboard_generator_spec.rb:273)