### PR TITLE
Add support for editing polymorphic fields

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -120,7 +120,14 @@ module Administrate
 
     def resource_params
       params.require(resource_class.model_name.param_key).
-        permit(dashboard.permitted_attributes).transform_values {|v|  v.respond_to?(:starts_with?) && v.starts_with?("gid://") ? GlobalID::Locator.locate(v) : v }
+        permit(dashboard.permitted_attributes).
+        transform_values do |v|
+          if v.respond_to?(:starts_with?) && v.starts_with?("gid://")
+            GlobalID::Locator.locate(v)
+          else
+            v
+          end
+        end
     end
 
     delegate :dashboard_class, :resource_class, :resource_name, :namespace,

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -120,7 +120,7 @@ module Administrate
 
     def resource_params
       params.require(resource_class.model_name.param_key).
-        permit(dashboard.permitted_attributes)
+        permit(dashboard.permitted_attributes).transform_values {|v|  v.respond_to?(:starts_with?) && v.starts_with?("gid://") ? GlobalID::Locator.locate(v) : v }
     end
 
     delegate :dashboard_class, :resource_class, :resource_name, :namespace,

--- a/app/views/fields/polymorphic/_form.html.erb
+++ b/app/views/fields/polymorphic/_form.html.erb
@@ -23,5 +23,7 @@ so this partial renders a message to that effect.
 </div>
 
 <div class="field-unit__field">
-  <%= t("administrate.fields.polymorphic.not_supported") %>
+  <%= f.select(field.permitted_attribute) do %>
+    <%= grouped_options_for_select(field.associated_resource_grouped_options, field.selected_global_id, prompt: true) %>
+  <% end %>
 </div>

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -19,8 +19,6 @@ ar:
       has_many:
         more: إظهار %{count} من %{total_count}
         none: "لا يوجد"
-      polymorphic:
-        not_supported: "غير مدعمه \"Polymorphic\" هذه العلاقه"
       has_one:
         not_supported: "غير مدعمه \"HasOne\" هذه العلاقه"
     search:

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -19,8 +19,6 @@ da:
       has_many:
         more: "Viser %{count} af %{total_count}"
         none: Ingen
-      polymorphic:
-        not_supported: "Formularer med polymorphic relationships er ikke understøttede."
       has_one:
         not_supported: "Formularer med has_one associationer er ikke understøttede."
     search:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -19,8 +19,6 @@ de:
       has_many:
         more: "%{count} von %{total_count}"
         none: Keine
-      polymorphic:
-        not_supported: Polymorphe Beziehungen werden nicht unterstützt.
       has_one:
         not_supported: HasOne Beziehungen werden nicht unterstützt.
     search:

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -19,8 +19,6 @@ en:
       has_many:
         more: Showing %{count} of %{total_count}
         none: None
-      polymorphic:
-        not_supported: Polymorphic relationship forms are not supported.
       has_one:
         not_supported: HasOne relationship forms are not supported.
     search:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -19,8 +19,6 @@ es:
       has_many:
         more: Mostrando %{count} de %{total_count}
         none: Ninguno
-      polymorphic:
-        not_supported: Los formularios con relaciones polimórficas no están soportados.
       has_one:
         not_supported: Los formularios con relaciones HasOne no están soportados.
     search:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -19,8 +19,6 @@ fr:
       has_many:
         more: "%{count} sur %{total_count}"
         none: Aucun
-      polymorphic:
-        not_supported: Les relations polymorphiques dans les formulaires ne sont pas supportées.
       has_one:
         not_supported: Les relations HasOne dans les formulaires ne sont pas supportées.
     search:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -19,8 +19,6 @@ it:
       has_many:
         more: Visualizzo %{count} di %{total_count}
         none: Nessuno
-      polymorphic:
-        not_supported: Associazioni polimorfiche non ancora supportate. Spiacenti!
       has_one:
         not_supported: Associazioni HasOne non ancora supportate. Spiacenti!
     search:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -19,8 +19,6 @@ ja:
       has_many:
         more: "%{total_count} 件中 %{count} 件表示"
         none: データがありません
-      polymorphic:
-        not_supported: フォームでは「多：多」の関連をサポートしていません。
       has_one:
         not_supported: フォームでは「１：１」の関連をサポートしていません。
     search:

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -19,8 +19,6 @@ ko:
       has_many:
         more: "%{total_count} 개 중에서 %{count} 개"
         none: 없음
-      polymorphic:
-        not_supported: 상속 관계에 대한 양식은 제공되지 않습니다.
       has_one:
         not_supported: 일대일 관계에 대한 양식은 제공되지 않습니다.
     search:

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -19,8 +19,6 @@ nl:
       has_many:
         more: Resultaat %{count} van %{total_count}
         none: Geen
