### PR TITLE
Field generators

### DIFF
--- a/docs/customizing_attribute_partials.md
+++ b/docs/customizing_attribute_partials.md
@@ -29,6 +29,12 @@ This will generate three files:
 - `app/view/fields/number/_index.html.erb`
 - `app/view/fields/number/_show.html.erb`
 
+You can generate the partials for all field types by passing `all` to the generator.
+
+```bash
+rails generate administrate:views:field all
+```
+
 The generated templates will have documentation
 describing which variables are in scope.
 The rendering part of the partial will look like:

--- a/docs/customizing_attribute_partials.md
+++ b/docs/customizing_attribute_partials.md
@@ -1,7 +1,20 @@
 # Customizing attribute partials
 
 Occasionally you might want to change how specific types of attributes appear
-across all dashboards.
+across all dashboards. You can customize the following built in field types:
+
+- `belongs_to`
+- `boolean`
+- `date_time`
+- `email`
+- `has_many`
+- `has_one`
+- `number`
+- `polymporphic`
+- `select`
+- `string`
+- `text`
+
 For example, you might want all `Number` values to round to three decimal points.
 
 To get started, run the appropriate rails generator:

--- a/lib/generators/administrate/views/field_generator.rb
+++ b/lib/generators/administrate/views/field_generator.rb
@@ -16,8 +16,9 @@ module Administrate
         def copy_partials
           resource_path = args.first.try(:underscore)
 
-          if resource_path == 'all'
-            field_types = Dir.entries(self.class.template_source_path).reject{ |name| name[0] == "."}
+          if resource_path == "all"
+            entries = Dir.entries(self.class.template_source_path)
+            field_types = entries.reject { |name| name[0] == "." }
 
             field_types.each do |field_type|
               copy_field_partials(field_type)
@@ -43,7 +44,6 @@ module Administrate
             "app/views/fields/#{template_file}",
           )
         end
-
       end
     end
   end

--- a/lib/generators/administrate/views/field_generator.rb
+++ b/lib/generators/administrate/views/field_generator.rb
@@ -14,15 +14,28 @@ module Administrate
         source_root template_source_path
 
         def copy_partials
-          copy_field_partial(:index)
-          copy_field_partial(:show)
-          copy_field_partial(:form)
+          resource_path = args.first.try(:underscore)
+
+          if resource_path == 'all'
+            field_types = Dir.entries(self.class.template_source_path).reject{ |name| name[0] == "."}
+
+            field_types.each do |field_type|
+              copy_field_partials(field_type)
+            end
+          else
+            copy_field_partials(resource_path)
+          end
         end
 
         private
 
-        def copy_field_partial(partial_name)
-          resource_path = args.first.try(:underscore)
+        def copy_field_partials(resource_path)
+          copy_field_partial(resource_path, :index)
+          copy_field_partial(resource_path, :show)
+          copy_field_partial(resource_path, :form)
+        end
+
+        def copy_field_partial(resource_path, partial_name)
           template_file = "#{resource_path}/_#{partial_name}.html.erb"
 
           copy_file(
@@ -30,6 +43,7 @@ module Administrate
             "app/views/fields/#{template_file}",
           )
         end
+
       end
     end
   end

--- a/spec/generators/views/field_generator_spec.rb
+++ b/spec/generators/views/field_generator_spec.rb
@@ -3,9 +3,7 @@ require "generators/administrate/views/field_generator"
 require "support/generator_spec_helpers"
 
 describe Administrate::Generators::Views::FieldGenerator, :generator do
-
   context "for an existing field type" do
-
     describe "administrate:views:field field_name" do
       it "copies the `_show` partial into the app/views/fields directory" do
         expected_contents = contents_for_field_template(:string, :show)
@@ -36,15 +34,18 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
     end
 
     describe "administrate:views:field all" do
-
-      let(:field_types) { Dir.entries("app/views/fields").reject{ |name| name[0] == "."} }
+      let(:field_types) do
+        Dir.entries("app/views/fields").reject { |name| name[0] == "." }
+      end
 
       it "copies the `_show` partial for each field type" do
         run_generator ["all"]
 
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :show)
-          contents = File.read(file("app/views/fields/#{field_type}/_show.html.erb"))
+          contents = File.read(
+            file("app/views/fields/#{field_type}/_show.html.erb"),
+          )
 
           expect(contents).to eq(expected_contents)
         end
@@ -55,7 +56,9 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
 
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :form)
-          contents = File.read(file("app/views/fields/#{field_type}/_form.html.erb"))
+          contents = File.read(
+            file("app/views/fields/#{field_type}/_form.html.erb"),
+          )
 
           expect(contents).to eq(expected_contents)
         end
@@ -66,14 +69,14 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
 
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :index)
-          contents = File.read(file("app/views/fields/#{field_type}/_index.html.erb"))
+          contents = File.read(
+            file("app/views/fields/#{field_type}/_index.html.erb"),
+          )
 
           expect(contents).to eq(expected_contents)
         end
       end
-
     end
-
   end
 
   def contents_for_field_template(field_name, partial_name)

--- a/spec/generators/views/field_generator_spec.rb
+++ b/spec/generators/views/field_generator_spec.rb
@@ -1,9 +1,11 @@
-require "spec_helper"
+require "rails_helper"
 require "generators/administrate/views/field_generator"
 require "support/generator_spec_helpers"
 
 describe Administrate::Generators::Views::FieldGenerator, :generator do
+
   context "for an existing field type" do
+
     describe "administrate:views:field field_name" do
       it "copies the `_show` partial into the app/views/fields directory" do
         expected_contents = contents_for_field_template(:string, :show)
@@ -32,6 +34,46 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
         expect(contents).to eq(expected_contents)
       end
     end
+
+    describe "administrate:views:field all" do
+
+      let(:field_types) { Dir.entries("app/views/fields").reject{ |name| name[0] == "."} }
+
+      it "copies the `_show` partial for each field type" do
+        run_generator ["all"]
+
+        field_types.each do |field_type|
+          expected_contents = contents_for_field_template(field_type, :show)
+          contents = File.read(file("app/views/fields/#{field_type}/_show.html.erb"))
+
+          expect(contents).to eq(expected_contents)
+        end
+      end
+
+      it "copies the `_form` partial for each field type" do
+        run_generator ["all"]
+
+        field_types.each do |field_type|
+          expected_contents = contents_for_field_template(field_type, :form)
+          contents = File.read(file("app/views/fields/#{field_type}/_form.html.erb"))
+
+          expect(contents).to eq(expected_contents)
+        end
+      end
+
+      it "copies the `_index` partial for each field type" do
+        run_generator ["all"]
+
+        field_types.each do |field_type|
+          expected_contents = contents_for_field_template(field_type, :index)
+          contents = File.read(file("app/views/fields/#{field_type}/_index.html.erb"))
+
+          expect(contents).to eq(expected_contents)
+        end
+      end
+
+    end
+
   end
 
   def contents_for_field_template(field_name, partial_name)


### PR DESCRIPTION
This addresses https://github.com/thoughtbot/administrate/issues/486. Instead of copying the partials for all field types when no argument is given as suggested in the issue, I added support for passing "all" in place of the field name.