### PR TITLE
Order attributes by association if it exists

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -6,8 +6,8 @@ module Administrate
     end
 
     def apply(relation)
-      return order_by_association(relation) if
-        !reflect_association(relation).nil?
+      return order_by_association(relation) unless
+        reflect_association(relation).nil?
 
       return relation.reorder("#{attribute} #{direction}") if
         relation.columns_hash.keys.include?(attribute.to_s)

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -6,11 +6,13 @@ module Administrate
     end
 
     def apply(relation)
-      if relation.columns_hash.keys.include?(attribute.to_s)
-        relation.order("#{attribute} #{direction}")
-      else
-        relation
-      end
+      return order_by_association(relation) if
+        !reflect_association(relation).nil?
+
+      return relation.reorder("#{attribute} #{direction}") if
+        relation.columns_hash.keys.include?(attribute.to_s)
+
+      relation
     end
 
     def ordered_by?(attr)
@@ -40,6 +42,37 @@ module Administrate
 
     def opposite_direction
       direction.to_sym == :asc ? :desc : :asc
+    end
+
+    def order_by_association(relation)
+      return order_by_count(relation) if has_many_attribute?(relation)
+
+      return order_by_id(relation) if belongs_to_attribute?(relation)
+
+      relation
+    end
+
+    def order_by_count(relation)
+      relation.
+        left_joins(attribute.to_sym).
+        group(:id).
+        reorder("COUNT(#{attribute}.id) #{direction}")
+    end
+
+    def order_by_id(relation)
+      relation.reorder("#{attribute}_id #{direction}")
+    end
+
+    def has_many_attribute?(relation)
+      reflect_association(relation).macro == :has_many
+    end
+
+    def belongs_to_attribute?(relation)
+      reflect_association(relation).macro == :belongs_to
+    end
+
+    def reflect_association(relation)
+      relation.klass.reflect_on_association(attribute.to_s)
     end
   end
 end

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,78 +1,78 @@
 module Administrate
-  class Order
-    def initialize(attribute = nil, direction = nil)
-      @attribute = attribute
-      @direction = direction || :asc
-    end
+	class Order
+		def initialize(attribute = nil, direction = nil)
+			@attribute = attribute
+			@direction = direction || :asc
+		end
 
-    def apply(relation)
-      return order_by_association(relation) if
-        !reflect_association(relation).nil?
+		def apply(relation)
+			return order_by_association(relation) if
+			!reflect_association(relation).nil?
 
-      return relation.reorder("#{attribute} #{direction}") if
-        relation.columns_hash.keys.include?(attribute.to_s)
+			return relation.reorder("#{attribute} #{direction}") if
+			relation.columns_hash.keys.include?(attribute.to_s)
 
-      relation
-    end
+			relation
+		end
 
-    def ordered_by?(attr)
-      attr.to_s == attribute.to_s
-    end
+		def ordered_by?(attr)
+			attr.to_s == attribute.to_s
+		end
 
-    def order_params_for(attr)
-      {
-        order: attr,
-        direction: reversed_direction_param_for(attr)
-      }
-    end
+		def order_params_for(attr)
+			{
+				order: attr,
+				direction: reversed_direction_param_for(attr)
+			}
+		end
 
-    attr_reader :direction
+		attr_reader :direction
 
-    private
+		private
 
-    attr_reader :attribute
+		attr_reader :attribute
 
-    def reversed_direction_param_for(attr)
-      if ordered_by?(attr)
-        opposite_direction
-      else
-        :asc
-      end
-    end
+		def reversed_direction_param_for(attr)
+			if ordered_by?(attr)
+				opposite_direction
+			else
+				:asc
+			end
+		end
 
-    def opposite_direction
-      direction.to_sym == :asc ? :desc : :asc
-    end
+		def opposite_direction
+			direction.to_sym == :asc ? :desc : :asc
+		end
 
-    def order_by_association(relation)
-      return order_by_count(relation) if has_many_attribute?(relation)
+		def order_by_association(relation)
+			return order_by_count(relation) if has_many_attribute?(relation)
 
