### PR TITLE
Make entire search bar clickable

### DIFF
--- a/app/assets/stylesheets/administrate/components/_search.scss
+++ b/app/assets/stylesheets/administrate/components/_search.scss
@@ -50,6 +50,7 @@
   flex-grow: 1;
   margin: 0;
   padding: ($small-spacing * 1.5) $small-spacing;
+  z-index: 1;
 
   &:focus {
     box-shadow: none;
@@ -63,7 +64,6 @@
   position: absolute;
   top: 1em;
   transition: opacity $base-duration $base-timing;
-  z-index: 1;
 
   svg {
     height: 100%;
@@ -77,5 +77,6 @@
 
   &--active {
     opacity: 1;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
The .search__hint div blocks a portion of the search input.  If the
user clicks around the word "Search" they are unable to activate the
search input.

* Remove z-index from .search__hint before it is active
* Add z-index to .search__hint--active so it only blocks a portion of
the search bar after the user has already clicked the search bar
* Add z-index to .search__input so it is clickable above other elements