-      polymorphic:
-        not_supported: Polymorphische relaties formulieren worden niet ondersteund.
       has_one:
         not_supported: HasOne relaties formulieren worden niet ondersteund.
     search:

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -19,8 +19,6 @@ pl:
       has_many:
         more: Wyświetlanie %{count} z %{total_count}
         none: Brak
-      polymorphic:
-        not_supported: Relacje polimorficzne nie są obsługiwane.
       has_one:
         not_supported: Relacje jeden-do-jednego nie są obsługiwane.
     search:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -20,8 +20,6 @@ pt-BR:
       has_many:
         more: "Exibindo %{count} de %{total_count}"
         none: Nenhum
-      polymorphic:
-        not_supported: Relações polimórficas nos formulários não são suportadas.
       has_one:
         not_supported: Relações um para muitos nos formulários não são suportadas.
     search:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -20,8 +20,6 @@ pt:
       has_many:
         more: "Mostrando %{count} de %{total_count}"
         none: Nenhum
-      polymorphic:
-        not_supported: Relações polimórficas nos formulários não são suportadas.
       has_one:
         not_supported: Relações um para muitos nos formulários não são suportadas.
     search:

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -19,8 +19,6 @@ ru:
       has_many:
         more: "%{count} из %{total_count}"
         none: Нет
-      polymorphic:
-        not_supported: Полиморфные отношения в формах не поддерживаются.
       has_one:
         not_supported: HasOne отношения в формах не поддерживаются.
     search:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -19,8 +19,6 @@ sv:
       has_many:
         more: "%{count} av %{total_count}"
         none: Inga
-      polymorphic:
-        not_supported: Formulär med polymorfiska relationer stöds inte.
       has_one:
         not_supported: Formulär med HasOne relationer stöds inte.
     search:

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -19,8 +19,6 @@ uk:
       has_many:
         more: "%{count} із %{total_count}"
         none: Немає
-      polymorphic:
-        not_supported: Поліморфні відношення у формах не підтримуються.
       has_one:
         not_supported: HasOne відношення у формах не підтримуються.
     search:

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -19,8 +19,6 @@ vi:
       has_many:
         more: "%{count} trên %{total_count}"
         none: Không
-      polymorphic:
-        not_supported: Quan hệ Polymorphic chưa được hỗ trợ.
       has_one:
         not_supported: Quan hệ HasOne chưa được hỗ trợ.
     search:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -19,8 +19,6 @@ zh-CN:
       has_many:
         more: 显示所有 %{total_count} 中 %{count} 条
         none: 无
-      polymorphic:
-        not_supported: Polymorphic 关系暂不支持
       has_one:
         not_supported: HasOne 关系暂不支持.
     search:

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -19,8 +19,6 @@ zh-TW:
       has_many:
         more: 顯示 %{total_count} 筆中的 %{count} 筆資料
         none: 無
