### PR TITLE
Remove worker from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
-worker: bundle exec rake jobs:work


### PR DESCRIPTION
The delayed_job_active_record gem was removed in #845 and the jobs:work
rake task is no longer available.  Remove the worker setup from the
Procfile so `rake jobs:work` will not be called.