-      return order_by_id(relation) if belongs_to_attribute?(relation)
+			return order_by_id(relation) if belongs_to_attribute?(relation)
 
-      relation
-    end
+			relation
+		end
 
-    def order_by_count(relation)
-      relation.
-        left_joins(attribute.to_sym).
-        group(:id).
-        reorder("COUNT(#{attribute}.id) #{direction}")
-    end
+		def order_by_count(relation)
+			relation.
+				left_joins(attribute.to_sym).
+				group(:id).
+				reorder("COUNT(#{attribute}.id) #{direction}")
+		end
 
-    def order_by_id(relation)
-      relation.reorder("#{attribute}_id #{direction}")
-    end
+		def order_by_id(relation)
+			relation.reorder("#{attribute}_id #{direction}")
+		end
 
-    def has_many_attribute?(relation)
-      reflect_association(relation).macro == :has_many
-    end
+		def has_many_attribute?(relation)
+			reflect_association(relation).macro == :has_many
+		end
 
-    def belongs_to_attribute?(relation)
-      reflect_association(relation).macro == :belongs_to
-    end
+		def belongs_to_attribute?(relation)
+			reflect_association(relation).macro == :belongs_to
+		end
 
-    def reflect_association(relation)
-      relation.klass.reflect_on_association(attribute.to_s)
-    end
-  end
+		def reflect_association(relation)
+			relation.klass.reflect_on_association(attribute.to_s)
+		end
+	end
 end

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,78 +1,78 @@
 module Administrate
-	class Order
-		def initialize(attribute = nil, direction = nil)
-			@attribute = attribute
-			@direction = direction || :asc
-		end
+  class Order
+    def initialize(attribute = nil, direction = nil)
+      @attribute = attribute
+      @direction = direction || :asc
+    end
 
-		def apply(relation)
-			return order_by_association(relation) if
-			!reflect_association(relation).nil?
+    def apply(relation)
+      return order_by_association(relation) if
+        !reflect_association(relation).nil?
 
-			return relation.reorder("#{attribute} #{direction}") if
-			relation.columns_hash.keys.include?(attribute.to_s)
+      return relation.reorder("#{attribute} #{direction}") if
+        relation.columns_hash.keys.include?(attribute.to_s)
 
-			relation
-		end
+      relation
+    end
 
-		def ordered_by?(attr)
-			attr.to_s == attribute.to_s
-		end
+    def ordered_by?(attr)
+      attr.to_s == attribute.to_s
+    end
 
-		def order_params_for(attr)
-			{
-				order: attr,
-				direction: reversed_direction_param_for(attr)
-			}
-		end
+    def order_params_for(attr)
+      {
+        order: attr,
+        direction: reversed_direction_param_for(attr)
+      }
+    end
 
-		attr_reader :direction
+    attr_reader :direction
 
-		private
+    private
 
-		attr_reader :attribute
+    attr_reader :attribute
 
-		def reversed_direction_param_for(attr)
-			if ordered_by?(attr)
-				opposite_direction
-			else
-				:asc
-			end
-		end
+    def reversed_direction_param_for(attr)
+      if ordered_by?(attr)
+        opposite_direction
+      else
+        :asc
+      end
+    end
 
-		def opposite_direction
-			direction.to_sym == :asc ? :desc : :asc
-		end
+    def opposite_direction
+      direction.to_sym == :asc ? :desc : :asc
+    end
 
-		def order_by_association(relation)
-			return order_by_count(relation) if has_many_attribute?(relation)
+    def order_by_association(relation)
+      return order_by_count(relation) if has_many_attribute?(relation)
 
-			return order_by_id(relation) if belongs_to_attribute?(relation)
+      return order_by_id(relation) if belongs_to_attribute?(relation)
 
-			relation
-		end
+      relation
+    end
 
