### PR TITLE
add support for big decimals in formatting numbers

### DIFF
--- a/lib/administrate/field/number.rb
+++ b/lib/administrate/field/number.rb
@@ -22,7 +22,8 @@ module Administrate
       end
 
       def decimals
-        default = data.is_a?(Float) ? data.to_s.split(".").last.size : 0
+        _left, right = data.to_s.split(".")
+        default = right.nil? ? 0 : right.size
         options.fetch(:decimals, default)
       end
 

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -58,8 +58,11 @@ describe Administrate::Field::Number do
       end
 
       it "defaults to the precision of the decimal" do
-        number = Administrate::Field::Number.new(:number, 12.123456, :page)
-        expect(number.to_s).to eq("12.123456")
+        float = Administrate::Field::Number.new(:number, 12.123456, :page)
+        big_decimal = Administrate::Field::Number.new(:number, 0.26186536e2, :page)
+
+        expect(float.to_s).to eq("12.123456")
+        expect(big_decimal.to_s).to eql("26.186536")
       end
     end
 


### PR DESCRIPTION
When doing #841, I forgot about `BigDecimal`s. To fix this, I've made the code class agnostic.