### PR TITLE
Replace dashboard_class method with a delegate

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -123,7 +123,8 @@ module Administrate
         permit(dashboard.permitted_attributes)
     end
 
-    delegate :dashboard_class, :resource_class, :resource_name, :namespace, to: :resource_resolver
+    delegate :dashboard_class, :resource_class, :resource_name, :namespace,
+      to: :resource_resolver
     helper_method :namespace
     helper_method :resource_name
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -123,13 +123,9 @@ module Administrate
         permit(dashboard.permitted_attributes)
     end
 
-    delegate :resource_class, :resource_name, :namespace, to: :resource_resolver
+    delegate :dashboard_class, :resource_class, :resource_name, :namespace, to: :resource_resolver
     helper_method :namespace
     helper_method :resource_name
-
-    def dashboard_class
-      resource_resolver.dashboard_class
-    end
 
     def resource_resolver
       @_resource_resolver ||=


### PR DESCRIPTION
@nickcharlton as per #914–`dashboard_class` is a method on the `resource_resolver`, so we can delegate to that object instead of defining another method.