-		def order_by_count(relation)
-			relation.
-				left_joins(attribute.to_sym).
-				group(:id).
-				reorder("COUNT(#{attribute}.id) #{direction}")
-		end
+    def order_by_count(relation)
+      relation.
+      left_joins(attribute.to_sym).
+      group(:id).
+      reorder("COUNT(#{attribute}.id) #{direction}")
+    end
 
-		def order_by_id(relation)
-			relation.reorder("#{attribute}_id #{direction}")
-		end
+    def order_by_id(relation)
+      relation.reorder("#{attribute}_id #{direction}")
+    end
 
-		def has_many_attribute?(relation)
-			reflect_association(relation).macro == :has_many
-		end
+    def has_many_attribute?(relation)
+      reflect_association(relation).macro == :has_many
+    end
 
-		def belongs_to_attribute?(relation)
-			reflect_association(relation).macro == :belongs_to
-		end
+    def belongs_to_attribute?(relation)
+      reflect_association(relation).macro == :belongs_to
+    end
 
-		def reflect_association(relation)
-			relation.klass.reflect_on_association(attribute.to_s)
-		end
-	end
+    def reflect_association(relation)
+      relation.klass.reflect_on_association(attribute.to_s)
+    end
+  end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -17,16 +17,16 @@ describe Administrate::Order do
 
     context "when `order` argument isn't a valid column" do
       it "ignores the order" do
-       order = Administrate::Order.new(:foo)
-       relation = relation_with_column(:id)
-       allow(relation).to receive(:reorder).and_return(relation)
+        order = Administrate::Order.new(:foo)
+        relation = relation_with_column(:id)
+        allow(relation).to receive(:reorder).and_return(relation)
 
-       ordered = order.apply(relation)
+        ordered = order.apply(relation)
 
-       expect(relation).not_to have_received(:reorder)
-       expect(ordered).to eq(relation)
+        expect(relation).not_to have_received(:reorder)
+        expect(ordered).to eq(relation)
+      end
     end
-  end
 
     context "when `order` argument is valid" do
       it "orders by the column" do
@@ -69,7 +69,7 @@ describe Administrate::Order do
       end
     end
 
-    context" when relation has belongs_to association" do
+    context "when relation has belongs_to association" do
       it "orders by id" do
         order = Administrate::Order.new(:name)
         relation = relation_with_association(:belongs_to)
@@ -169,14 +169,14 @@ describe Administrate::Order do
 
   def relation_with_column(column)
     double(
-      klass: double(:reflect_on_association => nil),
-      columns_hash: { column.to_s => :column_info }
+      klass => double(:reflect_on_association => nil),
+      columns_hash: { column.to_s => :column_info },
     )
   end
 
   def relation_with_association(association)
     double(
-      klass: double(:reflect_on_association => double( :macro => association))
+      klass => double(:reflect_on_association => double(:macro => association)),
     )
   end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -1,143 +1,182 @@
 require "administrate/order"
 
 describe Administrate::Order do
-  describe "#apply" do
-    context "when `order` argument is nil" do
-      it "doesn't sort the resources" do
-        order = Administrate::Order.new(nil, :desc)
-        relation = relation_with_column(:id)
-        allow(relation).to receive(:order).and_return(relation)
+	describe "#apply" do
+		context "when `order` argument is nil" do
+			it "doesn't sort the resources" do
+				order = Administrate::Order.new(nil, :desc)
+				relation = relation_with_column(:id)
+				allow(relation).to receive(:reorder).and_return(relation)
 
-        ordered = order.apply(relation)
+				ordered = order.apply(relation)
 
-        expect(relation).not_to have_received(:order)
-        expect(ordered).to eq(relation)
-      end
-    end
+				expect(relation).not_to have_received(:reorder)
+				expect(ordered).to eq(relation)
+			end
+		end
 
-    context "when `order` argument isn't a valid column" do
-      it "ignores the order" do
-        order = Administrate::Order.new(:foo)
-        relation = relation_with_column(:id)
-        allow(relation).to receive(:order).and_return(relation)
+		context "when `order` argument isn't a valid column" do
+			it "ignores the order" do
+				order = Administrate::Order.new(:foo)
+				relation = relation_with_column(:id)
+				allow(relation).to receive(:reorder).and_return(relation)
 
