### PR TITLE
Accepts string instead of symbol on order

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -7,7 +7,7 @@ module Administrate
 
     def apply(relation)
       if relation.columns_hash.keys.include?(attribute.to_s)
-        relation.order(attribute => direction)
+        relation.order("#{attribute} #{direction}")
       else
         relation
       end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -36,7 +36,7 @@ describe Administrate::Order do
 
         ordered = order.apply(relation)
 
-        expect(relation).to have_received(:order).with(name: :asc)
+        expect(relation).to have_received(:order).with("name asc")
         expect(ordered).to eq(relation)
       end
 
@@ -47,7 +47,7 @@ describe Administrate::Order do
 
         ordered = order.apply(relation)
 
-        expect(relation).to have_received(:order).with(name: :desc)
+        expect(relation).to have_received(:order).with("name desc")
         expect(ordered).to eq(relation)
       end
     end


### PR DESCRIPTION
This makes custom ordering possible

E.g.

 Administrate::Order.new('quality', 'desc NULLS last')

Fixes #341 