### PR TITLE
Remove dependency on remote images in tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,3 +32,7 @@ end
 
 ActiveRecord::Migration.maintain_test_schema!
 Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :poltergeist do |app|
+  options = { phantomjs_options: ["--load-images=no"] }
+  Capybara::Poltergeist::Driver.new(app, options)
+end


### PR DESCRIPTION
Fixes issue with images accessibility in tests (from #819). Issue can be reproduced with limiting internet bandwidth (test still pass if I've fully disabled internet).