### PR TITLE
Fix overlapping icon

### DIFF
--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -29,7 +29,8 @@
   display: inline-block;
   overflow: hidden;
   position: absolute;
-  right: 0;
+  left: 90%;
+  top: 14px
 
   svg {
     fill: $hint-grey;


### PR DESCRIPTION
Fix for this issue https://github.com/thoughtbot/administrate/issues/864. I remove the right property and add left, top property in `.cell-label__sort-indicator` class