### PR TITLE
Scoping index action

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -105,7 +105,7 @@ module Administrate
     end
 
     def find_resource(param)
-      resource_scope.find(param)
+      resource_class.find(param)
     end
 
     def resource_includes
@@ -117,8 +117,7 @@ module Administrate
         permit(dashboard.permitted_attributes)
     end
 
-    delegate :resource_class, :resource_name, :namespace, :resource_scope,
-             to: :resource_resolver
+    delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
     helper_method :namespace
     helper_method :resource_name
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -4,7 +4,9 @@ module Administrate
 
     def index
       search_term = params[:search].to_s.strip
-      resources = Administrate::Search.new(resource_resolver, search_term).run
+      resources = Administrate::Search.new(scoped_resource,
+                                           dashboard_class,
+                                           search_term).run
       resources = resources.includes(*resource_includes) if resource_includes.any?
       resources = order.apply(resources)
       resources = resources.page(params[:page]).per(records_per_page)
@@ -97,7 +99,7 @@ module Administrate
     end
 
     def dashboard
-      @_dashboard ||= resource_resolver.dashboard_class.new
+      @_dashboard ||= dashboard_class.new
     end
 
     def requested_resource
@@ -105,7 +107,11 @@ module Administrate
     end
 
     def find_resource(param)
-      resource_class.find(param)
+      scoped_resource.find(param)
+    end
+
+    def scoped_resource
+      resource_class.default_scoped
     end
 
     def resource_includes
@@ -120,6 +126,10 @@ module Administrate
     delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
     helper_method :namespace
     helper_method :resource_name
+
+    def dashboard_class
+      resource_resolver.dashboard_class
+    end
 
     def resource_resolver
       @_resource_resolver ||=

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -28,5 +28,15 @@ class Admin::FoosController < Admin::ApplicationController
   # def find_resource(param)
   #   Foo.find_by!(slug: param)
   # end
