### PR TITLE
Fix hiding of search bar when none of searchable columns are used on index page

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -165,7 +165,7 @@ module Administrate
 
     def show_search_bar?
       dashboard.attribute_types_for(
-        dashboard.collection_attributes,
+        dashboard.all_attributes,
       ).any? { |_name, attribute| attribute.searchable? }
     end
 

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -32,6 +32,10 @@ module Administrate
       end
     end
 
+    def all_attributes
+      attribute_types.keys
+    end
+
     def form_attributes
       self.class::FORM_ATTRIBUTES
     end
@@ -61,7 +65,7 @@ module Administrate
         field = self.class::ATTRIBUTE_TYPES[key]
 
         next key if association_classes.include?(field)
-        key if association_classes.include?(field.try :deferred_class)
+        key if association_classes.include?(field.try(:deferred_class))
       end.compact
     end
 


### PR DESCRIPTION
Untie search from representation of collection