### PR TITLE
Nested collection links should honour routes

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -47,7 +47,8 @@ to display a collection of resources in an HTML table.
           <% end %>
         </th>
       <% end %>
-      <% [valid_action?(:edit), valid_action?(:destroy)].count(true).times do %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
         <th scope="col"></th>
       <% end %>
     </tr>
@@ -57,7 +58,9 @@ to display a collection of resources in an HTML table.
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           tabindex="0"
-          <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) if valid_action? :show -%>
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
@@ -69,7 +72,7 @@ to display a collection of resources in an HTML table.
           </td>
         <% end %>
 
-        <% if valid_action? :edit %>
+        <% if valid_action? :edit, collection_presenter.resource_name %>
           <td><%= link_to(
             t("administrate.actions.edit"),
             [:edit, namespace, resource],
@@ -77,7 +80,7 @@ to display a collection of resources in an HTML table.
           ) %></td>
         <% end %>
 
-        <% if valid_action? :destroy %>
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
           <td><%= link_to(
             t("administrate.actions.destroy"),
             [namespace, resource],

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -14,6 +14,7 @@ class OrderDashboard < Administrate::BaseDashboard
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
+    payments: Field::HasMany,
   }
 
   READ_ONLY_ATTRIBUTES = [

--- a/spec/example_app/app/models/order.rb
+++ b/spec/example_app/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ActiveRecord::Base
 
   validates :customer, presence: true
   has_many :line_items, dependent: :destroy
+  has_many :payments, dependent: :destroy
 
   validates :address_line_one, presence: true
   validates :address_line_two, presence: true

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -19,4 +19,24 @@ feature "order show page" do
 
     expect(page).to have_header(displayed(line_item))
   end
+
+  scenario "user cannot click through to payment edit page" do
+    payment = create(:payment)
+
+    visit admin_order_path(payment.order)
+
+    within("table") do
+      expect(page).not_to have_link t("administrate.actions.edit")
+    end
+  end
+
+  scenario "user cannot click through to payment delete record" do
+    payment = create(:payment)
+
+    visit admin_order_path(payment.order)
+
+    within("table") do
+      expect(page).not_to have_link t("administrate.actions.destroy")
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit if any routes where omitted for a resource like:

```ruby
resources :users
resources :orders, except: [:edit, :update]
```

Navigating directly to a orders show page would correctly omit the edit link but if another associated dashboard utilised a field that rendered using the partial `_collection.html.erb` like:

```ruby
class UserDashboard < Administrate::BaseDashboard
  ATTRIBUTE_TYPES = {
    orders: Field::HasMany,
  }

  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
end
```

when navigating to the users show page an error 500 would be thrown because the rendering of orders would incorrectly try to link to the non existent edit route

Fixes #790