### PR TITLE
Adds _stylesheet to the resources to be generated.

### DIFF
--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -13,6 +13,7 @@ module Administrate
           )
 
           call_generator("administrate:views:navigation")
+          copy_resource_template("_stylesheet")
           copy_resource_template("_javascript")
           copy_resource_template("_flashes")
         end


### PR DESCRIPTION
This produces a file like the following:

    <%#
    # Stylesheet Partial

    This partial imports the necessary stylesheets on each page.
    By default, it includes the application CSS,
    but each page can define additional CSS sources
    by providing a `content_for(:stylesheet)` block.
    %>

    <% Administrate::Engine.stylesheets.each do |css_path| %>
      <%= stylesheet_link_tag css_path %>
    <% end %>

    <%= yield :stylesheet %>

In `app/views/admin/application/_stylesheet.html.erb`. Fixes #888.