### PR TITLE
Update documentation navigation

### DIFF
--- a/spec/example_app/app/views/layouts/docs.html.erb
+++ b/spec/example_app/app/views/layouts/docs.html.erb
@@ -19,7 +19,6 @@
       <h3>Documentation</h3>
 
       <ul class="sidebar-links">
-        <li><a href="/">README</a></li>
         <li><a href="/getting_started">Getting Started</a></li>
         <li><a href="/customizing_dashboards">Customizing Dashboards</a></li>
         <li><a href="/customizing_page_views">Customizing Page Views</a></li>

--- a/spec/example_app/app/views/layouts/docs.html.erb
+++ b/spec/example_app/app/views/layouts/docs.html.erb
@@ -12,6 +12,7 @@
 
       <ul class="sidebar-links">
         <li><a href="/">Home</a></li>
+        <li><a href="https://github.com/thoughtbot/administrate">GitHub</a></li>
         <li><a href="https://github.com/thoughtbot/administrate/issues/new">Feedback</a></li>
       </ul>
 

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe "documentation" do
+  it "links to the Github repo" do
+    visit root_path
+
+    expect(github_link[:href]).
+      to eq "https://github.com/thoughtbot/administrate"
+  end
+
+  private
+
+  def github_link
+    first(".sidebar-links").find("a", text: "GitHub")
+  end
+end

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,6 +1,18 @@
 require "rails_helper"
 
-describe "documentation" do
+describe "documentation navigation" do
+  it "links to each documentation page" do
+    visit root_path
+    links = internal_documentation_links
+
+    expect(links).to_not be_empty
+
+    links.each do |link|
+      visit link
+      expect(page).to have_http_status(:ok), "Unable to find #{link}"
+    end
+  end
+
   it "links to the Github repo" do
     visit root_path
 
@@ -12,5 +24,11 @@ describe "documentation" do
 
   def github_link
     first(".sidebar-links").find("a", text: "GitHub")
+  end
+
+  def internal_documentation_links
+    all(".sidebar a").
+      map { |anchor| anchor[:href] }.
+      select { |href| URI.parse(href).relative? }
   end
 end


### PR DESCRIPTION
## Changes:

- Add link to Github repo
- Remove duplicate "README" link (dupe of "Home")
- Test each navigation link points to a page which exists

## Before:
<img width="374" alt="a-before" src="https://cloud.githubusercontent.com/assets/4125410/26007159/453321f0-3737-11e7-82ea-9b4d48daf5ac.png">

## After:
<img width="320" alt="a-after" src="https://cloud.githubusercontent.com/assets/4125410/26007166/481c5990-3737-11e7-82d8-076497cc506f.png">