### PR TITLE
add module name option for generator commands to support #855

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,25 @@ Re-bundle, then run the installer:
 ```bash
 $ rails generate administrate:install
 ```
+Or to use a custom module name (default is `Admin`). eg. `Backend`
+```bash
+$ rails generate administrate:install -m Backend
+```
 
 Restart your server, and visit http://localhost:3000/admin
 to see your new dashboard in action.
 
 ## Create Additional Dashboards
 
-In order to create additional dashboards, pass in the resource name to 
+In order to create additional dashboards, pass in the resource name to
 the dashboard generator. A dashboard and controller will be created.
 
 ```bash
 $ rails generate administrate:dashboard Foo
+```
+Or to use a custom module name (default is `Admin`). eg. `Backend`
+```bash
+$ rails generate administrate:dashboard Foo -m Backend
 ```
 
 ## Documentation

--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -5,6 +5,15 @@ module Administrate
   class ViewGenerator < Rails::Generators::Base
     include Administrate::GeneratorHelpers
 
+    class_option :module, type: :string,
+                          default: 'Admin',
+                          desc: 'Indicates the module name',
+                          aliases: '-m'
+
+    def module_name
+      options['module']
+    end
+
     private
 
     def self.template_source_path
@@ -19,7 +28,7 @@ module Administrate
 
       copy_file(
         template_file,
-        "app/views/admin/#{resource_path}/#{template_file}",
+        "app/views/#{module_name}/#{resource_path}/#{template_file}",
       )
     end
 

--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -6,12 +6,12 @@ module Administrate
     include Administrate::GeneratorHelpers
 
     class_option :module, type: :string,
-                          default: 'Admin',
-                          desc: 'Indicates the module name',
-                          aliases: '-m'
+                          default: "Admin",
+                          desc: "Indicates the module name",
+                          aliases: "-m"
 
     def module_name
-      options['module']
+      options["module"]
     end
 
     private

--- a/lib/generators/administrate/dashboard/USAGE
+++ b/lib/generators/administrate/dashboard/USAGE
@@ -3,7 +3,8 @@ Description:
     pulling the attributes from database columns.
 
 Example:
