### PR TITLE
Update name of specification example.

### DIFF
--- a/spec/administrate/page/base_spec.rb
+++ b/spec/administrate/page/base_spec.rb
@@ -10,7 +10,7 @@ describe Administrate::Page::Base do
       expect(dashboard_page.resource_name).to eq "order"
     end
 
-    it "returns a string for a namespaced resource path" do
+    it "returns a string for a resource path without namespace" do
       dashboard = OrderDashboard.new
       dashboard_page = Administrate::Page::Base.new(dashboard)
 


### PR DESCRIPTION
Hi, thoughtbot's!

Name of specifications example don't corresponds code inside it.

Probably is a "copy/paste" mistake because example with the same name is follow below but it in a right context ("when provided a namespaced dashboard").

Thanks,
Harry :)