### PR TITLE
Fix interpolation highlighting at documentation examples

### DIFF
--- a/app/assets/stylesheets/docs.scss
+++ b/app/assets/stylesheets/docs.scss
@@ -80,6 +80,7 @@ code {
     padding-left: 1rem;
 
     .hljs-string { color: $code-green; }
+    .hljs-subst { color: $code-white; }
     .hljs-constant { color: $code-blue; }
     .hljs-symbol { color: $code-red; }
     .hljs-keyword { color: $code-yellow; }


### PR DESCRIPTION
Hi, thoughtbot's!

When I read [the documentation](http://administrate-prototype.herokuapp.com/adding_custom_field_types) of this gem I had face a bug of interpolation styles at code examples.

Returned string here use interpolation for digest hash.

<img width="706" alt="before" src="https://user-images.githubusercontent.com/3241812/30520847-359e2e74-9bbe-11e7-86c4-1f25aae8898f.png">

I have researched a process of parsing by highlight.js library and structure of default highlight.js styles to know that text color within interpolation class and main text of code block must be equal.

This PR fix this issue. It would be useful for another documentation blocks of code in a future that will use interpolation.

<img width="706" alt="after" src="https://user-images.githubusercontent.com/3241812/30520828-d56c79c0-9bbd-11e7-8618-00898fb5e7a2.png">
