### PR TITLE
Accessibility improvements

### DIFF
--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -6,6 +6,7 @@ table {
 
   a {
     color: inherit;
+    text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/app/assets/stylesheets/administrate/base/_typography.scss
@@ -23,7 +23,7 @@ p {
 
 a {
   color: $action-color;
-  text-decoration: none;
+  text-decoration-skip: ink;
   transition: color $base-duration $base-timing;
 
   &:hover {

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -7,7 +7,7 @@ for all resources in the admin dashboard,
 as defined by the routes in the `admin/` namespace
 %>
 
-<nav class="navigation">
+<nav class="navigation" role="navigation">
   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
     <%= link_to(
       display_resource_name(resource),

--- a/app/views/administrate/application/_search.html.erb
+++ b/app/views/administrate/application/_search.html.erb
@@ -1,4 +1,4 @@
-<form class="search">
+<form class="search" role="search">
   <span class="search__icon">
     <%= svg_tag "administrate/search.svg", "search", width: 16, height: 16 %>
   </span>

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -17,7 +17,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
 <% content_for(:title) { "#{t("administrate.actions.edit")} #{page.page_title}" } %>
 
-<header class="main-content__header">
+<header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -33,7 +33,7 @@ It renders the `_table` partial to display details about the resources.
   <% end %>
 <% end %>
 
-<header class="main-content__header">
+<header class="main-content__header" role="banner">
   <h1 class="main-content__page-title" id="page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -17,7 +17,7 @@ to do the heavy lifting.
 
 <% content_for(:title) { "#{t("administrate.actions.new")} #{page.resource_name.titleize}" } %>
 
-<header class="main-content__header">
+<header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -18,7 +18,7 @@ as well as a link to its edit page.
 
 <% content_for(:title) { "#{t("administrate.actions.show")} #{page.page_title}" } %>
 
-<header class="main-content__header">
+<header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -19,7 +19,7 @@ By default, it renders:
   <meta name="ROBOTS" content="NOODP">
   <meta name="viewport" content="initial-scale=1">
   <title>
-    <%= content_for(:title) %> | <%= Rails.application.class.parent_name.titlecase %>
+    <%= content_for(:title) %> - <%= Rails.application.class.parent_name.titlecase %>
   </title>
   <%= render "stylesheet" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
- Add link underlines
  - Underlines are a standard way of indicating a link. By only using color to indicate links, people with vision impairments, such as color blindness, might not be able to distinguish linked text from non-linked text.
- Use a hyphen separator in page titles
  - The vertical pipe is read aloud by screen readers. So a page title of `page | Administrate` would be read as ”page vertical pipe Administrate.”
  - By using a hyphen instead, the screen reader will read as “page, Administrate.”
  - Related: https://github.com/thoughtbot/administrate/issues/794
- Add ARIA landmark roles
  - ARIA landmark roles provide useful navigation features for assistive technology and helps people understand the content structure.