### PR TITLE
Retroactively set migration versions.

### DIFF
--- a/spec/example_app/db/migrate/20150220194224_create_customers.rb
+++ b/spec/example_app/db/migrate/20150220194224_create_customers.rb
@@ -1,4 +1,4 @@
-class CreateCustomers < ActiveRecord::Migration
+class CreateCustomers < ActiveRecord::Migration[4.2]
   def change
     create_table :customers do |t|
       t.string :name, null: false

--- a/spec/example_app/db/migrate/20150403065618_create_products.rb
+++ b/spec/example_app/db/migrate/20150403065618_create_products.rb
@@ -1,4 +1,4 @@
-class CreateProducts < ActiveRecord::Migration
+class CreateProducts < ActiveRecord::Migration[4.2]
   def change
     create_table :products do |t|
       t.string :name

--- a/spec/example_app/db/migrate/20150411204433_create_orders.rb
+++ b/spec/example_app/db/migrate/20150411204433_create_orders.rb
@@ -1,4 +1,4 @@
-class CreateOrders < ActiveRecord::Migration
+class CreateOrders < ActiveRecord::Migration[4.2]
   def change
     create_table :orders do |t|
       t.references :customer, index: true

--- a/spec/example_app/db/migrate/20150417044505_create_line_items.rb
+++ b/spec/example_app/db/migrate/20150417044505_create_line_items.rb
@@ -1,4 +1,4 @@
-class CreateLineItems < ActiveRecord::Migration
+class CreateLineItems < ActiveRecord::Migration[4.2]
   def change
     create_table :line_items do |t|
       t.references :order, index: true

--- a/spec/example_app/db/migrate/20150903215027_add_shipped_at_to_orders.rb
+++ b/spec/example_app/db/migrate/20150903215027_add_shipped_at_to_orders.rb
@@ -1,4 +1,4 @@
-class AddShippedAtToOrders < ActiveRecord::Migration
+class AddShippedAtToOrders < ActiveRecord::Migration[4.2]
   def change
     add_column :orders, :shipped_at, :datetime
   end

--- a/spec/example_app/db/migrate/20150914175022_add_slug_to_products.rb
+++ b/spec/example_app/db/migrate/20150914175022_add_slug_to_products.rb
@@ -1,4 +1,4 @@
-class AddSlugToProducts < ActiveRecord::Migration
+class AddSlugToProducts < ActiveRecord::Migration[4.2]
   def change
     add_column :products, :slug, :string, null: true
 

--- a/spec/example_app/db/migrate/20150916011117_add_email_subscriber_to_customers.rb
+++ b/spec/example_app/db/migrate/20150916011117_add_email_subscriber_to_customers.rb
@@ -1,4 +1,4 @@
-class AddEmailSubscriberToCustomers < ActiveRecord::Migration
+class AddEmailSubscriberToCustomers < ActiveRecord::Migration[4.2]
   def change
     add_column :customers, :email_subscriber, :boolean
   end

--- a/spec/example_app/db/migrate/20160119024340_add_kind_to_customer.rb
+++ b/spec/example_app/db/migrate/20160119024340_add_kind_to_customer.rb
@@ -1,4 +1,4 @@
-class AddKindToCustomer < ActiveRecord::Migration
+class AddKindToCustomer < ActiveRecord::Migration[4.2]
   def change
     add_column :customers, :kind, :string, null: false, default: "standard"
   end

--- a/spec/example_app/db/migrate/20160815100728_create_payments.rb
+++ b/spec/example_app/db/migrate/20160815100728_create_payments.rb
@@ -1,4 +1,4 @@
-class CreatePayments < ActiveRecord::Migration
+class CreatePayments < ActiveRecord::Migration[4.2]
   def change
     create_table :payments do |t|
       t.references :order, index: true

--- a/spec/example_app/db/migrate/20170507115814_create_blog_posts.rb
+++ b/spec/example_app/db/migrate/20170507115814_create_blog_posts.rb
@@ -1,4 +1,4 @@
-class CreateBlogPosts < ActiveRecord::Migration
+class CreateBlogPosts < ActiveRecord::Migration[4.2]
   def change
     create_table :blog_posts do |t|
       t.string :title

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -16,66 +15,62 @@ ActiveRecord::Schema.define(version: 20170507115814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "blog_posts", force: :cascade do |t|
-    t.string   "title"
+  create_table "blog_posts", id: :serial, force: :cascade do |t|
+    t.string "title"
     t.datetime "published_at"
-    t.text     "body"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
-  create_table "customers", force: :cascade do |t|
-    t.string   "name",                                  null: false
-    t.string   "email",                                 null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.boolean  "email_subscriber"
-    t.string   "kind",             default: "standard", null: false
-  end
-
-  create_table "line_items", force: :cascade do |t|
-    t.integer  "order_id"
-    t.integer  "product_id"
-    t.float    "unit_price"
-    t.integer  "quantity"
+    t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "line_items", ["order_id"], name: "index_line_items_on_order_id", using: :btree
-  add_index "line_items", ["product_id"], name: "index_line_items_on_product_id", using: :btree
-
-  create_table "orders", force: :cascade do |t|
-    t.integer  "customer_id"
-    t.string   "address_line_one"
-    t.string   "address_line_two"
-    t.string   "address_city"
-    t.string   "address_state"
-    t.string   "address_zip"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-    t.datetime "shipped_at"
+  create_table "customers", id: :serial, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "email_subscriber"
+    t.string "kind", default: "standard", null: false
   end
 
-  add_index "orders", ["customer_id"], name: "index_orders_on_customer_id", using: :btree
-
-  create_table "payments", force: :cascade do |t|
+  create_table "line_items", id: :serial, force: :cascade do |t|
     t.integer "order_id"
+    t.integer "product_id"
+    t.float "unit_price"
+    t.integer "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_line_items_on_order_id"
+    t.index ["product_id"], name: "index_line_items_on_product_id"
   end
 
-  add_index "payments", ["order_id"], name: "index_payments_on_order_id", using: :btree
-
-  create_table "products", force: :cascade do |t|
-    t.string   "name"
-    t.float    "price"
-    t.text     "description"
-    t.string   "image_url"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.string   "slug",        null: false
+  create_table "orders", id: :serial, force: :cascade do |t|
+    t.integer "customer_id"
+    t.string "address_line_one"
+    t.string "address_line_two"
+    t.string "address_city"
+    t.string "address_state"
+    t.string "address_zip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "shipped_at"
+    t.index ["customer_id"], name: "index_orders_on_customer_id"
   end
 
-  add_index "products", ["slug"], name: "index_products_on_slug", unique: true, using: :btree
+  create_table "payments", id: :serial, force: :cascade do |t|
+    t.integer "order_id"
+    t.index ["order_id"], name: "index_payments_on_order_id"
+  end
+
+  create_table "products", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.float "price"
+    t.text "description"
+    t.string "image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug", null: false
+    t.index ["slug"], name: "index_products_on_slug", unique: true
+  end
 
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"


### PR DESCRIPTION
Rails 5.1 onwards fails when this isn't set and in CI we're running
fresh so this causes a failure.

It sets the version to 4.2, as that's when they originate from.