### PR TITLE
Add appraisal and foreman commands to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,22 +10,22 @@ issue trackers, chatrooms, and mailing lists.
 
 1. Fork the repo.
 
-2. Run `./bin/setup`.
+1. Run `./bin/setup`.
 
-3. Run `appraisal install`
+1. Run `appraisal install`
 
-4. Run the tests. We only take pull requests with passing tests, and it's great
+1. Run the tests. We only take pull requests with passing tests, and it's great
    to know that you have a clean slate: `bundle exec rake && bundle exec appraisal rake`
 
-5. Add a test for your change. Only refactoring and documentation changes
+1. Add a test for your change. Only refactoring and documentation changes
    require no new tests. If you are adding functionality or fixing a bug,
    we need a test!
 
-6. Make the test pass.
+1. Make the test pass.
 
-7. Write a [good commit message][commit].
+1. Write a [good commit message][commit].
 
-8. Push to your fork and submit a pull request.
+1. Push to your fork and submit a pull request.
 
 Others will give constructive feedback.
 This is a time for discussion and improvements,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ This is a time for discussion and improvements,
 and making the necessary changes will be required before we can
 merge the contribution.
 
-## Start Appliction in Develepment
+## Start Application in Development
 
 Configure your local environment with `./bin/setup`.
 After that start the application with the `foreman start` command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,24 +12,30 @@ issue trackers, chatrooms, and mailing lists.
 
 2. Run `./bin/setup`.
 
-3. Run the tests. We only take pull requests with passing tests, and it's great
-   to know that you have a clean slate:
-   `bundle exec rake && bundle exec appraisal rake`
+3. Run `appraisal install`
 
-4. Add a test for your change. Only refactoring and documentation changes
+4. Run the tests. We only take pull requests with passing tests, and it's great
+   to know that you have a clean slate: `bundle exec rake && bundle exec appraisal rake`
+
+5. Add a test for your change. Only refactoring and documentation changes
    require no new tests. If you are adding functionality or fixing a bug,
    we need a test!
 
-5. Make the test pass.
+6. Make the test pass.
 
-6. Write a [good commit message][commit].
+7. Write a [good commit message][commit].
 
-7. Push to your fork and submit a pull request.
+8. Push to your fork and submit a pull request.
 
 Others will give constructive feedback.
 This is a time for discussion and improvements,
 and making the necessary changes will be required before we can
 merge the contribution.
+
+## Start Appliction in Develepment
+
+Configure your local environment with `./bin/setup`.
+After that start the application with the `foreman start` command.
 
 ## Performance Improvements
 


### PR DESCRIPTION
For contributors that not aware about appraisal and foreman it is hard to know how to run the development server and tests with appraisal.

As a suggestion, it will be good to move the `appraisal install` command to `bin/setup`, but not sure how CI will react on this change.