### PR TITLE
improve performance for n+1s

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -5,6 +5,7 @@ module Administrate
     def index
       search_term = params[:search].to_s.strip
       resources = Administrate::Search.new(resource_resolver, search_term).run
+      resources = resources.includes(*resource_includes) if resource_includes.any?
       resources = order.apply(resources)
       resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
@@ -73,11 +74,7 @@ module Administrate
 
     helper_method :nav_link_state
     def nav_link_state(resource)
-      if resource_name.to_s.pluralize == resource.to_s
-        :active
-      else
-        :inactive
-      end
+      resource_name.to_s.pluralize == resource.to_s ? :active : :inactive
     end
 
     helper_method :valid_action?
@@ -109,6 +106,18 @@ module Administrate
 
     def find_resource(param)
       resource_class.find(param)
+    end
+
+    def resource_includes
+      association_classes = [
+        Administrate::Field::HasMany, Administrate::Field::HasOne,
+        Administrate::Field::BelongsTo
+      ]
+
+      dashboard.class::ATTRIBUTE_TYPES.map do |key, value|
+        key if association_classes.include?(value) ||
+               association_classes.include?(value.try :deferred_class)
+      end.compact
     end
 
     def resource_params

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -109,15 +109,7 @@ module Administrate
     end
 
     def resource_includes
-      association_classes = [
-        Administrate::Field::HasMany, Administrate::Field::HasOne,
-        Administrate::Field::BelongsTo
-      ]
-
-      dashboard.class::ATTRIBUTE_TYPES.map do |key, value|
-        key if association_classes.include?(value) ||
-               association_classes.include?(value.try :deferred_class)
-      end.compact
+      dashboard.association_includes
     end
 
     def resource_params

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -52,6 +52,17 @@ module Administrate
       "#{resource.class} ##{resource.id}"
     end
 
+    def association_includes
+      association_classes = [Field::HasMany, Field::HasOne, Field::BelongsTo]
+
+      collection_attributes.map do |key|
+        field = self.class::ATTRIBUTE_TYPES[key]
+
+        next key if association_classes.include?(field)
+        key if association_classes.include?(field.try :deferred_class)
+      end.compact
+    end
+
     private
 
     def attribute_not_found_message(attr)

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -38,7 +38,8 @@ module Administrate
       end
 
       def resources(page = 1)
-        order.apply(data).page(page).per(limit)
+        resources = order.apply(data).page(page).per(limit)
+        includes.any? ? resources.includes(*includes) : resources
       end
 
       def more_than_limit?
@@ -46,6 +47,10 @@ module Administrate
       end
 
       private
+
+      def includes
+        associated_dashboard.association_includes
+      end
 
       def candidate_resources
         if options.key?(:includes)


### PR DESCRIPTION
This guy solves some n+1 problems in the application. The solution is global. ~I need to take time though to scope the n+1s down to just what attribute constants we're actually using.~

Tried using `COLLECTION_ATTRIBUTES` but that didn't work out very well. Didn't remove a single n+1. As per n+1 issues, I think sticking to `ATTRIBUTE_TYPES` is a good first step. I think we should integrate this with `Administate::Page::Collection`.