### PR TITLE
Render JavaScript in application layout head

### DIFF
--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -22,6 +22,7 @@ By default, it renders:
     <%= content_for(:title) %> - <%= Rails.application.class.parent_name.titlecase %>
   </title>
   <%= render "stylesheet" %>
+  <%= render "javascript" %>
   <%= csrf_meta_tags %>
 </head>
 <body>
@@ -36,6 +37,5 @@ By default, it renders:
     </main>
   </div>
 
-  <%= render "javascript" %>
 </body>
 </html>


### PR DESCRIPTION
https://github.com/thoughtbot/administrate/issues/539

ReferenceErrors were being thrown when trying to reference JavaScript
code before it was loaded.

*Move JavaScript partial view render to head