### PR TITLE
Add test coverage to ApplicationHelper#sort_order

### DIFF
--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe Administrate::ApplicationHelper do
       expect(route_key).to eq("customers")
     end
   end
+
+  describe "#sort_order" do
+    it "sanitizes to ascending/descending/none" do
+      expect(sort_order("asc")).to eq("ascending")
+      expect(sort_order("desc")).to eq("descending")
+      expect(sort_order("for anything else")).to eq("none")
+    end
+  end
 end


### PR DESCRIPTION
This method was previously entirely uncovered by the test suite.
Deleting it would still have all the tests pass when `bundle exec rake && bunde exec appraisal rake`. I recognize this is minor and the demo app will fail pretty obvious when started manually, but I like my test suites thorough :)

Edit: Also, congrats on 1000 PRs 😋 