### PR TITLE
Improve german translation.

### DIFF
--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -15,7 +15,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.edit")} #{page.page_title}" } %>
+<% content_for(:title) { t("administrate.actions.edit_item", item: page.page_title) } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
@@ -24,7 +24,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.show")} #{page.page_title}",
+      t("administrate.actions.show", item: page.page_title),
       [namespace, page.resource],
       class: "button",
     ) if valid_action? :show %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -42,7 +42,7 @@ It renders the `_table` partial to display details about the resources.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.new")} #{page.resource_name.titleize.downcase}",
+      t("administrate.actions.new", resource: page.resource_name.titleize.downcase),
       [:new, namespace, page.resource_path],
       class: "button",
     ) if valid_action? :new %>

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -15,7 +15,7 @@ to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.new")} #{page.resource_name.titleize}" } %>
+<% content_for(:title) { t("administrate.actions.new", resource: page.resource_name.titleize) } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -16,7 +16,7 @@ as well as a link to its edit page.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.show")} #{page.page_title}" } %>
+<% content_for(:title) { t("administrate.actions.show", item: page.page_title) } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
@@ -25,7 +25,7 @@ as well as a link to its edit page.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.edit")} #{page.page_title}",
+      t("administrate.actions.edit_item", item: page.page_title),
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action? :edit %>

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -5,7 +5,8 @@ ar:
       confirm: "هل أنت متأكد ؟"
       destroy: "حذف"
       edit: "تعديل"
-      show: "إظهار"
+      edit_item: "تعديل %{item}"
+      show: "إظهار %{item}"
       new: "جديد  %{resource}"
       back: "الى الخلف"
     controller:

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -6,7 +6,7 @@ ar:
       destroy: "حذف"
       edit: "تعديل"
       show: "إظهار"
-      new: "جديد"
+      new: "جديد  %{resource}"
       back: "الى الخلف"
     controller:
       create:

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -4,7 +4,8 @@ bs:
       confirm: Jeste li sigurni?
       destroy: Izbrisati
       edit: Izmjena
-      show: Pregled
+      edit_item: Izmjena %{item}
+      show: Pregled %{item}
       new: Novi %{resource}
       back: Nazad
     controller:

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -5,7 +5,7 @@ bs:
       destroy: Izbrisati
       edit: Izmjena
       show: Pregled
-      new: Novi
+      new: Novi %{resource}
       back: Nazad
     controller:
       create:

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -5,7 +5,8 @@ da:
       confirm: Er du sikker?
       destroy: Slet
       edit: Rediger
-      show: Vis
+      edit_item: Rediger %{item}
+      show: Vis %{item}
       new: Ny %{resource}
       back: Tilbage
     controller:

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -6,7 +6,7 @@ da:
       destroy: Slet
       edit: Rediger
       show: Vis
-      new: Ny
+      new: Ny %{resource}
       back: Tilbage
     controller:
       create:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -5,7 +5,8 @@ de:
       confirm: Sind Sie sicher?
       destroy: Löschen
       edit: Editieren
-      show: Anzeigen
+      edit_item: "%{item} editieren"
+      show: "%{item} anzeigen"
       new: "%{resource} erstellen"
       back: Zurück
     controller:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -6,7 +6,7 @@ de:
       destroy: Löschen
       edit: Editieren
       show: Anzeigen
-      new: Neu
+      new: "%{resource} erstellen"
       back: Zurück
     controller:
       create:
@@ -24,5 +24,5 @@ de:
       has_one:
         not_supported: HasOne Beziehungen werden nicht unterstützt.
     search:
-      clear: Saubere Suche
-      label: Suche %{resource}
+      clear: Suche zurücksetzen
+      label: "%{resource} durchsuchen"

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -6,7 +6,7 @@ en:
       destroy: Destroy
       edit: Edit
       show: Show
-      new: New
+      new: New %{resource}
       back: Back
     controller:
       create:

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -5,7 +5,8 @@ en:
       confirm: Are you sure?
       destroy: Destroy
       edit: Edit
-      show: Show
+      edit_item: Edit %{item}
+      show: Show %{item}
       new: New %{resource}
       back: Back
     controller:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -5,7 +5,8 @@ es:
       confirm: ¿Estás seguro?
       destroy: Destruir
       edit: Editar
