### PR TITLE
Change const_get to constantize to fix undefined method `default_scoped'

### DIFF
--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -5,7 +5,7 @@ module Administrate
     end
 
     def dashboard_class
-      Object.const_get(resource_class_name + "Dashboard")
+      ActiveSupport::Inflector.constantize("#{resource_class_name}Dashboard")
     end
 
     def namespace
@@ -13,7 +13,7 @@ module Administrate
     end
 
     def resource_class
-      Object.const_get(resource_class_name)
+      ActiveSupport::Inflector.constantize(resource_class_name)
     end
 
     def resource_name


### PR DESCRIPTION
Found a strange problem when my namespace and model name are the same
(e.g. Order::Order)
config/routes
```
resources :order do
  resources :orders
end
```
When restart / modify source and the rails got reloaded, accessing /admin/order/orders and I get:
```
undefined method `default_scoped' for Order:Module
```
No problem if I get back to /admin and click the navigator link in the left.

And I found that in rails console
```
Object.const_get('Order::Order') 
=> Order
"Order::Order".constantize 
=> Order::Order
```
using constantize, I can get the correct model class name.

p.s. my model sources

app/models/order.rb
```
module Order
  def self.table_name_prefix
    'order_'
  end
end
```

app/models/order/order.rb
```
class Order::Order < ApplicationRecord
end
```