### PR TITLE
Refactor: Extract Search::Query object

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -33,13 +33,13 @@ module Administrate
       if @term.blank?
         @scoped_resource.all
       else
-        @scoped_resource.where(query, *search_terms)
+        @scoped_resource.where(query_template, *query_values)
       end
     end
 
     private
 
-    def query
+    def query_template
       search_attributes.map do |attr|
         table_name = ActiveRecord::Base.connection.
           quote_table_name(@scoped_resource.table_name)
@@ -48,7 +48,7 @@ module Administrate
       end.join(" OR ")
     end
 
-    def search_terms
+    def query_values
       ["%#{term.mb_chars.downcase}%"] * search_attributes.count
     end
 

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -3,6 +3,26 @@ require "active_support/core_ext/object/blank"
 
 module Administrate
   class Search
+    class Query
+      delegate :blank?, to: :terms
+
+      def initialize(original_query)
+        @original_query = original_query
+      end
+
+      def original
+        @original_query
+      end
+
+      def terms
+        original.to_s
+      end
+
+      def to_s
+        original
+      end
+    end
+
     def initialize(scoped_resource, dashboard_class, term)
       @dashboard_class = dashboard_class
       @scoped_resource = scoped_resource

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -26,11 +26,11 @@ module Administrate
     def initialize(scoped_resource, dashboard_class, term)
       @dashboard_class = dashboard_class
       @scoped_resource = scoped_resource
-      @term = term
+      @query = Query.new(term)
     end
 
     def run
-      if @term.blank?
+      if query.blank?
         @scoped_resource.all
       else
         @scoped_resource.where(query_template, *query_values)
@@ -62,6 +62,10 @@ module Administrate
       @dashboard_class::ATTRIBUTE_TYPES
     end
 
-    attr_reader :resolver, :term
+    def term
+      query.terms
+    end
+
+    attr_reader :resolver, :query
   end
 end

--- a/spec/lib/administrate/search_query_spec.rb
+++ b/spec/lib/administrate/search_query_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+# require "support/constant_helpers"
+# require "administrate/field/string"
+# require "administrate/field/email"
+# require "administrate/field/number"
+require "administrate/search"
+
+describe Administrate::Search::Query do
+  let(:query) { "foo bar" }
+
+  it "returns the parsed search terms" do
+    query = described_class.new("foo bar")
+    expect(query.terms).to eq("foo bar")
+  end
+
+  it "treats nil as a blank string" do
+    query = described_class.new(nil)
+    expect(query.terms).to eq("")
+  end
+
+  it "returns the original query" do
+    query = described_class.new("original")
+    expect(query.original).to eq("original")
+  end
+
+  it "uses the original query to represent itself as a string" do
+    query = described_class.new("original")
+    expect(query.to_s).to eq("original")
+  end
+
+  it "returns true if blank" do
+    query = described_class.new("")
+    expect(query).to be_blank
+  end
+end

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "rails_helper"
 require "support/constant_helpers"
 require "administrate/field/string"
 require "administrate/field/email"


### PR DESCRIPTION
This is a step towards making it easier to integrate the solution built by @nando in #276.

Adding collection scopes/filters means we need to add more involved search query parsing; this pull request gives us a place for that, instead of cluttering the `Administrate::Search` class with string-parsing capabilities.

This pull request changes no public behaviours.