### PR TITLE
add namespace option to generators

### DIFF
--- a/lib/generators/administrate/dashboard/USAGE
+++ b/lib/generators/administrate/dashboard/USAGE
@@ -3,7 +3,7 @@ Description:
     pulling the attributes from database columns.
 
 Example:
-    rails generate administrate:dashboard FooBar
+    rails generate administrate:dashboard FooBar [--namespace admin]
 
     This will create:
         app/dashboards/foo_bar_dashboard.rb

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -24,6 +24,8 @@ module Administrate
       COLLECTION_ATTRIBUTE_LIMIT = 4
       READ_ONLY_ATTRIBUTES = %w[id created_at updated_at]
 
+      class_option :namespace, type: :string, default: "admin"
+
       source_root File.expand_path("../templates", __FILE__)
 
       def create_dashboard_definition
@@ -35,13 +37,17 @@ module Administrate
 
       def create_resource_controller
         destination = Rails.root.join(
-          "app/controllers/admin/#{file_name.pluralize}_controller.rb",
+          "app/controllers/#{namespace}/#{file_name.pluralize}_controller.rb",
         )
 
         template("controller.rb.erb", destination)
       end
 
       private
+
+      def namespace
+        options[:namespace]
+      end
 
       def attributes
         klass.reflections.keys + klass.attribute_names - redundant_attributes

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,5 +1,5 @@
-module Admin
-  class <%= class_name.pluralize %>Controller < Admin::ApplicationController
+module <%= namespace.classify %>
+  class <%= class_name.pluralize %>Controller < <%= namespace.classify %>::ApplicationController
     # To customize the behavior of this controller,
     # you can overwrite any of the RESTful actions. For example:
     #

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -8,34 +8,41 @@ module Administrate
       include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :namespace, type: :string, default: "admin"
+
       def run_routes_generator
         if dashboard_resources.none?
-          call_generator("administrate:routes")
+          call_generator("administrate:routes", "--namespace", namespace)
           load Rails.root.join("config/routes.rb")
         end
       end
 
       def create_dashboard_controller
