### PR TITLE
Remove the word "simply".

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,7 +1,8 @@
 # Authenticating admin users
 
 Authentication is left for you to implement after you install Administrate into
-your app. You can easily plugin your existing authentication system.
+your app. It's expected that you can plugin your existing authentication
+system.
 
 The base `Admin::ApplicationController` has a `TODO` to be completed:
 

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -3,7 +3,7 @@
 When you install Administrate into your app,
 we generate empty controllers for each of your resources.
 If you want to create more complex application behavior for a dashboard,
-simply overwrite controller actions.
+you can overwrite controller actions.
 
 The generated controller will look something like:
 

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,7 +1,7 @@
 module Admin
   class <%= class_name.pluralize %>Controller < Admin::ApplicationController
     # To customize the behavior of this controller,
-    # simply overwrite any of the RESTful actions. For example:
+    # you can overwrite any of the RESTful actions. For example:
     #
     # def index
     #   super


### PR DESCRIPTION
A recent Twitter exchange (inspired by a conference talk, I think) suggested
that we shouldn't use the words "simply", "easily" and "just". This
removes our only case of those.

https://twitter.com/iamsapegin/status/856880857570832384