### PR TITLE
Fix cell sort indicator positioning

### DIFF
--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -26,10 +26,9 @@
 }
 
 .cell-label__sort-indicator {
-  display: inline-block;
   overflow: hidden;
-  position: absolute;
-  right: 0;
+  float: right;
+  margin-left: 5px;
 
   svg {
     fill: $hint-grey;

--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -1,6 +1,4 @@
 .cell-label {
-  position: relative;
-
   &:hover {
     a {
       color: $action-color;
@@ -26,7 +24,6 @@
 }
 
 .cell-label__sort-indicator {
-  overflow: hidden;
   float: right;
   margin-left: 5px;
 


### PR DESCRIPTION
Happy Hacktoberfest!

To fix #864, we float the element instead of using absolute positioning with a slight margin for fields with long labels.

Please let me know if you need anything else. Cheers!