-      polymorphic:
-        not_supported: 表單尚未支援 Polymorphic 關聯。
       has_one:
         not_supported: 表單尚未支援 HasOne 關聯。
     search:

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -119,6 +119,11 @@ Or, to display a distance in kilometers:
   )
 ```
 
+**Field::Polymorphic**
+
+`:classes` - Specify a list of classes whose objects will be used to populate select boxes for editing this polymorphic field.
+Default is `[]`.
+
 **Field::Select**
 
 `:collection` - Specify the array or range to select from.  Defaults to `[]`.

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -5,7 +5,7 @@ module Administrate
     class Polymorphic < BelongsTo
       def associated_resource_grouped_options
         classes.map do |klass|
-          [klass.to_s, candidate_resources(klass).map do |resource|
+          [klass.to_s, candidate_resources_for(klass).map do |resource|
             [display_candidate_resource(resource), resource.to_global_id]
           end]
         end
@@ -39,7 +39,7 @@ module Administrate
         @_order ||= options.delete(:order)
       end
 
-      def candidate_resources(klass)
+      def candidate_resources_for(klass)
         order ? klass.order(order) : klass.all
       end
 

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -5,44 +5,44 @@ module Administrate
     class Polymorphic < BelongsTo
       def associated_resource_grouped_options
         classes.map do |klass|
-          [ klass.to_s, candidate_resources(klass).map do |resource|
+          [klass.to_s, candidate_resources(klass).map do |resource|
             [display_candidate_resource(resource), resource.to_global_id]
-          end ]
+          end]
         end
       end
-      
+
       def self.permitted_attribute(attr)
         attr
       end
-      
+
       def permitted_attribute
         attribute
       end
-      
+
       def selected_global_id
         data.respond_to?(:to_global_id) ? data.to_global_id : nil
       end
-      
+
       protected
 
-      def associated_dashboard(klass=data.class)
+      def associated_dashboard(klass = data.class)
         "#{klass.name}Dashboard".constantize.new
       end
-      
+
       def classes
         options.fetch(:classes) || []
       end
-      
+
       private
-      
+
       def order
         @_order ||= options.delete(:order)
       end
-      
+
       def candidate_resources(klass)
         order ? klass.order(order) : klass.all
       end
-      
+
       def display_candidate_resource(resource)
         associated_dashboard(resource.class).display_resource(resource)
       end

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -2,11 +2,49 @@ require_relative "associative"
 
 module Administrate
   module Field
-    class Polymorphic < Associative
+    class Polymorphic < BelongsTo
+      def associated_resource_grouped_options
+        classes.map do |klass|
+          [ klass.to_s, candidate_resources(klass).map do |resource|
+            [display_candidate_resource(resource), resource.to_global_id]
+          end ]
+        end
+      end
+      
+      def self.permitted_attribute(attr)
+        attr
+      end
+      
+      def permitted_attribute
+        attribute
+      end
+      
+      def selected_global_id
+        data.respond_to?(:to_global_id) ? data.to_global_id : nil
+      end
+      
       protected
 
-      def associated_dashboard
-        "#{data.class.name}Dashboard".constantize.new
+      def associated_dashboard(klass=data.class)
+        "#{klass.name}Dashboard".constantize.new
+      end
+      
+      def classes
+        options.fetch(:classes) || []
+      end
+      
+      private
+      
+      def order
+        @_order ||= options.delete(:order)
+      end
+      
+      def candidate_resources(klass)
+        order ? klass.order(order) : klass.all
+      end
+      
+      def display_candidate_resource(resource)
+        associated_dashboard(resource.class).display_resource(resource)
       end
     end
   end

--- a/spec/administrate/views/fields/polymorphic/_form_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_form_spec.rb
@@ -1,30 +1,23 @@
 require "rails_helper"
 
 describe "fields/polymorphic/_form", type: :view do
-  it "displays the field name" do
-    polymorphic = double(name: "Commentable")
+
+  it "displays the association name" do
+    polymorphic = double(name: "parent").as_null_object
 
     render(
       partial: "fields/polymorphic/form.html.erb",
-      locals: { field: polymorphic, f: form_builder },
+      locals: { field: polymorphic, f: fake_form_builder },
     )
 
-    expect(rendered.strip).to include("Commentable")
+    expect(rendered).to include("Parent")
   end
 
-  it "does not display a form" do
-    polymorphic = double(name: "Commentable")
-
-    render(
-      partial: "fields/polymorphic/form.html.erb",
-      locals: { field: polymorphic, f: form_builder },
-    )
-
-    expect(rendered).
-      to include(t("administrate.fields.polymorphic.not_supported"))
-  end
-
-  def form_builder
-    double("Form Builder", label: "Commentable")
+  def fake_form_builder
+    double("Form Builder").as_null_object.tap do |form_builder|
+      allow(form_builder).to receive(:label) do |*args|
+        args.first.to_s.titleize
+      end
+    end
   end
 end

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "administrate/field/belongs_to"
 require "administrate/field/polymorphic"
 
 describe "fields/polymorphic/_show", type: :view do

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -38,10 +38,10 @@ describe Administrate::Field::Polymorphic do
       end
     end
   end
-  
-  describe '#selected_global_id' do
+
+  describe "#selected_global_id" do
     it "returns the global ID of the data" do
-      item = double('SomeModel', to_global_id: "gid://myapp/SomeModel/1")
+      item = double("SomeModel", to_global_id: "gid://myapp/SomeModel/1")
       field = Administrate::Field::Polymorphic.new(:foo, item, :show)
       expect(field.selected_global_id).to eq(item.to_global_id)
     end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -1,3 +1,4 @@
+require "administrate/field/belongs_to"
 require "administrate/field/polymorphic"
 require "support/constant_helpers"
 require "support/field_matchers"
@@ -35,6 +36,18 @@ describe Administrate::Field::Polymorphic do
       ensure
         remove_constants :Thing, :ThingDashboard
       end
+    end
+  end
+  
+  describe '#selected_global_id' do
+    it "returns the global ID of the data" do
+      item = double('SomeModel', to_global_id: "gid://myapp/SomeModel/1")
+      field = Administrate::Field::Polymorphic.new(:foo, item, :show)
+      expect(field.selected_global_id).to eq(item.to_global_id)
+    end
+    it "returns nil for nil" do
+      field = Administrate::Field::Polymorphic.new(:foo, nil, :show)
+      expect(field.selected_global_id).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
This PR allows users to edit `Field::Polymorphic` fields (previously they were just told this was not possible).

The `<select>` is a grouped select, populated using the contents of zero-or-more model classes specified in the `:classes` option.

I appreciate I haven't really added much in the way of testing for this, but I think it's comparable with the amount of testing the other complex built-in types already have (e.g. `Field::HasMany`).

The one place in the core that's changed here and might be controversial, is that `#resource_params` now auto-converts anything that looks like a GlobalID. This is necessary for a polymorphic field without JavaScript as GlobalIDs are the only IDs that work across multiple models. Let me know if you need this implementing a different way.