### PR TITLE
Use `display_resource_name` helper in page header

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -7,16 +7,16 @@ module Administrate
       render locals: locals, partial: field.to_partial_path
     end
 
-    def display_resource_name(resource_name)
+    def display_resource_name(resource_name, plural = true)
+      opts = { default: resource_name.to_s.pluralize.titleize }
+      opts[:count] = PLURAL_MANY_COUNT if plural
+
       resource_name.
         to_s.
         classify.
         constantize.
         model_name.
-        human(
-          count: PLURAL_MANY_COUNT,
-          default: resource_name.to_s.pluralize.titleize,
-        )
+        human(opts)
     end
 
     def sort_order(order)

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -42,7 +42,7 @@ It renders the `_table` partial to display details about the resources.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.new")} #{page.resource_name.titleize.downcase}",
+      "#{t("administrate.actions.new")} #{display_resource_name(page.resource_name, false)}",
       [:new, namespace, page.resource_path],
       class: "button",
     ) if valid_action? :new %>

--- a/spec/example_app/config/locales/en.yml
+++ b/spec/example_app/config/locales/en.yml
@@ -17,3 +17,17 @@ en:
 
   titles:
     application: Administrate-prototype
+  activerecord:
+    models:
+      product:
+        one: "Product"
+        other: "Products"
+      line_item:
+        one: "Line Item"
+        other: "Line Items"
+      customer:
+        one: "Customer"
+        other: "Customers"
+      order:
+        one: "Order"
+        other: "Orders"

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -42,7 +42,7 @@ describe "customer index page" do
 
   it "links to the new page" do
     visit admin_customers_path
-    click_on("New customer")
+    click_on("New Customer")
 
     expect(current_path).to eq(new_admin_customer_path)
   end

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe "line item index page" do
 
   it "links to the new page" do
     visit admin_line_items_path
-    click_on("New line item")
+    click_on("New Line Item")
 
     expect(page).to have_header("New Line Item")
   end
 
   it "links back to line items" do
     visit admin_line_items_path
-    click_on("New line item")
+    click_on("New Line Item")
 
     click_on("Back")
 

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -40,7 +40,7 @@ feature "order index page" do
 
   scenario "user clicks through to the new page" do
     visit admin_orders_path
-    click_on("New order")
+    click_on("New Order")
 
     expect(current_path).to eq(new_admin_order_path)
   end

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "product index page" do
 
   it "links to the new page" do
     visit admin_products_path
-    click_on("New product")
+    click_on("New Product")
 
     expect(current_path).to eq(new_admin_product_path)
   end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Administrate::ApplicationHelper do
     end
 
     context "when translations are defined" do
-      it "uses the plural of the defined translation" do
+      it "uses the plural of the defined translation by default" do
         translations = {
           activerecord: {
             models: {
@@ -37,6 +37,25 @@ RSpec.describe Administrate::ApplicationHelper do
           displayed = display_resource_name(:customer)
 
           expect(displayed).to eq("Users")
+        end
+      end
+
+      it "uses the singular of the defined translation if specified" do
+        translations = {
+          activerecord: {
+            models: {
+              customer: {
+                one: "User",
+                other: "Users",
+              },
+            },
+          },
+        }
+
+        with_translations(:en, translations) do
+          displayed = display_resource_name(:customer, false)
+
+          expect(displayed).to eq("User")
         end
       end
     end


### PR DESCRIPTION
This is one of the steps to reuse i18n everywhere.