-      show: Mostrar
+      edit_item: Editar %{item}
+      show: Mostrar %{item}
       new: Nuevo %{resource}
       back: Volver
     controller:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -6,7 +6,7 @@ es:
       destroy: Destruir
       edit: Editar
       show: Mostrar
-      new: Nuevo
+      new: Nuevo %{resource}
       back: Volver
     controller:
       create:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -5,7 +5,8 @@ fr:
       confirm: Êtes-vous sûr ?
       destroy: Supprimer
       edit: Modifier
-      show: Détails
+      edit_item: Modifier %{item}
+      show: Détails %{item}
       new: Création %{resource}
       back: Précédent
     controller:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -6,7 +6,7 @@ fr:
       destroy: Supprimer
       edit: Modifier
       show: Détails
-      new: Création
+      new: Création %{resource}
       back: Précédent
     controller:
       create:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -5,7 +5,8 @@ it:
       confirm: Sei sicuro?
       destroy: Elimina
       edit: Modifica
-      show: Visualizza
+      edit_item: Modifica %{item}
+      show: Visualizza %{item}
       new: Nuovo %{resource}
       back: Indietro
     controller:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -6,7 +6,7 @@ it:
       destroy: Elimina
       edit: Modifica
       show: Visualizza
-      new: Nuovo
+      new: Nuovo %{resource}
       back: Indietro
     controller:
       create:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -5,7 +5,8 @@ ja:
       confirm: 本当によろしいですか？
       destroy: 削除
       edit: 編集
-      show: 参照
+      edit_item: 編集 %{item}
+      show: 参照 %{item}
       new: 新規 %{resource}
       back: 戻る
     controller:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -6,7 +6,7 @@ ja:
       destroy: 削除
       edit: 編集
       show: 参照
-      new: 新規
+      new: 新規 %{resource}
       back: 戻る
     controller:
       create:

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -5,7 +5,8 @@ ko:
       confirm: 괜찮습니까?
       destroy: 삭제
       edit: 편집
-      show: 보여주기
+      edit_item: 편집 %{item}
+      show: 보여주기 %{item}
       new: 새로운 %{resource}
       back: 뒤로
     controller:

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -6,7 +6,7 @@ ko:
       destroy: 삭제
       edit: 편집
       show: 보여주기
-      new: 새로운
+      new: 새로운 %{resource}
       back: 뒤로
     controller:
       create:

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -5,7 +5,8 @@ nl:
       confirm: Weet u het zeker?
       destroy: Verwijder
       edit: Bewerk
-      show: Toon
+      edit_item: Bewerk %{item}
+      show: Toon %{item}
       new: Nieuw %{resource}
       back: Terug
     controller:

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -6,7 +6,7 @@ nl:
       destroy: Verwijder
       edit: Bewerk
       show: Toon
-      new: Nieuw
+      new: Nieuw %{resource}
       back: Terug
     controller:
       create:

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -6,7 +6,7 @@ pl:
       destroy: Usuń
       edit: Edytuj
       show: Wyświetl
-      new: Nowy
+      new: Nowy %{resource}
       back: Wstecz
     controller:
       create:

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -5,7 +5,8 @@ pl:
       confirm: Czy jesteś pewien?
       destroy: Usuń
       edit: Edytuj
-      show: Wyświetl
+      edit_item: Edytuj %{item}
+      show: Wyświetl %{item}
       new: Nowy %{resource}
       back: Wstecz
     controller:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -7,7 +7,7 @@ pt-BR:
       destroy: Deletar
       edit: Editar
       show: Visualizar
-      new: Criar
+      new: Criar %{resource}
       back: Voltar
     controller:
       create:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -6,7 +6,8 @@ pt-BR:
       confirm: Você tem certeza?
       destroy: Deletar
       edit: Editar
-      show: Visualizar
+      edit_item: Editar %{item}
+      show: Visualizar %{item}
       new: Criar %{resource}
       back: Voltar
     controller:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -6,7 +6,8 @@ pt:
       confirm: Tem certeza?
       destroy: Remover
       edit: Editar