-        ordered = order.apply(relation)
+				ordered = order.apply(relation)
 
-        expect(relation).not_to have_received(:order)
-        expect(ordered).to eq(relation)
-      end
-    end
+				expect(relation).not_to have_received(:reorder)
+				expect(ordered).to eq(relation)
+			end
+		end
 
-    context "when `order` argument is valid" do
-      it "orders by the column" do
-        order = Administrate::Order.new(:name, :asc)
-        relation = relation_with_column(:name)
-        allow(relation).to receive(:order).and_return(relation)
+		context "when `order` argument is valid" do
+			it "orders by the column" do
+				order = Administrate::Order.new(:name, :asc)
+				relation = relation_with_column(:name)
+				allow(relation).to receive(:reorder).and_return(relation)
 
-        ordered = order.apply(relation)
+				ordered = order.apply(relation)
 
-        expect(relation).to have_received(:order).with("name asc")
-        expect(ordered).to eq(relation)
-      end
+				expect(relation).to have_received(:reorder).with("name asc")
+				expect(ordered).to eq(relation)
+			end
 
-      it "honors the `direction` argument" do
-        order = Administrate::Order.new(:name, :desc)
-        relation = relation_with_column(:name)
-        allow(relation).to receive(:order).and_return(relation)
+			it "honors the `direction` argument" do
+				order = Administrate::Order.new(:name, :desc)
+				relation = relation_with_column(:name)
+				allow(relation).to receive(:reorder).and_return(relation)
 
-        ordered = order.apply(relation)
+				ordered = order.apply(relation)
 
-        expect(relation).to have_received(:order).with("name desc")
-        expect(ordered).to eq(relation)
-      end
-    end
-  end
+				expect(relation).to have_received(:reorder).with("name desc")
+				expect(ordered).to eq(relation)
+			end
+		end
 
-  describe "#ordered_by?" do
-    it "returns true if the order is by the given attribute" do
-      order = Administrate::Order.new(:name, :desc)
-
-      expect(order).to be_ordered_by("name")
-    end
-
-    it "returns false if the order is not by the given attribute" do
-      order = Administrate::Order.new(:email, :desc)
-
-      expect(order).not_to be_ordered_by(:name)
-    end
-
-    it "returns false if there is no order" do
-      order = Administrate::Order.new(nil, :desc)
-
-      expect(order).not_to be_ordered_by(:name)
-    end
-  end
-
-  describe "#order_params_for" do
-    context "when there is no order" do
-      it "returns the attribute" do
-        order = Administrate::Order.new(nil)
-
-        params = order.order_params_for(:name)
-
-        expect(params[:order]).to eq(:name)
-      end
-
-      it "does not sort descending" do
-        order = Administrate::Order.new(nil)
-
-        params = order.order_params_for(:name)
-
-        expect(params[:direction]).to eq(:asc)
-      end
-    end
-
-    context "when the order is by a different attribute" do
-      it "returns the attribute" do
-        order = Administrate::Order.new(:email)
-
-        params = order.order_params_for(:name)
-
-        expect(params[:order]).to eq(:name)
-      end
-
-      it "sorts ascending" do
-        order = Administrate::Order.new(:email)
-
-        params = order.order_params_for(:name)
-
-        expect(params[:direction]).to eq(:asc)
-      end
-    end
-
-    context "when the data is already ordered by the given attribute" do
-      it "returns the attribute" do
+    context "when relation has_many association" do
+      it "orders the column by count" do
         order = Administrate::Order.new(:name)
+        relation = relation_with_association(:has_many)
+        allow(relation).to receive(:reorder).and_return(relation)
+        allow(relation).to receive(:left_joins).and_return(relation)
+        allow(relation).to receive(:group).and_return(relation)
 
-        params = order.order_params_for(:name)
+        ordered = order.apply(relation)
 
