### PR TITLE
when the number data is a float, default to the decimal amount

### DIFF
--- a/lib/administrate/field/number.rb
+++ b/lib/administrate/field/number.rb
@@ -4,11 +4,7 @@ module Administrate
   module Field
     class Number < Field::Base
       def to_s
-        if data.nil?
-          "-"
-        else
-          format_string % value
-        end
+        data.nil? ? "-" : format_string % value
       end
 
       private
@@ -26,7 +22,8 @@ module Administrate
       end
 
       def decimals
-        options.fetch(:decimals, 0)
+        default = data.is_a?(Float) ? data.to_s.split(".").last.size : 0
+        options.fetch(:decimals, default)
       end
 
       def value

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -21,10 +21,7 @@ describe Administrate::Field::Number do
   describe "#to_s" do
     it "defaults to displaying no decimal points" do
       int = Administrate::Field::Number.new(:quantity, 3, :show)
-      float = Administrate::Field::Number.new(:quantity, 3.1415926, :show)
-
       expect(int.to_s).to eq("3")
-      expect(float.to_s).to eq("3")
     end
 
     context "with `prefix` option" do
@@ -58,6 +55,11 @@ describe Administrate::Field::Number do
         number = number_with_options(12, decimals: 2)
 
         expect(number.to_s).to eq("12.00")
+      end
+
+      it "defaults to the precision of the decimal" do
+        number = Administrate::Field::Number.new(:number, 12.123456, :page)
+        expect(number.to_s).to eq("12.123456")
       end
     end
 


### PR DESCRIPTION
fixes #740 

Calling a class `Number` should probably incorporate integers, floats, and friends. When we want to render a decimal, we want to render a _decimal_. It is a number, but it should be treated fairly. We should always default to render the next half of a number.