### PR TITLE
Feature/custom sorting via options

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -29,7 +29,7 @@ to display a collection of resources in an HTML table.
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
         <%= link_to(sanitized_order_params.merge(
-          collection_presenter.order_params_for(attr_name)
+          collection_presenter.order_params_for(attr_type.try(:options).try(:fetch, :order, attr_name) || attr_name)
         )) do %>
         <%= t(
           "helpers.label.#{resource_name}.#{attr_name}",

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -22,22 +22,26 @@ to display a collection of resources in an HTML table.
   <thead>
     <tr>
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <% custom_attr_name = attr_type.try(:options).try(:fetch, :order, attr_name) || attr_name %>
+
         <th class="cell-label
         cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        cell-label--<%= collection_presenter.ordered_html_class(custom_attr_name) %>"
         scope="col"
         role="columnheader"
-        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(custom_attr_name)) %>">
+
         <%= link_to(sanitized_order_params.merge(
-          collection_presenter.order_params_for(attr_type.try(:options).try(:fetch, :order, attr_name) || attr_name)
+          collection_presenter.order_params_for(custom_attr_name)
         )) do %>
+
         <%= t(
-          "helpers.label.#{resource_name}.#{attr_name}",
-          default: attr_name.to_s,
+          "helpers.label.#{resource_name}.#{custom_attr_name}",
+          default: custom_attr_name.to_s,
         ).titleize %>
 
-            <% if collection_presenter.ordered_by?(attr_name) %>
-              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+            <% if collection_presenter.ordered_by?(custom_attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(custom_attr_name) %>">
                 <svg aria-hidden="true">
                   <use xlink:href="#icon-up-caret" />
                 </svg>

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -7,7 +7,7 @@ module Administrate
 
     def apply(relation)
       if attribute.to_s.match?(/\./)
-        join_table, join_attribute = attribute.split('.')
+        join_table, join_attribute = attribute.split(".")
 
         relation.
           joins(join_table.to_sym).

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -6,7 +6,7 @@ module Administrate
     end
 
     def apply(relation)
-      if attribute.match?(/\./)
+      if attribute.to_s.match?(/\./)
         join_table, join_attribute = attribute.split('.')
 
         relation.

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -6,7 +6,21 @@ module Administrate
     end
 
     def apply(relation)
-      if relation.columns_hash.keys.include?(attribute.to_s)
+      if attribute.match?(/\./)
+        join_table, join_attribute = attribute.split('.')
+
+        relation.
+          joins(join_table.to_sym).
+          merge(
+            join_table.
+              camelize.
+              singularize.
+              constantize.
+              order(
+                join_attribute.to_sym => direction.to_sym,
+              ),
+          )
+      elsif relation.columns_hash.keys.include?(attribute.to_s)
         relation.order(attribute => direction)
       else
         relation


### PR DESCRIPTION
I'm sure this code could be cleaned up, and there are likely edge cases, but I wanted to get this out here to start a discussion as to whether or not people would find this useful? Here are my two use cases: 

1. I want to present one of the attributes differently so I create a new method on the model called, for example, `display_phone`, where I do some formatting of the sanitized stored phone number data. The problem is that once I do that, I can't sort by that field because the db only knows about `phone` not `display_phone`. With this change I can specify an `order: 'phone'` option to the `display_phone` field on the dashboard and allow that pretty displayed data to be sorted by its underlying db column. 

        phone: Field::String,
        display_phone: Field::String.with_options(
          searchable: false,
          order: 'phone',
        ),

1. I am displaying a list of Clinics that belong to an Organization and I would like to be able to sort the clinic list by this associated model's `name` field. By allowing `order: 'organization.name'` to be specified, we can detect that we're sorting across a join table with the presence of a `.` and join to that table and order by the specified attribute. One trick/bummer here is that with this implementation, we need to leave the plurality of the join table name to be specified by the user. So in this case with a Clinic#index view where a Clinic belongs to an Organization it'd be a singular `organization.name` specified.

        organization: Field::BelongsTo.with_options(
          order: 'organization.name',
        ),