-        expect(params[:order]).to eq(:name)
+        expect(relation).to have_received(:left_joins).with(:name)
+        expect(relation).to have_received(:group).with(:id)
+        expect(relation).to have_received(:reorder).with("COUNT(name.id) asc")
+        expect(ordered).to eq(relation)
       end
+    end
 
-      it "orders the data descending if it's not already" do
-        order = Administrate::Order.new("name")
+    context" when relation has belongs_to association" do
+      it "orders by id" do
+        order = Administrate::Order.new(:name)
+        relation = relation_with_association(:belongs_to)
+        allow(relation).to receive(:reorder).and_return(relation)
 
-        params = order.order_params_for(:name)
+        ordered = order.apply(relation)
 
-        expect(params[:direction]).to eq(:desc)
-      end
-
-      it "sets direction ascending if the data is already descending" do
-        order = Administrate::Order.new(:name, "desc")
-
-        params = order.order_params_for(:name)
-
-        expect(params[:direction]).to eq(:asc)
+        expect(relation).to have_received(:reorder).with("name_id asc")
+        expect(ordered).to eq(relation)
       end
     end
   end
 
-  def relation_with_column(column)
-    double(columns_hash: { column.to_s => :column_info })
+	describe "#ordered_by?" do
+		it "returns true if the order is by the given attribute" do
+			order = Administrate::Order.new(:name, :desc)
+
+			expect(order).to be_ordered_by("name")
+		end
+
+		it "returns false if the order is not by the given attribute" do
+			order = Administrate::Order.new(:email, :desc)
+
+			expect(order).not_to be_ordered_by(:name)
+		end
+
+		it "returns false if there is no order" do
+			order = Administrate::Order.new(nil, :desc)
+
+			expect(order).not_to be_ordered_by(:name)
+		end
+	end
+
+	describe "#order_params_for" do
+		context "when there is no order" do
+			it "returns the attribute" do
+				order = Administrate::Order.new(nil)
+
+				params = order.order_params_for(:name)
+
+				expect(params[:order]).to eq(:name)
+			end
+
+			it "does not sort descending" do
+				order = Administrate::Order.new(nil)
+
+				params = order.order_params_for(:name)
+
+				expect(params[:direction]).to eq(:asc)
+			end
+		end
+
+		context "when the order is by a different attribute" do
+			it "returns the attribute" do
+				order = Administrate::Order.new(:email)
+
+				params = order.order_params_for(:name)
+
+				expect(params[:order]).to eq(:name)
+			end
+
+			it "sorts ascending" do
+				order = Administrate::Order.new(:email)
+
+				params = order.order_params_for(:name)
+
+				expect(params[:direction]).to eq(:asc)
+			end
+		end
+
+		context "when the data is already ordered by the given attribute" do
+			it "returns the attribute" do
+				order = Administrate::Order.new(:name)
+
+				params = order.order_params_for(:name)
+
+				expect(params[:order]).to eq(:name)
+			end
+
+			it "orders the data descending if it's not already" do
+				order = Administrate::Order.new("name")
+
+				params = order.order_params_for(:name)
+
+				expect(params[:direction]).to eq(:desc)
+			end
+
+			it "sets direction ascending if the data is already descending" do
+				order = Administrate::Order.new(:name, "desc")
+
+				params = order.order_params_for(:name)
+
+				expect(params[:direction]).to eq(:asc)
+			end
+		end
+	end
+
+	def relation_with_column(column)
+		double(
+		  klass: double(:reflect_on_association => nil),
+		  columns_hash: { column.to_s => :column_info }
+		  )
+	end
+
+  def relation_with_association(association)
+    double(
+      klass: double(:reflect_on_association => double( :macro => association))
+      )
   end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -1,56 +1,56 @@
 require "administrate/order"
 
 describe Administrate::Order do
