### PR TITLE
(Rebased #414): Use ActiveModel::Naming.route_key in sidebar link_to

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -7,11 +7,12 @@ module Administrate
       render locals: locals, partial: field.to_partial_path
     end
 
+    def class_from_resource(resource_name)
+      resource_name.to_s.classify.constantize
+    end
+
     def display_resource_name(resource_name)
-      resource_name.
-        to_s.
-        classify.
-        constantize.
+      class_from_resource(resource_name).
         model_name.
         human(
           count: PLURAL_MANY_COUNT,
@@ -25,6 +26,10 @@ module Administrate
       when "desc" then "descending"
       else "none"
       end
+    end
+
+    def resource_index_route_key(resource_name)
+      ActiveModel::Naming.route_key(class_from_resource(resource_name))
     end
 
     def sanitized_order_params

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -11,7 +11,7 @@ as defined by the routes in the `admin/` namespace
   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
     <%= link_to(
       display_resource_name(resource),
-      [namespace, resource.path],
+      [namespace, resource_index_route_key(resource)],
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
     ) %>
   <% end %>

--- a/spec/example_app/app/controllers/admin/series_controller.rb
+++ b/spec/example_app/app/controllers/admin/series_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class SeriesController < Admin::ApplicationController
+  end
+end

--- a/spec/example_app/app/dashboards/series_dashboard.rb
+++ b/spec/example_app/app/dashboards/series_dashboard.rb
@@ -1,0 +1,16 @@
+require "administrate/base_dashboard"
+
+class SeriesDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i(id name).freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i(id name).freeze
+
+  FORM_ATTRIBUTES = [
+    :name,
+  ].freeze
+end

--- a/spec/example_app/app/models/series.rb
+++ b/spec/example_app/app/models/series.rb
@@ -1,0 +1,3 @@
+class Series < ActiveRecord::Base
+  validates :name, presence: true
+end

--- a/spec/example_app/config/initializers/inflections.rb
+++ b/spec/example_app/config/initializers/inflections.rb
@@ -3,12 +3,12 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
+ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+  inflect.uncountable %w(series)
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     resources :products
     resources :product_meta_tags
     resources :payments, only: [:index, :show]
+    resources :series
 
     namespace :blog do
       resources :posts

--- a/spec/example_app/db/migrate/20160117011028_create_series.rb
+++ b/spec/example_app/db/migrate/20160117011028_create_series.rb
@@ -1,0 +1,7 @@
+class CreateSeries < ActiveRecord::Migration[5.1]
+  def change
+    create_table :series do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -95,6 +95,10 @@ ActiveRecord::Schema.define(version: 20170508183744) do
     t.index ["slug"], name: "index_products_on_slug", unique: true
   end
 
+  create_table "series", force: :cascade do |t|
+    t.string "name", null: false
+  end
+
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"
   add_foreign_key "orders", "customers"

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -11,6 +11,7 @@ Order.destroy_all
 Customer.destroy_all
 Product.destroy_all
 ProductMetaTag.destroy_all
+Series.destroy_all
 
 100.times do
   name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
@@ -52,3 +53,5 @@ Customer.all.each do |customer|
     end
   end
 end
+
+Series.create(name: "An example")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,4 +52,8 @@ FactoryGirl.define do
     sequence(:title) { |n| "Post #{n}" }
     body "Empty"
   end
+
+  factory :series do
+    sequence(:name) { |n| "Series #{n}" }
+  end
 end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe Administrate::ApplicationHelper do
       end
     end
   end
+
+  describe "#resource_index_route_key" do
+    it "handles index routes when resource is uncountable" do
+      route_key = resource_index_route_key(:series)
+      expect(route_key).to eq("series_index")
+    end
+
+    it "handles normal inflection" do
+      route_key = resource_index_route_key(:customer)
+      expect(route_key).to eq("customers")
+    end
+  end
 end


### PR DESCRIPTION
This fixes the ActionController::UrlGenerationError thrown when the
sidebar partial tries to render index links on models which have an
uncountable inflection.

This is #414, but rebased against current changes.