### PR TITLE
Do not redirect to show page when selecting text

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -11,7 +11,8 @@ $(function() {
       }
 
       var dataUrl = $(event.target).closest("tr").data("url");
-      if (dataUrl) {
+      var selection = window.getSelection().toString();
+      if (selection.length === 0 && dataUrl) {
         window.location = dataUrl;
       }
     }


### PR DESCRIPTION
This PR fixes the problem when user wants to select text on index page but instead we redirect them to show page of particular record. 

Here is how it works:

![screencast 2017-04-10 15-23-43](https://cloud.githubusercontent.com/assets/26284375/24878623/e10727ba-1e01-11e7-8b07-7d56a04b59a1.gif)

I've also tried to write a test on this, but looks like Capybara (Poltergeist?) does not support `getSelection` API.

Fixes #770

/r @carlosramireziii
/cc @stevenmilton58