-    rails generate administrate:dashboard FooBar
+    1. rails generate administrate:dashboard FooBar
+    2. rails generate administrate:dashboard FooBar -m Backend
 
     This will create:
         app/dashboards/foo_bar_dashboard.rb

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -27,9 +27,9 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       class_option :module, type: :string,
-                            default: 'Admin',
-                            desc: 'Indicates the module name',
-                            aliases: '-m'
+                            default: "Admin",
+                            desc: "Indicates the module name",
+                            aliases: "-m"
 
       def create_dashboard_definition
         template(
@@ -40,14 +40,15 @@ module Administrate
 
       def create_resource_controller
         destination = Rails.root.join(
-          "app/controllers/#{module_name.underscore}/#{file_name.pluralize}_controller.rb",
+          "app/controllers/#{module_name.underscore}/\
+           #{file_name.pluralize}_controller.rb",
         )
 
         template("controller.rb.erb", destination)
       end
 
       def module_name
-        options['module']
+        options["module"]
       end
 
       private

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -34,14 +34,15 @@ module Administrate
       def create_dashboard_definition
         template(
           "dashboard.rb.erb",
-          Rails.root.join("app/dashboards/#{file_name}_dashboard.rb"),
+          Rails.root.join("app/dashboards/"\
+            "#{file_name}_dashboard.rb"),
         )
       end
 
       def create_resource_controller
         destination = Rails.root.join(
-          "app/controllers/#{module_name.underscore}/\
-           #{file_name.pluralize}_controller.rb",
+          "app/controllers/#{module_name.underscore}/"\
+            "#{file_name.pluralize}_controller.rb",
         )
 
         template("controller.rb.erb", destination)

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -26,6 +26,11 @@ module Administrate
 
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :module, type: :string,
+                            default: 'Admin',
+                            desc: 'Indicates the module name',
+                            aliases: '-m'
+
       def create_dashboard_definition
         template(
           "dashboard.rb.erb",
@@ -35,10 +40,14 @@ module Administrate
 
       def create_resource_controller
         destination = Rails.root.join(
-          "app/controllers/admin/#{file_name.pluralize}_controller.rb",
+          "app/controllers/#{module_name.underscore}/#{file_name.pluralize}_controller.rb",
         )
 
         template("controller.rb.erb", destination)
+      end
+
+      def module_name
+        options['module']
       end
 
       private

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,5 +1,5 @@
-module Admin
-  class <%= class_name.pluralize %>Controller < Admin::ApplicationController
+module <%= module_name.classify %>
+  class <%= class_name.pluralize %>Controller < <%= module_name.classify %>::ApplicationController
     # To customize the behavior of this controller,
     # you can overwrite any of the RESTful actions. For example:
     #

--- a/lib/generators/administrate/install/USAGE
+++ b/lib/generators/administrate/install/USAGE
@@ -1,0 +1,13 @@
+Description:
+    Generates the application controller for the admin,
+
+Example:
+    1. rails generate administrate:install
+
+    This will create:
+        app/controllers/admin/application_controller.rb
+
+    2. rails generate administrate:install -m Backend
+
+    This will create:
+        app/controllers/backend/application_controller.rb

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -8,6 +8,11 @@ module Administrate
       include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :module, type: :string,
+                            default: 'Admin',
+                            desc: 'Indicates the module name',
+                            aliases: '-m'
+
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes")
@@ -16,9 +21,9 @@ module Administrate
       end
 
       def create_dashboard_controller
-        copy_file(
-          "application_controller.rb",
-          "app/controllers/admin/application_controller.rb"
+        template(
+          "application_controller.rb.erb",
+          "app/controllers/#{module_name.underscore}/application_controller.rb"
         )
       end
 
@@ -26,6 +31,10 @@ module Administrate
         singular_dashboard_resources.each do |resource|
           call_generator("administrate:dashboard", resource)
         end
+      end
+
+      def module_name
+        options['module']
       end
 
       private

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -9,9 +9,9 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       class_option :module, type: :string,
-                            default: 'Admin',
-                            desc: 'Indicates the module name',
-                            aliases: '-m'
+                            default: "Admin",
+                            desc: "Indicates the module name",
+                            aliases: "-m"
 
       def run_routes_generator
         if dashboard_resources.none?
@@ -23,7 +23,7 @@ module Administrate
       def create_dashboard_controller
         template(
           "application_controller.rb.erb",
-          "app/controllers/#{module_name.underscore}/application_controller.rb"
+          "app/controllers/#{module_name.underscore}/application_controller.rb",
         )
       end
 
@@ -34,7 +34,7 @@ module Administrate
       end
 
       def module_name
-        options['module']
+        options["module"]
       end
 
       private

--- a/lib/generators/administrate/install/templates/application_controller.rb.erb
+++ b/lib/generators/administrate/install/templates/application_controller.rb.erb
@@ -4,7 +4,7 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-module Admin
+module <%= module_name.classify %>
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -7,6 +7,11 @@ module Administrate
     class RoutesGenerator < Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :module, type: :string,
+                            default: 'Admin',
+                            desc: 'Indicates the module name',
+                            aliases: '-m'
+
       def insert_dashboard_routes
         if should_route_dashboard?
           route(dashboard_routes)
@@ -28,6 +33,10 @@ module Administrate
         unnamed_constants.each do |invalid_model|
           puts "NOTICE: Skipping dynamically generated model #{invalid_model}."
         end
+      end
+
+      def module_name
+        options['module']
       end
 
       private

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -8,9 +8,9 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       class_option :module, type: :string,
-                            default: 'Admin',
-                            desc: 'Indicates the module name',
-                            aliases: '-m'
+                            default: "Admin",
+                            desc: "Indicates the module name",
+                            aliases: "-m"
 
       def insert_dashboard_routes
         if should_route_dashboard?
@@ -36,7 +36,7 @@ module Administrate
       end
 
       def module_name
-        options['module']
+        options["module"]
       end
 
       private

--- a/lib/generators/administrate/routes/templates/routes.rb.erb
+++ b/lib/generators/administrate/routes/templates/routes.rb.erb
@@ -1,4 +1,4 @@
-namespace :admin do
+namespace :<%= module_name.underscore %> do
 <% dashboard_resources.each do |resource| %>    resources :<%= resource %>
 <%end%>
     root to: "<%= dashboard_resources.first %>#index"

--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -9,7 +9,7 @@ module Administrate
         def copy_template
           copy_file(
             "../../layouts/administrate/application.html.erb",
-            "app/views/layouts/admin/application.html.erb",
+            "app/views/layouts/#{module_name}/application.html.erb",
           )
 
           call_generator("administrate:views:navigation")

--- a/spec/example_app/config/database.yml
+++ b/spec/example_app/config/database.yml
@@ -5,6 +5,9 @@ development: &default
   min_messages: warning
   pool: 2
   timeout: 5000
+  host: 127.0.0.1
+  port: 5432
+  user: postgres
 
 test:
   <<: *default

--- a/spec/example_app/config/database.yml
+++ b/spec/example_app/config/database.yml
@@ -5,9 +5,6 @@ development: &default
   min_messages: warning
   pool: 2
   timeout: 5000
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
 
 test:
   <<: *default

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -458,9 +458,9 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     end
 
     it "accepts module name as options" do
-      controller = file("app/controllers/backend/customers_controller.rb")
+      controller = file("app/controllers/manage/customers_controller.rb")
 
-      run_generator ["customer", "--module", "Backend"]
+      run_generator ["customer", "--module", "Manage"]
 
       expect(controller).to exist
     end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -456,5 +456,13 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         Admin.send(:remove_const, :FoosController)
       end
     end
+
+    it "accepts module name as options" do
+      controller = file("app/controllers/backend/customers_controller.rb")
+
+      run_generator ["customer", "--module", "Backend"]
+
+      expect(controller).to exist
+    end
   end
 end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -18,6 +18,20 @@ describe Administrate::Generators::InstallGenerator, :generator do
           class ApplicationController < Administrate::ApplicationController
       RB
     end
+
+    it "accepts module name as options" do
+      stub_generator_dependencies
+      controller = file("app/controllers/backend/application_controller.rb")
+
+      run_generator ["--module", "backend"]
+
+      expect(controller).to exist
+      expect(controller).to have_correct_syntax
+      expect(controller).to contain <<-RB.strip_heredoc
+        module Backend
+          class ApplicationController < Administrate::ApplicationController
+      RB
+    end
   end
 
   describe "routes generator" do

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -21,14 +21,14 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
     it "accepts module name as options" do
       stub_generator_dependencies
-      controller = file("app/controllers/backend/application_controller.rb")
+      controller = file("app/controllers/manage/application_controller.rb")
 
-      run_generator ["--module", "backend"]
+      run_generator ["--module", "Manage"]
 
       expect(controller).to exist
       expect(controller).to have_correct_syntax
       expect(controller).to contain <<-RB.strip_heredoc
-        module Backend
+        module Manage
           class ApplicationController < Administrate::ApplicationController
       RB
     end

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -93,9 +93,9 @@ describe Administrate::Generators::RoutesGenerator, :generator do
     it "accepts module name as options" do
       routes = file("config/routes.rb")
 
-      run_generator ["--module", "Backend"]
+      run_generator ["--module", "Manage"]
 
-      expect(routes).to contain("namespace :backend")
+      expect(routes).to contain("namespace :manage")
     end
   end
 

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -89,6 +89,14 @@ describe Administrate::Generators::RoutesGenerator, :generator do
           "dashboard for AbstractModel")
       end
     end
+
+    it "accepts module name as options" do
+      routes = file("config/routes.rb")
+
+      run_generator ["--module", "Backend"]
+
+      expect(routes).to contain("namespace :backend")
+    end
   end
 
   it "creates a root route for the admin namespace" do

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -16,14 +16,15 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
-    it "copies the layout template into the `module/application` namespace when module option is specified" do
+    it "copies the layout template into the `module/application` namespace
+        when module option is specified" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = File.read(
         "app/views/layouts/administrate/application.html.erb",
       )
 
-      run_generator ["--module", "Backend"]
-      contents = File.read(file("app/views/layouts/backend/application.html.erb"))
+      run_generator ["--module", "Manage"]
+      contents = File.read(file("app/views/layouts/manage/application.html.erb"))
 
       expect(contents).to eq(expected_contents)
     end
@@ -39,12 +40,13 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
-    it "copies the flashes partial into the `module/application` namespace when module option is specified" do
+    it "copies the flashes partial into the `module/application` namespace
+        when module option is specified" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_flashes")
-      generated_file = file("app/views/backend/application/_flashes.html.erb")
+      generated_file = file("app/views/manage/application/_flashes.html.erb")
 
