### PR TITLE
Sort has_many fields

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -101,7 +101,10 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(params[:order], params[:direction])
+      @order ||= Administrate::Order.new(
+        params.fetch(resource_name, {}).fetch(:order, nil),
+        params.fetch(resource_name, {}).fetch(:direction, nil),
+      )
     end
 
     def dashboard

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -33,11 +33,14 @@ module Administrate
     end
 
     def sanitized_order_params
-      params.permit(:search, :id, :order, :page, :per_page, :direction, :orders)
+      params.permit(:search, :id, :page, :per_page, :orders, {
+                      attr_name => [:order, :direction, :page, :per_page]
+                    })
     end
 
+
     def clear_search_params
-      params.except(:search, :page).permit(:order, :direction, :per_page)
+      params.except(:search, :page).permit(:per_page, { resource_name => [:order, :direction] })
     end
   end
 end

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -32,15 +32,15 @@ module Administrate
       ActiveModel::Naming.route_key(class_from_resource(resource_name))
     end
 
-    def sanitized_order_params
-      params.permit(:search, :id, :page, :per_page, :orders, {
-                      attr_name => [:order, :direction, :page, :per_page]
-                    })
+    def sanitized_order_params(attr_name)
+      params.permit(:search, :id, :page, :per_page,
+                    attr_name => %i[order direction page per_page])
     end
 
-
     def clear_search_params
-      params.except(:search, :page).permit(:per_page, { resource_name => [:order, :direction] })
+      params.except(:search, :page).permit(
+        :per_page, resource_name => %i[order direction]
+      )
     end
   end
 end

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -32,9 +32,12 @@ module Administrate
       ActiveModel::Naming.route_key(class_from_resource(resource_name))
     end
 
-    def sanitized_order_params(attr_name)
-      params.permit(:search, :id, :page, :per_page,
-                    attr_name => %i[order direction page per_page])
+    def sanitized_order_params(association_includes)
+      association_params = association_includes.map do |assoc_name|
+        { assoc_name => %i[order direction page per_page] }
+      end
+
+      params.permit(:search, :id, :page, :per_page, association_params)
     end
 
     def clear_search_params

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -32,11 +32,11 @@ module Administrate
       ActiveModel::Naming.route_key(class_from_resource(resource_name))
     end
 