-	describe "#apply" do
-		context "when `order` argument is nil" do
-			it "doesn't sort the resources" do
-				order = Administrate::Order.new(nil, :desc)
-				relation = relation_with_column(:id)
-				allow(relation).to receive(:reorder).and_return(relation)
+  describe "#apply" do
+    context "when `order` argument is nil" do
+      it "doesn't sort the resources" do
+        order = Administrate::Order.new(nil, :desc)
+        relation = relation_with_column(:id)
+        allow(relation).to receive(:reorder).and_return(relation)
 
-				ordered = order.apply(relation)
+        ordered = order.apply(relation)
 
-				expect(relation).not_to have_received(:reorder)
-				expect(ordered).to eq(relation)
-			end
-		end
+        expect(relation).not_to have_received(:reorder)
+        expect(ordered).to eq(relation)
+      end
+    end
 
-		context "when `order` argument isn't a valid column" do
-			it "ignores the order" do
-				order = Administrate::Order.new(:foo)
-				relation = relation_with_column(:id)
-				allow(relation).to receive(:reorder).and_return(relation)
+    context "when `order` argument isn't a valid column" do
+      it "ignores the order" do
+       order = Administrate::Order.new(:foo)
+       relation = relation_with_column(:id)
+       allow(relation).to receive(:reorder).and_return(relation)
 
-				ordered = order.apply(relation)
+       ordered = order.apply(relation)
 
-				expect(relation).not_to have_received(:reorder)
-				expect(ordered).to eq(relation)
-			end
-		end
+       expect(relation).not_to have_received(:reorder)
+       expect(ordered).to eq(relation)
+    end
+  end
 
-		context "when `order` argument is valid" do
-			it "orders by the column" do
-				order = Administrate::Order.new(:name, :asc)
-				relation = relation_with_column(:name)
-				allow(relation).to receive(:reorder).and_return(relation)
+    context "when `order` argument is valid" do
+      it "orders by the column" do
+        order = Administrate::Order.new(:name, :asc)
+        relation = relation_with_column(:name)
+        allow(relation).to receive(:reorder).and_return(relation)
 
-				ordered = order.apply(relation)
+        ordered = order.apply(relation)
 
-				expect(relation).to have_received(:reorder).with("name asc")
-				expect(ordered).to eq(relation)
-			end
+        expect(relation).to have_received(:reorder).with("name asc")
+        expect(ordered).to eq(relation)
+      end
 
-			it "honors the `direction` argument" do
-				order = Administrate::Order.new(:name, :desc)
-				relation = relation_with_column(:name)
-				allow(relation).to receive(:reorder).and_return(relation)
+      it "honors the `direction` argument" do
+        order = Administrate::Order.new(:name, :desc)
+        relation = relation_with_column(:name)
+        allow(relation).to receive(:reorder).and_return(relation)
 
-				ordered = order.apply(relation)
+        ordered = order.apply(relation)
 
-				expect(relation).to have_received(:reorder).with("name desc")
-				expect(ordered).to eq(relation)
-			end
-		end
+        expect(relation).to have_received(:reorder).with("name desc")
+        expect(ordered).to eq(relation)
+      end
+    end
 
     context "when relation has_many association" do
       it "orders the column by count" do
@@ -83,100 +83,100 @@ describe Administrate::Order do
     end
   end
 
-	describe "#ordered_by?" do
-		it "returns true if the order is by the given attribute" do
-			order = Administrate::Order.new(:name, :desc)
+  describe "#ordered_by?" do
+    it "returns true if the order is by the given attribute" do
+      order = Administrate::Order.new(:name, :desc)
 
-			expect(order).to be_ordered_by("name")
-		end
+      expect(order).to be_ordered_by("name")
+    end
 
-		it "returns false if the order is not by the given attribute" do
-			order = Administrate::Order.new(:email, :desc)
+    it "returns false if the order is not by the given attribute" do
+      order = Administrate::Order.new(:email, :desc)
 
-			expect(order).not_to be_ordered_by(:name)
-		end
+      expect(order).not_to be_ordered_by(:name)
+    end
 
-		it "returns false if there is no order" do
-			order = Administrate::Order.new(nil, :desc)
+    it "returns false if there is no order" do
+      order = Administrate::Order.new(nil, :desc)
 