-      run_generator ["--module", "Backend"]
+      run_generator ["--module", "Manage"]
       contents = File.read(generated_file)
 
       expect(contents).to eq(expected_contents)
@@ -70,12 +72,13 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
-    it "copies the javascript partial into the `module/application` namespace when module is specified" do
+    it "copies the javascript partial into the `module/application` namespace
+        when module is specified" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_javascript")
-      generated_file = file("app/views/backend/application/_javascript.html.erb")
+      generated_file = file("app/views/manage/application/_javascript.html.erb")
 
-      run_generator ["--module", "Backend"]
+      run_generator ["--module", "Manage"]
       contents = File.read(generated_file)
 
       expect(contents).to eq(expected_contents)

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -24,7 +24,9 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       )
 
       run_generator ["--module", "Manage"]
-      contents = File.read(file("app/views/layouts/manage/application.html.erb"))
+      contents = File.read(
+        file("app/views/layouts/manage/application.html.erb"),
+      )
 
       expect(contents).to eq(expected_contents)
     end

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -16,12 +16,35 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
+    it "copies the layout template into the `module/application` namespace when module option is specified" do
+      allow(Rails::Generators).to receive(:invoke)
+      expected_contents = File.read(
+        "app/views/layouts/administrate/application.html.erb",
+      )
+
+      run_generator ["--module", "Backend"]
+      contents = File.read(file("app/views/layouts/backend/application.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
     it "copies the flashes partial into the `admin/application` namespace" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_flashes")
       generated_file = file("app/views/admin/application/_flashes.html.erb")
 
       run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the flashes partial into the `module/application` namespace when module option is specified" do
+      allow(Rails::Generators).to receive(:invoke)
+      expected_contents = contents_for_application_template("_flashes")
+      generated_file = file("app/views/backend/application/_flashes.html.erb")
+
+      run_generator ["--module", "Backend"]
       contents = File.read(generated_file)
 
       expect(contents).to eq(expected_contents)
@@ -42,6 +65,17 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       generated_file = file("app/views/admin/application/_javascript.html.erb")
 
       run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the javascript partial into the `module/application` namespace when module is specified" do
+      allow(Rails::Generators).to receive(:invoke)
+      expected_contents = contents_for_application_template("_javascript")
+      generated_file = file("app/views/backend/application/_javascript.html.erb")
+
+      run_generator ["--module", "Backend"]
       contents = File.read(generated_file)
 
       expect(contents).to eq(expected_contents)

--- a/spec/generators/views/navigation_generator_spec.rb
+++ b/spec/generators/views/navigation_generator_spec.rb
@@ -14,11 +14,12 @@ describe Administrate::Generators::Views::NavigationGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
-    it "copies the navigation partial into the `module/application` namespace when module options is specified" do
+    it "copies the navigation partial into the `module/application` namespace
+      when module options is specified" do
       expected_contents = contents_for_application_template("_navigation")
-      generated_file = file("app/views/backend/application/_navigation.html.erb")
+      generated_file = file("app/views/manage/application/_navigation.html.erb")
 
-      run_generator ["--module", "Backend"]
+      run_generator ["--module", "Manage"]
 
       contents = File.read(generated_file)
       expect(contents).to eq(expected_contents)

--- a/spec/generators/views/navigation_generator_spec.rb
+++ b/spec/generators/views/navigation_generator_spec.rb
@@ -13,5 +13,15 @@ describe Administrate::Generators::Views::NavigationGenerator, :generator do
       contents = File.read(generated_file)
       expect(contents).to eq(expected_contents)
     end
+
+    it "copies the navigation partial into the `module/application` namespace when module options is specified" do
+      expected_contents = contents_for_application_template("_navigation")
+      generated_file = file("app/views/backend/application/_navigation.html.erb")
+
+      run_generator ["--module", "Backend"]
+
+      contents = File.read(generated_file)
+      expect(contents).to eq(expected_contents)
+    end
   end
 end


### PR DESCRIPTION
add —module (-m) option for administrate generators that will create generated file under the specified module name. eg. rails g administrate:install -m Manage.

This will solve the problem if anyone already has a model named `Admin` in their application and wish to use a different module name other than the default `Admin` module of the Administrate.

We can now use the `--module` (`-m` as shorthand) and then specify the module name we wish to use in the generator command like below -
- `rails g administrate:install -m Manage`
- `rails g administrate:dashboard Foo -m Manage`
etc.

We can then see that the generated files are using the specified `Manage` module instead of the default `Admin` module namespacing.