-    def sanitized_order_params(association_includes)
-      association_params = association_includes.map do |assoc_name|
+    def sanitized_order_params(page, current_field_name)
+      collection_names = page.association_includes + [current_field_name]
+      association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end
-
       params.permit(:search, :id, :page, :per_page, association_params)
     end
 

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -28,14 +28,13 @@ to display a collection of resources in an HTML table.
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params.merge(
-          collection_presenter.order_params_for(attr_name)
+        <%= link_to(sanitized_order_params(collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
         <%= t(
           "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
           default: attr_name.to_s,
         ).titleize %>
-
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
                 <svg aria-hidden="true">

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -28,7 +28,7 @@ to display a collection of resources in an HTML table.
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(collection_field_name).merge(
+        <%= link_to(sanitized_order_params(association_includes + [collection_field_name]).merge(
           collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
         <%= t(

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -28,7 +28,7 @@ to display a collection of resources in an HTML table.
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(association_includes + [collection_field_name]).merge(
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
           collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
         <%= t(

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -56,6 +56,7 @@ It renders the `_table` partial to display details about the resources.
   <%= render(
     "collection",
     collection_presenter: page,
+    collection_field_name: resource_name,
     resources: resources,
     table_title: "page-title"
   ) %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -58,6 +58,7 @@ It renders the `_table` partial to display details about the resources.
     collection_presenter: page,
     collection_field_name: resource_name,
     resources: resources,
+	association_includes: page.association_includes,
     table_title: "page-title"
   ) %>
 

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -57,8 +57,8 @@ It renders the `_table` partial to display details about the resources.
     "collection",
     collection_presenter: page,
     collection_field_name: resource_name,
+    page: page,
     resources: resources,
-	association_includes: page.association_includes,
     table_title: "page-title"
   ) %>
 

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -43,7 +43,7 @@ as well as a link to its edit page.
       </dt>
 
       <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute %></dd>
+          ><%= render_field attribute, association_includes: page.association_includes %></dd>
     <% end %>
   </dl>
 </section>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -43,7 +43,7 @@ as well as a link to its edit page.
       </dt>
 
       <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute, association_includes: page.association_includes %></dd>
+          ><%= render_field attribute, page: page %></dd>
     <% end %>
   </dl>
 </section>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -20,17 +20,17 @@ from the associated resource class's dashboard.
 
 <% if field.resources.any? %>
   <% order = field.order_from_params(params.fetch(field.name, {})) %>
-  <% page = params.fetch(field.name, {}).fetch(:page, nil) %>
+  <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
   <%= render(
     "collection",
     collection_presenter: field.associated_collection(order),
     collection_field_name: field.name,
-    resources: field.resources(page, order),
+    page: page,
+    resources: field.resources(page_number, order),
     table_title: field.name,
-	association_includes: association_includes,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate field.resources(page), param_name: "#{field.name}[page]" %>
+    <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -26,7 +26,8 @@ from the associated resource class's dashboard.
     collection_presenter: field.associated_collection(order),
     collection_field_name: field.name,
     resources: field.resources(page, order),
-    table_title: field.name
+    table_title: field.name,
+	association_includes: association_includes,
   ) %>
   <% if field.more_than_limit? %>
     <%= paginate field.resources(page), param_name: "#{field.name}[page]" %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -22,12 +22,12 @@ from the associated resource class's dashboard.
   <%= render(
     "collection",
     collection_presenter: field.associated_collection,
-    resources: field.resources(params[field.name]),
+    resources: field.resources(params.fetch(field.name, {}).fetch(:page, nil))
     table_title: field.name
   ) %>
 
   <% if field.more_than_limit? %>
-    <%= paginate field.resources(params[field.name]), param_name: "#{field.name}" %>
+    <%= paginate field.resources(params.fetch(field.name, {}).fetch(:page, nil)), param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -25,7 +25,7 @@ from the associated resource class's dashboard.
     "collection",
     collection_presenter: field.associated_collection(order),
     collection_field_name: field.name,
-    resources: field.resources(page, order)
+    resources: field.resources(page, order),
     table_title: field.name
   ) %>
   <% if field.more_than_limit? %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -19,15 +19,17 @@ from the associated resource class's dashboard.
 %>
 
 <% if field.resources.any? %>
+  <% order = field.order_from_params(params.fetch(field.name, {})) %>
+  <% page = params.fetch(field.name, {}).fetch(:page, nil) %>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection,
-    resources: field.resources(params.fetch(field.name, {}).fetch(:page, nil))
+    collection_presenter: field.associated_collection(order),
+    collection_field_name: field.name,
+    resources: field.resources(page, order)
     table_title: field.name
   ) %>
-
   <% if field.more_than_limit? %>
-    <%= paginate field.resources(params.fetch(field.name, {}).fetch(:page, nil)), param_name: "#{field.name}[page]" %>
+    <%= paginate field.resources(page), param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -60,7 +60,7 @@ module Administrate
       end
 
       def order
-        @_order ||= Administrate::Order.new(sort_by, direction)
+        @order ||= Administrate::Order.new(sort_by, direction)
       end
 
       private

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -55,7 +55,7 @@ module Administrate
       def order_from_params(params)
         Administrate::Order.new(
           params.fetch(:order, sort_by),
-          params.fetch(:direction, direction)
+          params.fetch(:direction, direction),
         )
       end
 

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -11,8 +11,8 @@ module Administrate
         { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 
-      def associated_collection
-        Administrate::Page::Collection.new(associated_dashboard)
+      def associated_collection(order = self.order)
+        Administrate::Page::Collection.new(associated_dashboard, order: order)
       end
 
       def attribute_key
@@ -39,7 +39,7 @@ module Administrate
         self.class.permitted_attribute(attribute)
       end
 
-      def resources(page = 1)
+      def resources(page = 1, order = self.order)
         resources = order.apply(data).page(page).per(limit)
         includes.any? ? resources.includes(*includes) : resources
       end
@@ -49,7 +49,18 @@ module Administrate
       end
 
       def data
-        @data ||= associated_class.none 
+        @data ||= associated_class.none
+      end
+
+      def order_from_params(params)
+        Administrate::Order.new(
+          params.fetch(:order, sort_by),
+          params.fetch(:direction, direction)
+        )
+      end
+
+      def order
+        @_order ||= Administrate::Order.new(sort_by, direction)
       end
 
       private
@@ -69,10 +80,6 @@ module Administrate
 
       def display_candidate_resource(resource)
         associated_dashboard.display_resource(resource)
-      end
-
-      def order
-        @_order ||= Administrate::Order.new(sort_by, direction)
       end
 
       def sort_by

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -15,6 +15,10 @@ module Administrate
         @resource_path ||= resource_name.gsub("/", "_")
       end
 
+      def association_includes
+        dashboard.try(:association_includes) || []
+      end
+
       protected
 
       def attribute_field(dashboard, resource, attribute_name, page)

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -21,7 +21,11 @@ module Administrate
         ordered_by?(attr) && order.direction
       end
 
-      delegate :ordered_by?, :order_params_for, to: :order
+      delegate :ordered_by?, to: :order
+
+      def order_params_for(attr, key: resource_name)
+        { key => order.order_params_for(attr) }
+      end
 
       private
 

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -8,6 +8,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
+    log_entries: Field::HasMany.with_options(limit: 2, sort_by: :id),
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
     country: Field::BelongsTo.with_options(

--- a/spec/example_app/app/dashboards/log_entry_dashboard.rb
+++ b/spec/example_app/app/dashboards/log_entry_dashboard.rb
@@ -4,11 +4,12 @@ class LogEntryDashboard < Administrate::BaseDashboard
   ATTRIBUTES = %i(action logeable).freeze
 
   ATTRIBUTE_TYPES = {
+    id: Field::Number,
     action: Field::String,
     logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order]),
   }.freeze
 
-  COLLECTION_ATTRIBUTES = ATTRIBUTES
+  COLLECTION_ATTRIBUTES = [:id] + ATTRIBUTES
   FORM_ATTRIBUTES = ATTRIBUTES
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTES
 

--- a/spec/example_app/app/dashboards/product_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_dashboard.rb
@@ -13,7 +13,7 @@ class ProductDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     description: Field::Text,
-    image_url: Field::Image,
+    image_url: Field::String,
     name: Field::String,
     price: Field::Number.with_options(prefix: "$", decimals: 2),
     product_meta_tag: Field::HasOne,

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -49,11 +49,11 @@ feature "Search" do
   scenario "admin clears search" do
     query = "foo"
     mismatch = create(:customer, name: "someone")
-    visit admin_customers_path(search: query, order: :name)
+    visit admin_customers_path(search: query, customer: { order: :name })
 
     expect(page).not_to have_content(mismatch.email)
     clear_search
-    expect(page_params).to eq("order=name")
+    expect(page_params).to eq("customer[order]=name")
     expect(page).to have_content(mismatch.email)
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -77,7 +77,7 @@ feature "Search" do
   end
 
   def page_params
-    URI.parse(page.current_url).query
+    CGI.unescape(URI.parse(page.current_url).query)
   end
 
   def submit_search

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe "customer show page" do
       create(:line_item, order: order, unit_price: 10, quantity: index)
     end
 
-    visit admin_customer_path(customer, orders: { order: :id, direction: :desc })
+    visit admin_customer_path(customer, orders: {
+                                order: :id, direction: :desc
+                              })
 
     order_ids = orders.sort_by(&:id).map(&:id).reverse
 
@@ -75,7 +77,9 @@ RSpec.describe "customer show page" do
       expect(order_ids.first(2)).to eq(ids_in_table)
     end
 
-    visit admin_customer_path(customer, orders: { order: :id, direction: :desc, page: 2 })
+    visit admin_customer_path(customer, orders: {
+                                order: :id, direction: :desc, page: 2
+                              })
 
     within(".attribute-data--has-many table[aria-labelledby=orders]") do
       expect(order_ids.last(2)).to eq(ids_in_table)
@@ -91,10 +95,9 @@ RSpec.describe "customer show page" do
       create(:line_item, order: order, unit_price: 10, quantity: index)
     end
 
-    visit admin_customer_path(
-            customer,
-            orders: { order: :id, direction: :desc },
-          )
+    visit admin_customer_path(customer,
+                              orders: { order: :id, direction: :desc },
+                              log_entries: { order: :id, direction: :asc })
 
     order_ids = orders.sort_by(&:id).map(&:id).reverse
     log_entry_ids = log_entries.sort_by(&:id).map(&:id)
@@ -107,7 +110,9 @@ RSpec.describe "customer show page" do
       expect(log_entry_ids.first(2)).to eq(ids_in_table)
     end
 
-    visit admin_customer_path(customer, orders: { order: :id, direction: :desc, page: 2 })
+    visit admin_customer_path(customer, orders: {
+                                order: :id, direction: :desc, page: 2
+                              })
 
     within(".attribute-data--has-many table[aria-labelledby=orders]") do
       expect(order_ids.last(2)).to eq(ids_in_table)

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -95,9 +95,11 @@ RSpec.describe "customer show page" do
       create(:line_item, order: order, unit_price: 10, quantity: index)
     end
 
-    visit admin_customer_path(customer,
-                              orders: { order: :id, direction: :desc },
-                              log_entries: { order: :id, direction: :asc })
+    visit admin_customer_path(
+      customer,
+      orders: { order: :id, direction: :desc },
+      log_entries: { order: :id, direction: :asc },
+    )
 
     order_ids = orders.sort_by(&:id).map(&:id).reverse
     log_entry_ids = log_entries.sort_by(&:id).map(&:id)
@@ -110,9 +112,14 @@ RSpec.describe "customer show page" do
       expect(log_entry_ids.first(2)).to eq(ids_in_table)
     end
 
-    visit admin_customer_path(customer, orders: {
-                                order: :id, direction: :desc, page: 2
-                              })
+    visit admin_customer_path(
+      customer,
+      orders: {
+        order: :id,
+        direction: :desc,
+        page: 2,
+      },
+    )
 
     within(".attribute-data--has-many table[aria-labelledby=orders]") do
       expect(order_ids.last(2)).to eq(ids_in_table)

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "customer show page" do
 
       visit admin_customer_path(customer)
 
-      within(".attribute-data--has-many") do
+      within(".attribute-data--has-many table[aria-labelledby=orders]") do
         ids_in_page1 = ids_in_table
         expect(ids_in_page1.count).to eq 2
         expect(order_ids).to include(*ids_in_page1)
@@ -18,7 +18,7 @@ RSpec.describe "customer show page" do
 
       click_on("Next ›")
 
-      within(".attribute-data--has-many") do
+      within(".attribute-data--has-many table[aria-labelledby=orders]") do
         ids_in_page2 = ids_in_table
         expect(ids_in_page2.count).to eq 2
         expect(order_ids).to include(*ids_in_page2)
@@ -56,6 +56,65 @@ RSpec.describe "customer show page" do
 
     orders.each do |order|
       expect(page).to have_content(order.total_price)
+    end
+  end
+
+  it "sorts each of the customer's orders" do
+    customer = create(:customer)
+    orders = create_list(:order, 4, customer: customer)
+
+    orders.map.with_index(1) do |order, index|
+      create(:line_item, order: order, unit_price: 10, quantity: index)
+    end
+
+    visit admin_customer_path(customer, orders: { order: :id, direction: :desc })
+
+    order_ids = orders.sort_by(&:id).map(&:id).reverse
+
+    within(".attribute-data--has-many table[aria-labelledby=orders]") do
+      expect(order_ids.first(2)).to eq(ids_in_table)
+    end
+
+    visit admin_customer_path(customer, orders: { order: :id, direction: :desc, page: 2 })
+
+    within(".attribute-data--has-many table[aria-labelledby=orders]") do
+      expect(order_ids.last(2)).to eq(ids_in_table)
+    end
+  end
+
+  it "sorts each of the customer's orders and log entries independently" do
+    customer = create(:customer)
+    orders = create_list(:order, 4, customer: customer)
+    log_entries = create_list(:log_entry, 4, logeable: customer)
+
+    orders.map.with_index(1) do |order, index|
+      create(:line_item, order: order, unit_price: 10, quantity: index)
+    end
+
+    visit admin_customer_path(
+            customer,
+            orders: { order: :id, direction: :desc },
+          )
+
+    order_ids = orders.sort_by(&:id).map(&:id).reverse
+    log_entry_ids = log_entries.sort_by(&:id).map(&:id)
+
+    within(".attribute-data--has-many table[aria-labelledby=orders]") do
+      expect(order_ids.first(2)).to eq(ids_in_table)
+    end
+
+    within(".attribute-data--has-many table[aria-labelledby=log_entries]") do
+      expect(log_entry_ids.first(2)).to eq(ids_in_table)
+    end
+
+    visit admin_customer_path(customer, orders: { order: :id, direction: :desc, page: 2 })
+
+    within(".attribute-data--has-many table[aria-labelledby=orders]") do
+      expect(order_ids.last(2)).to eq(ids_in_table)
+    end
+
+    within(".attribute-data--has-many table[aria-labelledby=log_entries]") do
+      expect(log_entry_ids.first(2)).to eq(ids_in_table)
     end
   end
 


### PR DESCRIPTION
Hi!

I'm opening this pull request to disscuss how sorting `has_many` dashboard fields could be implemented. This is the implementation we are using but it could be done better.

I'm copying the text from the issue I opened with comments regarding improvements:

It is currently not possible to sort an HasMany field on the model's show view such as http://administrate-prototype.herokuapp.com/admin/customers/9085?direction=asc&order=address_state. There was a similar issue with its pagination which was fixed with release 0.5.0.

I have implemented it on a fork but I think it would require a bit more work. My implementation is based on the work done in PR #736

I suggest that we use a convention of #{attr_name}[param], for example orders[page] for the pagination and orders[direction] & orders[order] for sorting. But the issue is that there is currently no proper way to do this except by adding more arguments to the Page::Collection methods. Maybe a better solution would be to be able to propagate request parameters through Page#attribute_field overriding options for the field. It would be consistent with the HasMany field implementation and its pagination could be implemented that way too (having page as an option).

What are your thoughts about this? I am willing to push this (small) feature as it is a great quality of life improvement and follows the extensibility goals set by the project.