-      show: Visualizar
+      edit_item: Editar %{item}
+      show: Visualizar %{item}
       new: Novo %{resource}
       back: Voltar atrás
     controller:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -7,7 +7,7 @@ pt:
       destroy: Remover
       edit: Editar
       show: Visualizar
-      new: Novo
+      new: Novo %{resource}
       back: Voltar atrás
     controller:
       create:

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -6,7 +6,7 @@ ru:
       destroy: Удалить
       edit: Редактировать
       show: Показать
-      new: Новый
+      new: Новый %{resource}
       back: Вернуться назад
     controller:
       create:

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -5,7 +5,8 @@ ru:
       confirm: Вы уверены?
       destroy: Удалить
       edit: Редактировать
-      show: Показать
+      edit_item: Редактировать %{item}
+      show: Показать %{item}
       new: Новый %{resource}
       back: Вернуться назад
     controller:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -6,7 +6,7 @@ sv:
       destroy: Ta bort
       edit: Ändra
       show: Visa
-      new: Ny
+      new: Ny %{resource}
       back: Tillbaka
     controller:
       create:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -5,7 +5,8 @@ sv:
       confirm: Är du säker?
       destroy: Ta bort
       edit: Ändra
-      show: Visa
+      edit_item: Ändra %{item}
+      show: Visa %{item}
       new: Ny %{resource}
       back: Tillbaka
     controller:

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -5,7 +5,8 @@ uk:
       confirm: Ви впевнені?
       destroy: Видалити
       edit: Редагувати
-      show: Показати
+      edit_item: Редагувати %{item}
+      show: Показати %{item}
       new: Новий %{resource}
       back: Назад
     controller:

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -6,7 +6,7 @@ uk:
       destroy: Видалити
       edit: Редагувати
       show: Показати
-      new: Новий
+      new: Новий %{resource}
       back: Назад
     controller:
       create:

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -6,7 +6,7 @@ vi:
       destroy: Xóa
       edit: Sửa
       show: Xem
-      new: Mới
+      new: Mới %{resource}
       back: Trở lại
     controller:
       create:

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -5,7 +5,8 @@ vi:
       confirm: Bạn có chắc không?
       destroy: Xóa
       edit: Sửa
-      show: Xem
+      edit_item: Sửa %{item}
+      show: Xem %{item}
       new: Mới %{resource}
       back: Trở lại
     controller:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -6,7 +6,7 @@ zh-CN:
       destroy: 删除
       edit: 编辑
       show: 查看
-      new: 新建
+      new: 新建 %{resource}
       back: 返回
     controller:
       create:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -5,7 +5,8 @@ zh-CN:
       confirm: 确定?
       destroy: 删除
       edit: 编辑
-      show: 查看
+      edit_item: 编辑 %{item}
+      show: 查看 %{item}
       new: 新建 %{resource}
       back: 返回
     controller:

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -5,7 +5,8 @@ zh-TW:
       confirm: 確定？
       destroy: 刪除
       edit: 編輯
-      show: 檢視
+      edit_item: 編輯 %{item}
+      show: 檢視 %{item}
       new: 新增 %{resource}
       back: 返回
     controller:

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -6,7 +6,7 @@ zh-TW:
       destroy: 刪除
       edit: 編輯
       show: 檢視
-      new: 新增
+      new: 新增 %{resource}
       back: 返回
     controller:
       create:

--- a/spec/features/payments_show_spec.rb
+++ b/spec/features/payments_show_spec.rb
@@ -5,7 +5,8 @@ feature "payment show page" do
     payment = create(:payment)
 
     visit admin_payment_path(payment)
-    expect(page).not_to have_button t("administrate.actions.edit")
+    expect(page).not_to have_button t("administrate.actions.edit_item",
+                                      item: payment.id)
   end
 
   scenario "user cannot delete record" do


### PR DESCRIPTION
German translation of "Clear search", "Search Resource" and "New resource" did not make any sense.

In order to be able to improve the german translation of "New post",
the string contatenation of "new" + resource had to be moved into
the i18n string instead of being performed inside the template. This
will help other locales as well I assume. To keep the current
behaviour for all other locales, I appended "%{resource}".