### PR TITLE
Remove Web Console from Being Installed on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,6 @@ gem "redcarpet"
 gem "sentry-raven"
 gem "unicorn"
 
-group :development do
-  gem "web-console", ">= 2.1.3"
-end
-
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,6 @@ GEM
     autoprefixer-rails (6.7.7.1)
       execjs
     awesome_print (1.6.1)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bourbon (5.0.0.beta.7)
       sass (~> 3.4.22)
       thor (~> 0.19.1)
@@ -92,7 +90,6 @@ GEM
     database_cleaner (1.5.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
-    debug_inspector (0.0.2)
     delayed_job (4.1.1)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.1.0)
@@ -279,11 +276,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    web-console (2.2.1)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -329,7 +321,6 @@ DEPENDENCIES
   timecop
   uglifier
   unicorn
-  web-console (>= 2.1.3)
   webmock
 
 BUNDLED WITH

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - gem install bundler --version "1.13.7"
+    - gem install bundler
   post:
     - bundle exec appraisal install
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -15,10 +15,6 @@ gem "sentry-raven"
 gem "unicorn"
 gem "rails", "~> 4.2.0"
 
-group :development do
-  gem "web-console", ">= 2.1.3"
-end
-
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -16,10 +16,6 @@ gem "unicorn"
 gem "rails", "~> 5.0.0"
 gem "rails-controller-testing"
 
-group :development do
-  gem "web-console", ">= 2.1.3"
-end
-
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -16,10 +16,6 @@ gem "unicorn"
 gem "sass", "~> 3.4"
 gem "rails-controller-testing"
 
-group :development do
-  gem "web-console", ">= 2.1.3"
-end
-
 group :development, :test do
   gem "appraisal"
   gem "awesome_print"


### PR DESCRIPTION
I noticed a CI failure from installing web-console. I've noticed that it appears to be random failures from installing gems with native extensions. This was caused by CircleCI changing containers. I've rebuilt without cache. I also took a look at some of the warnings. I think we should run with installing the latest bundler version and I also discovered we could drop the web-console debug gem.