### PR TITLE
Added Time Field

### DIFF
--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,5 +1,9 @@
 $(function () {
-  $(".datetimepicker").datetimepicker({
+  $(".field-unit--time .datetimepicker").datetimepicker({
+  debug: false,
+  format: "HH:mm:ss",
+  });
+  $(".field-unit--date-time .datetimepicker").datetimepicker({
     debug: false,
     format: "YYYY-MM-DD HH:mm:ss",
   });

--- a/app/views/fields/time/_form.html.erb
+++ b/app/views/fields/time/_form.html.erb
@@ -1,0 +1,22 @@
+<%#
+# Time Form Partial
+
+This partial renders an input element for time attributes.
+By default, the input is a select field for the time attributes.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::Time][1].
+  A wrapper around the tmie attributes pulled from the model.
+
+%>
+
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.text_field field.attribute, class: "datetimepicker" %>
+</div>

--- a/app/views/fields/time/_index.html.erb
+++ b/app/views/fields/time/_index.html.erb
@@ -1,0 +1,17 @@
+<%#
+# Time Index Partial
+
+This partial renders an time attribute
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered as a text tag.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Time][1].
+  A wrapper around the time attributes pulled from the model.
+
+%>
+
+<%= field.data.strftime("%I:%M%p").to_s %>

--- a/app/views/fields/time/_show.html.erb
+++ b/app/views/fields/time/_show.html.erb
@@ -1,0 +1,17 @@
+<%#
+# Time Show Partial
+
+This partial renders an time attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered as a text tag.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::Time][1].
+  A wrapper around the time attributes pulled from the model.
+
+%>
+
+<%= field.data.strftime("%I:%M%p").to_s %>

--- a/lib/administrate/field/time.rb
+++ b/lib/administrate/field/time.rb
@@ -1,0 +1,8 @@
+require_relative "base"
+
+module Administrate
+  module Field
+    class Time < Base
+    end
+  end
+end


### PR DESCRIPTION
Added a time field to administrate. Instead of showing both the calendar and the time picker it only shows the time picker as shown in the screenshot. It's based on my [administrate-field-time gem](http://www.github.com/DisruptiveAngels/administrate-field-time)
<img width="658" alt="screenshot 2017-05-25 23 29 41" src="https://cloud.githubusercontent.com/assets/7603314/26480799/0bb6ecca-41a2-11e7-877d-aa897fe363c2.png">
