### PR TITLE
Find routes config

### DIFF
--- a/lib/administrate/generator_helpers.rb
+++ b/lib/administrate/generator_helpers.rb
@@ -4,10 +4,31 @@ module Administrate
       Rails::Generators.invoke(generator, args, generator_options)
     end
 
+    def find_routes_file
+      routes_file = Rails.root.join("config/routes.rb")
+      if File.exist?(routes_file)
+        routes_file = find_file("routes.rb")
+        raise "Unable to locate your routes.rb file" if routes_file.nil?
+      end
+      routes_file
+    end
+
     private
 
     def generator_options
       { behavior: behavior }
+    end
+
+    def find_file(file_name)
+      file = nil
+      Find.find(Rails.root) do |path|
+        Find.prune if path.include? ".git"
+
+        next unless path.include? file_name
+
+        file = path
+      end
+      file
     end
   end
 end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -13,7 +13,7 @@ module Administrate
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes", "--namespace", namespace)
-          load Rails.root.join("config/routes.rb")
+          load find_routes_file
         end
       end
 

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -5,11 +5,13 @@ else
 end
 
 require "rails/generators/base"
+require "administrate/generator_helpers"
 require "administrate/namespace"
 
 module Administrate
   module Generators
     class RoutesGenerator < Rails::Generators::Base
+      include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
       class_option :namespace, type: :string, default: "admin"
 
@@ -81,7 +83,7 @@ module Administrate
       end
 
       def rails_routes_file_path
-        Rails.root.join("config/routes.rb")
+        find_routes_file
       end
 
       def routes_file_path

--- a/spec/lib/administrate/generator_helpers_spec.rb
+++ b/spec/lib/administrate/generator_helpers_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Administrate::GeneratorHelpers do
+  include Administrate::GeneratorHelpers
+
+  describe "#find_routes_file" do
+    it "returns the typical path for a Rails routes file if found" do
+      typical_routes_path = "config/routes.rb"
+
+      returned_path = find_routes_file
+
+      expect(returned_path.to_s).to include(typical_routes_path)
+    end
+  end
+end


### PR DESCRIPTION
PR for issue #720 : Both the Install and Routes generators were looking for the project's routes.rb file in /config from the Rail's root path. Which the helper method I added will look for first, if it cannot find the routes.rb file there, then it will search through the project until it finds the path for that file.