+  #
+  # Override this if you have certain roles that require a subset
+  # this will be used to set the records shown on the `index` action.
+  # def scoped_resource
+  #  if current_user.super_admin?
+  #    resource_class
+  #  else
+  #    resource_class.with_less_stuff
+  #  end
+  # end
 end
 ```

--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -16,10 +16,6 @@ module Administrate
       Object.const_get(resource_class_name)
     end
 
-    def resource_scope
-      dashboard_class.new.try(:resource_scope) || resource_class.default_scoped
-    end
-
     def resource_name
       model_path_parts.map(&:underscore).join("__").to_sym
     end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -3,27 +3,26 @@ require "active_support/core_ext/object/blank"
 
 module Administrate
   class Search
-    def initialize(resolver, term)
-      @resolver = resolver
+    def initialize(scoped_resource, dashboard_class, term)
+      @dashboard_class = dashboard_class
+      @scoped_resource = scoped_resource
       @term = term
     end
 
     def run
       if @term.blank?
-        resource_class.all
+        @scoped_resource.all
       else
-        resource_class.where(query, *search_terms)
+        @scoped_resource.where(query, *search_terms)
       end
     end
 
     private
 
-    delegate :resource_class, to: :resolver
-
     def query
       search_attributes.map do |attr|
         table_name = ActiveRecord::Base.connection.
-          quote_table_name(resource_class.table_name)
+          quote_table_name(@scoped_resource.table_name)
         attr_name = ActiveRecord::Base.connection.quote_column_name(attr)
         "lower(#{table_name}.#{attr_name}) LIKE ?"
       end.join(" OR ")
@@ -40,7 +39,7 @@ module Administrate
     end
 
     def attribute_types
-      resolver.dashboard_class::ATTRIBUTE_TYPES
+      @dashboard_class::ATTRIBUTE_TYPES
     end
 
     attr_reader :resolver, :term

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -10,15 +10,15 @@ module Administrate
 
     def run
       if @term.blank?
-        resource_scope.all
+        resource_class.all
       else
-        resource_scope.where(query, *search_terms)
+        resource_class.where(query, *search_terms)
       end
     end
 
     private
 
-    delegate :resource_class, :resource_scope, to: :resolver
+    delegate :resource_class, to: :resolver
 
     def query
       search_attributes.map do |attr|

--- a/spec/lib/administrate/resource_resolver_spec.rb
+++ b/spec/lib/administrate/resource_resolver_spec.rb
@@ -60,38 +60,6 @@ describe Administrate::ResourceResolver do
     end
   end
 
-  describe "#resource_scope" do
-    it "defaults to model default scope when no override defined" do
-      begin
-        class Post
-          def self.default_scoped
-            "default scope"
-          end
-        end
-        class PostDashboard; end
-        resolver = Administrate::ResourceResolver.new("admin/posts")
-        expect(resolver.resource_scope).to eq("default scope")
-      ensure
-        remove_constants :PostDashboard, :Post
-      end
-    end
-
-    it "uses defined scope when present" do
-      begin
-        class Post; end
-        class PostDashboard
-          def resource_scope
-            "a resource scope"
-          end
-        end
-        resolver = Administrate::ResourceResolver.new("admin/posts")
-        expect(resolver.resource_scope).to eq("a resource scope")
-      ensure
-        remove_constants :PostDashboard, :Post
-      end
-    end
-  end
-
   describe "#resource_title" do
     it "handles global-namepsace models" do
       resolver = Administrate::ResourceResolver.new("admin/users")

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -17,10 +17,12 @@ describe Administrate::Search do
   describe "#run" do
     it "returns all records when no search term" do
       begin
-        class User; end
-        resolver = double(resource_class: User, dashboard_class: MockDashboard)
-        search = Administrate::Search.new(resolver, nil)
-        expect(User).to receive(:all)
+        class User < ActiveRecord::Base; end
+        scoped_object = User.default_scoped
+        search = Administrate::Search.new(scoped_object,
+                                          MockDashboard,
+                                          nil)
+        expect(scoped_object).to receive(:all)
 
         search.run
       ensure
@@ -30,10 +32,12 @@ describe Administrate::Search do
 
     it "returns all records when search is empty" do
       begin
-        class User; end
-        resolver = double(resource_class: User, dashboard_class: MockDashboard)
-        search = Administrate::Search.new(resolver, "   ")
-        expect(User).to receive(:all)
+        class User < ActiveRecord::Base; end
+        scoped_object = User.default_scoped
+        search = Administrate::Search.new(scoped_object,
+                                          MockDashboard,
+                                          "   ")
+        expect(scoped_object).to receive(:all)
 
         search.run
       ensure
@@ -44,15 +48,17 @@ describe Administrate::Search do
     it "searches using lower() + LIKE for all searchable fields" do
       begin
         class User < ActiveRecord::Base; end
-        resolver = double(resource_class: User, dashboard_class: MockDashboard)
-        search = Administrate::Search.new(resolver, "test")
+        scoped_object = User.default_scoped
+        search = Administrate::Search.new(scoped_object,
+                                          MockDashboard,
+                                          "test")
         expected_query = [
           "lower(\"users\".\"name\") LIKE ?"\
           " OR lower(\"users\".\"email\") LIKE ?",
           "%test%",
           "%test%",
         ]
-        expect(User).to receive(:where).with(*expected_query)
+        expect(scoped_object).to receive(:where).with(*expected_query)
 
         search.run
       ensure
@@ -63,15 +69,17 @@ describe Administrate::Search do
     it "converts search term lower case for latin and cyrillic strings" do
       begin
         class User < ActiveRecord::Base; end
-        resolver = double(resource_class: User, dashboard_class: MockDashboard)
-        search = Administrate::Search.new(resolver, "Тест Test")
+        scoped_object = User.default_scoped
+        search = Administrate::Search.new(scoped_object,
+                                          MockDashboard,
+                                          "Тест Test")
         expected_query = [
           "lower(\"users\".\"name\") LIKE ?"\
           " OR lower(\"users\".\"email\") LIKE ?",
           "%тест test%",
           "%тест test%",
         ]
-        expect(User).to receive(:where).with(*expected_query)
+        expect(scoped_object).to receive(:where).with(*expected_query)
 
         search.run
       ensure


### PR DESCRIPTION
Hi

@bobf discussed this and feel this is more of a railsy implementation for scoping the index action.

The purpose is to allow people to override the controller action

```ruby
def scoped_resource
     # Do something special with what's displayed in the index action
end
```

In order to manage what's displayed on the index page.

Which will certainly help Bob and I use roles within administrate.

Ta
Ad