-        copy_file(
-          "application_controller.rb",
-          "app/controllers/admin/application_controller.rb"
+        template(
+          "application_controller.rb.erb",
+          "app/controllers/#{namespace}/application_controller.rb",
         )
       end
 
       def run_dashboard_generators
         singular_dashboard_resources.each do |resource|
-          call_generator("administrate:dashboard", resource)
+          call_generator "administrate:dashboard", resource,
+            "--namespace", namespace
         end
       end
 
       private
+
+      def namespace
+        options[:namespace]
+      end
 
       def singular_dashboard_resources
         dashboard_resources.map(&:to_s).map(&:singularize)
       end
 
       def dashboard_resources
-        Administrate::Namespace.new(:admin).resources
+        Administrate::Namespace.new(namespace).resources
       end
     end
   end

--- a/lib/generators/administrate/install/templates/application_controller.rb.erb
+++ b/lib/generators/administrate/install/templates/application_controller.rb.erb
@@ -4,7 +4,7 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-module Admin
+module <%= namespace.classify %>
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -6,6 +6,7 @@ module Administrate
   module Generators
     class RoutesGenerator < Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
+      class_option :namespace, type: :string, default: "admin"
 
       def insert_dashboard_routes
         if should_route_dashboard?
@@ -31,6 +32,10 @@ module Administrate
       end
 
       private
+
+      def namespace
+        options[:namespace]
+      end
 
       def dashboard_resources
         valid_dashboard_models.map do |model|

--- a/lib/generators/administrate/routes/templates/routes.rb.erb
+++ b/lib/generators/administrate/routes/templates/routes.rb.erb
@@ -1,4 +1,4 @@
-namespace :admin do
+namespace :<%= namespace %> do
 <% dashboard_resources.each do |resource| %>    resources :<%= resource %>
 <%end%>
     root to: "<%= dashboard_resources.first %>#index"

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -441,7 +441,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       expect(controller).to have_correct_syntax
     end
 
-    it "subclasses Admin::ApplicationController" do
+    it "subclasses Admin::ApplicationController by default" do
       begin
         ActiveRecord::Schema.define { create_table :foos }
         class Foo < ActiveRecord::Base; end
@@ -454,6 +454,25 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       ensure
         remove_constants :Foo
         Admin.send(:remove_const, :FoosController)
+      end
+    end
+
+    it "uses the given namespace to create controllers" do
+      begin
+        ActiveRecord::Schema.define { create_table :foos }
+        class Foo < ActiveRecord::Base; end
+        module Manager
+          class ApplicationController < Administrate::ApplicationController; end
+        end
+
+        run_generator ["foo", "--namespace", "manager"]
+        load file("app/controllers/manager/foos_controller.rb")
+
+        expect(Manager::FoosController.ancestors).
+          to include(Manager::ApplicationController)
+      ensure
+        remove_constants :Foo
+        Manager.send(:remove_const, :FoosController)
       end
     end
   end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -4,7 +4,9 @@ require "support/generator_spec_helpers"
 require "support/constant_helpers"
 
 describe Administrate::Generators::InstallGenerator, :generator do
-  describe "admin/application_controller" do
+  after { reset_routes }
+
+  describe "application_controller" do
     it "is copied to the application" do
       stub_generator_dependencies
       controller = file("app/controllers/admin/application_controller.rb")
@@ -18,34 +20,70 @@ describe Administrate::Generators::InstallGenerator, :generator do
           class ApplicationController < Administrate::ApplicationController
       RB
     end
+
+    it "uses the namespace option" do
+      stub_generator_dependencies
+      controller = file("app/controllers/manager/application_controller.rb")
+
+      run_generator ["--namespace", "manager"]
+
+      expect(controller).to exist
+      expect(controller).to have_correct_syntax
+      expect(controller).to contain <<-RB.strip_heredoc
+        module Manager
+          class ApplicationController < Administrate::ApplicationController
+      RB
+    end
   end
 
   describe "routes generator" do
     it "invokes the routes generator if there are no namespace resources" do
-      begin
-        stub_generator_dependencies
-        Rails.application.routes.draw {}
+      stub_generator_dependencies
+      Rails.application.routes.draw {}
 
-        run_generator
+      run_generator
 
-        expect(Rails::Generators).to invoke_generator("administrate:routes")
-      ensure
-        reset_routes
-      end
+      expect(Rails::Generators).to invoke_generator(
+        "administrate:routes", ["--namespace", "admin"]
+      )
     end
 
     it "does not invoke routes generator if namespace routes already exist" do
-      begin
+      stub_generator_dependencies
+      Rails.application.routes.draw do
+        namespace(:admin) { resources :customers }
+      end
+
+      run_generator
+
+      expect(Rails::Generators).not_to invoke_generator(
+        "administrate:routes", ["--namespace", "admin"]
+      )
+    end
+
+    context "using the namespace option" do
+      it "invokes the routes generator if there are no namespace resources" do
+        stub_generator_dependencies
+        Rails.application.routes.draw {}
+
+        run_generator ["--namespace", "manager"]
+
+        expect(Rails::Generators).to invoke_generator(
+          "administrate:routes", ["--namespace", "manager"]
+        )
+      end
+
+      it "does not invoke routes generator if namespace routes already exist" do
         stub_generator_dependencies
         Rails.application.routes.draw do
-          namespace(:admin) { resources :customers }
+          namespace(:manager) { resources :customers }
         end
 
-        run_generator
+        run_generator ["--namespace", "manager"]
 
-        expect(Rails::Generators).not_to invoke_generator("administrate:routes")
-      ensure
-        reset_routes
+        expect(Rails::Generators).not_to invoke_generator(
+          "administrate:routes", ["--namespace", "manager"]
+        )
       end
     end
   end
@@ -58,7 +96,9 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
       %w[customer order product line_item].each do |resource|
         expect(Rails::Generators).
-          to invoke_generator("administrate:dashboard", [resource])
+          to invoke_generator(
+            "administrate:dashboard", [resource, "--namespace", "admin"]
+          )
       end
     end
   end

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -19,6 +19,14 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       end
     end
 
+    it "populates default dashboards under the given namespace" do
+      routes = file("config/routes.rb")
+
+      run_generator ["--namespace", "manager"]
+
+      expect(routes).to contain("namespace :manager")
+    end
+
     it "does not populate routes when no models exist" do
       routes = file("config/routes.rb")
       allow(ActiveRecord::Base).to receive(:descendants).and_return([])


### PR DESCRIPTION
fixes #754 

With this change, we'll be able to run the generators with the namespace option:

```
rails generate administrate:install --namespace manager
rails generate administrate:dashboard --namespace manager
```
