### PR TITLE
Fix specs with Rails 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,10 +166,6 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.4.2)
-    rails-controller-testing (1.0.1)
-      actionpack (~> 5.x)
-      actionview (~> 5.x)
-      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -273,7 +269,6 @@ DEPENDENCIES
   poltergeist
   pry-rails
   rack-timeout
-  rails-controller-testing
   rails_stdout_logging
   redcarpet
   rspec-rails (~> 3.5.0)

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -31,7 +31,6 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -31,7 +31,6 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -31,7 +31,6 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -29,7 +29,6 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
-  gem "rails-controller-testing"
   gem "shoulda-matchers", "~> 2.8.0", require: false
   gem "timecop"
   gem "webmock"

--- a/spec/controllers/admin/blog/posts_controller_spec.rb
+++ b/spec/controllers/admin/blog/posts_controller_spec.rb
@@ -76,6 +76,8 @@ describe Admin::Blog::PostsController, type: :controller do
     end
 
     context "with invalid params" do
+      render_views
+
       it "passes a form page object to the view" do
         invalid_attributes = { title: "" }
 
@@ -93,7 +95,7 @@ describe Admin::Blog::PostsController, type: :controller do
 
         post :create, blog_post: invalid_attributes
 
-        expect(response).to render_template("new")
+        expect(page.find("h1")).to have_content "New Blog/Post"
       end
     end
   end
@@ -122,13 +124,15 @@ describe Admin::Blog::PostsController, type: :controller do
     end
 
     context "with invalid params" do
+      render_views
+
       it "re-renders the 'edit' template" do
         blog_post = create(:blog_post)
         invalid_attributes = { title: "" }
 
         put :update, id: blog_post.to_param, blog_post: invalid_attributes
 
-        expect(response).to render_template("edit")
+        expect(page.find("h1")).to have_content "Edit"
       end
 
       it "passes a form page object to the view" do
@@ -162,5 +166,11 @@ describe Admin::Blog::PostsController, type: :controller do
 
       expect(response).to redirect_to(admin_blog_posts_path)
     end
+  end
+
+  private
+
+  def page
+    Capybara::Node::Simple.new(response.body)
   end
 end


### PR DESCRIPTION
Via this [`rspec-rails` issue](https://github.com/rspec/rspec-rails/issues/1644), I discovered [this issue](https://github.com/rails/rails-controller-testing/issues/24) where `rails-controller-testing` is breaking URL helpers in view tests.

This was [fixed](https://github.com/rails/rails-controller-testing/commit/e56cee404a67a812514e95f92282632ada1912e9) in `rails-controller-testing` v1.0.2 but unfortunately we can't use this in the `rails42.gemfile` because the v1.0.2 version depends on ActionView / ActionPack at v5.x.

Removing the `rails-controller-testing` gem and rewriting the two affected specs which used `assert_render_template` fixed the failures on my machine.