### PR TITLE
No dashboard generation when NameError #960

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -32,10 +32,12 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       def create_dashboard_definition
-        template(
-          "dashboard.rb.erb",
-          Rails.root.join("app/dashboards/#{file_name}_dashboard.rb"),
-        )
+        if klass
+          template(
+            "dashboard.rb.erb",
+            Rails.root.join("app/dashboards/#{file_name}_dashboard.rb"),
+          )
+        end
       end
 
       def create_resource_controller

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -18,6 +18,16 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       expect(dashboard).to have_correct_syntax
     end
 
+    it "should not create file with uninitialized model" do
+      dashboard = file("app/dashboards/customer_dashboard.rb")
+
+      expect do
+        run_generator ["invalid_model"]
+      end.to raise_error(NameError)
+
+      expect(dashboard).not_to exist
+    end
+
     describe "#attribute_types" do
       it "includes standard model attributes" do
         begin


### PR DESCRIPTION
When using the `rails g administrate:dashboard` generator with an
uninitialized model name, the method will raise a NameError but the
`app/dashboards/#{foo}_dashboard.rb` file will be created regardless.
This happens because the generator uses the built-in `file_name`
parameter to create the file name regardless of whether or not the rest
of the generator runs.

To solve this, we simply check whether or not `klass` is truthy before
actually generating the file because this is the same guard that we use for the
rest of the generator.

I did have a problem writing the test case for this. I expect the `run_generator` method to raise and expect the file to not exist. It's interesting because... it definitely does raise a `NameError` but it raises before the test expectations happen. Could use some direction there