-			expect(order).not_to be_ordered_by(:name)
-		end
-	end
+      expect(order).not_to be_ordered_by(:name)
+    end
+  end
 
-	describe "#order_params_for" do
-		context "when there is no order" do
-			it "returns the attribute" do
-				order = Administrate::Order.new(nil)
+  describe "#order_params_for" do
+    context "when there is no order" do
+      it "returns the attribute" do
+        order = Administrate::Order.new(nil)
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:order]).to eq(:name)
-			end
+        expect(params[:order]).to eq(:name)
+      end
 
-			it "does not sort descending" do
-				order = Administrate::Order.new(nil)
+      it "does not sort descending" do
+        order = Administrate::Order.new(nil)
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:direction]).to eq(:asc)
-			end
-		end
+        expect(params[:direction]).to eq(:asc)
+      end
+    end
 
-		context "when the order is by a different attribute" do
-			it "returns the attribute" do
-				order = Administrate::Order.new(:email)
+    context "when the order is by a different attribute" do
+      it "returns the attribute" do
+        order = Administrate::Order.new(:email)
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:order]).to eq(:name)
-			end
+        expect(params[:order]).to eq(:name)
+      end
 
-			it "sorts ascending" do
-				order = Administrate::Order.new(:email)
+      it "sorts ascending" do
+        order = Administrate::Order.new(:email)
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:direction]).to eq(:asc)
-			end
-		end
+        expect(params[:direction]).to eq(:asc)
+      end
+    end
 
-		context "when the data is already ordered by the given attribute" do
-			it "returns the attribute" do
-				order = Administrate::Order.new(:name)
+    context "when the data is already ordered by the given attribute" do
+      it "returns the attribute" do
+        order = Administrate::Order.new(:name)
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:order]).to eq(:name)
-			end
+        expect(params[:order]).to eq(:name)
+      end
 
-			it "orders the data descending if it's not already" do
-				order = Administrate::Order.new("name")
+      it "orders the data descending if it's not already" do
+        order = Administrate::Order.new("name")
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:direction]).to eq(:desc)
-			end
+        expect(params[:direction]).to eq(:desc)
+      end
 
-			it "sets direction ascending if the data is already descending" do
-				order = Administrate::Order.new(:name, "desc")
+      it "sets direction ascending if the data is already descending" do
+        order = Administrate::Order.new(:name, "desc")
 
-				params = order.order_params_for(:name)
+        params = order.order_params_for(:name)
 
-				expect(params[:direction]).to eq(:asc)
-			end
-		end
-	end
+        expect(params[:direction]).to eq(:asc)
+      end
+    end
+  end
 
-	def relation_with_column(column)
-		double(
-		  klass: double(:reflect_on_association => nil),
-		  columns_hash: { column.to_s => :column_info }
-		  )
-	end
+  def relation_with_column(column)
+    double(
+      klass: double(:reflect_on_association => nil),
+      columns_hash: { column.to_s => :column_info }
+    )
+  end
 
   def relation_with_association(association)
     double(
       klass: double(:reflect_on_association => double( :macro => association))
-      )
+    )
   end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -169,14 +169,14 @@ describe Administrate::Order do
 
   def relation_with_column(column)
     double(
-      klass => double(:reflect_on_association => nil),
+      klass: double(reflect_on_association: nil),
       columns_hash: { column.to_s => :column_info },
     )
   end
 
   def relation_with_association(association)
     double(
-      klass => double(:reflect_on_association => double(:macro => association)),
+      klass: double(reflect_on_association: double(macro: association)),
     )
   end
 end


### PR DESCRIPTION
Adding an order clause to the relation for an associated attribute was having no effect on the dashboard's sorting. When the order is applied, the current relation will check if the attribute is an association and reorder by count on the attribute's id column or on the relation's {attribute}_id column following the Rails convention of naming FK columns. The relation order method was changed to reorder to override any default scoping that may exist for the relation.

https://github.com/thoughtbot/administrate/issues/471