### PR TITLE
Fix `aria-labelledby` on tables

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -18,7 +18,7 @@ to display a collection of resources in an HTML table.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
 
-<table aria-labelledby="page-title">
+<table aria-labelledby="<%= table_title %>">
   <thead>
     <tr>
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -48,6 +48,12 @@ It renders the `_table` partial to display details about the resources.
 </header>
 
 <section class="main-content__body main-content__body--flush">
-  <%= render "collection", collection_presenter: page, resources: resources %>
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
   <%= paginate resources %>
 </section>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -35,7 +35,7 @@ as well as a link to its edit page.
 <section class="main-content__body">
   <dl>
     <% page.attributes.each do |attribute| %>
-      <dt class="attribute-label">
+      <dt class="attribute-label" id="<%= attribute.name %>">
       <%= t(
         "helpers.label.#{resource_name}.#{attribute.name}",
         default: attribute.name.titleize,

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -22,7 +22,8 @@ from the associated resource class's dashboard.
   <%= render(
     "collection",
     collection_presenter: field.associated_collection,
-    resources: field.resources(params[field.name])
+    resources: field.resources(params[field.name]),
+    table_title: field.name
   ) %>
 
   <% if field.more_than_limit? %>


### PR DESCRIPTION
`aria-labelledby` accepts `id`s of other elements which act as an
accessible label(s). It's great for providing a label to tables, which
are large amounts of content; it helps people understand what the
table content actually is.

We're currently using `aria-labelledby` on tables in Administrate,
pointing to the `id` of the `h1` on index pages. However, this breaks
when tables are shown as attribute data on show pages, because the `id`
of `page-title` does not exist, and it also is not the proper label for
the table (the attribute name is). You can see an example of this here:
https://administrate-prototype.herokuapp.com/admin/customers/9849

This PR allows an `id` of an element to be passed into the partial
which displays the collection table, so that it can used as the value
for the table's `aria-labelledby` attribute.