### PR TITLE
Add table name to search query

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -19,9 +19,10 @@ module Administrate
     private
 
     delegate :resource_class, to: :resolver
+    delegate :table_name, to: :resource_class
 
     def query
-      search_attributes.map { |attr| "lower(#{attr}) LIKE ?" }.join(" OR ")
+      search_attributes.map { |attr| "lower(#{table_name}.#{attr}) LIKE ?" }.join(" OR ")
     end
 
     def search_terms

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -19,10 +19,14 @@ module Administrate
     private
 
     delegate :resource_class, to: :resolver
-    delegate :table_name, to: :resource_class
 
     def query
-      search_attributes.map { |attr| "lower(#{table_name}.#{attr}) LIKE ?" }.join(" OR ")
+      search_attributes.map do |attr|
+        table_name = ActiveRecord::Base.connection.
+          quote_table_name(resource_class.table_name)
+        attr_name = ActiveRecord::Base.connection.quote_column_name(attr)
+        "lower(#{table_name}.#{attr_name}) LIKE ?"
+      end.join(" OR ")
     end
 
     def search_terms

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -43,11 +43,11 @@ describe Administrate::Search do
 
     it "searches using lower() + LIKE for all searchable fields" do
       begin
-        class User; end
+        class User < ActiveRecord::Base; end
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "test")
         expected_query = [
-          "lower(name) LIKE ? OR lower(email) LIKE ?",
+          "lower(users.name) LIKE ? OR lower(users.email) LIKE ?",
           "%test%",
           "%test%",
         ]

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -47,7 +47,8 @@ describe Administrate::Search do
         resolver = double(resource_class: User, dashboard_class: MockDashboard)
         search = Administrate::Search.new(resolver, "test")
         expected_query = [
-          "lower(users.name) LIKE ? OR lower(users.email) LIKE ?",
+          "lower(\"users\".\"name\") LIKE ?"\
+          " OR lower(\"users\".\"email\") LIKE ?",
           "%test%",
           "%test%",
         ]


### PR DESCRIPTION
Hi! As always, thank you for a great gem. Ran into a problem with a pretty straightforward fix. Hit me with your feedback! 👍 

## Problem

When default scopes with joins are used, the generated search query can lead to ambiguity. For instance, the column `id` may exist in two tables, which will lead to a SQL error when it is impossible to decide which table to use.

## Solution

Add `resource_class`'s `table_name` to the generated search query. This ensures that the generated query produces the format `table_name.id` instead of `id` in the where clause generated for the search.