### PR TITLE
use an array instead of a regex

### DIFF
--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -24,7 +24,12 @@ module Administrate
     @@javascripts = []
     @@stylesheets = []
 
-    Engine.config.assets.precompile << /\.(?:svg)\z/
+    Engine.config.assets.precompile << %w(
+      administrate/cancel.svg
+      administrate/dropdown.svg
+      administrate/search.svg
+      administrate/sort_arrow.svg
+    )
 
     def self.add_javascript(script)
       @@javascripts << script


### PR DESCRIPTION
Sass calls `String#start_with?` in version 6 on the precompile assets, yet Regex doesn't implement this method leading to an error.