### PR TITLE
Add `aria-sort` attribute to table headers

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -20,12 +20,10 @@ module Administrate
     end
 
     def sort_order(order)
-      if order == "asc"
-        "ascending"
-      elsif order == "desc"
-        "descending"
-      else
-        "none"
+      case order
+      when "asc" then "ascending"
+      when "desc" then "descending"
+      else "none"
       end
     end
 

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -19,6 +19,16 @@ module Administrate
         )
     end
 
+    def sort_order(order)
+      if order == "asc"
+        "ascending"
+      elsif order == "desc"
+        "descending"
+      else
+        "none"
+      end
+    end
+
     def sanitized_order_params
       params.permit(:search, :id, :order, :page, :per_page, :direction, :orders)
     end

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -24,8 +24,10 @@ to display a collection of resources in an HTML table.
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
         <th class="cell-label
         cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
-        " scope="col">
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
         <%= link_to(sanitized_order_params.merge(
           collection_presenter.order_params_for(attr_name)
         )) do %>


### PR DESCRIPTION
Adding the `aria-sort` attribute indicates to assistive technology if
items in a table or grid are sorted in ascending or descending order. It
accepts values of `ascending`, `descending` and `none`.

I’m no Ruby developer, so I have a hunch that this could be 
implemented in a much better way.