### PR TITLE
Add and improve I18n for application templates

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -18,8 +18,11 @@ and renders all form fields for a resource's editable attributes.
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>
-        <%= pluralize(page.resource.errors.count, "error") %>
-        prohibited this <%= page.resource_name %> from being saved:
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
       </h2>
 
       <ul>

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -15,7 +15,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.edit")} #{page.page_title}" } %>
+<% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
@@ -24,7 +24,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.show")} #{page.page_title}",
+      t("administrate.actions.show_resource", name: page.page_title),
       [namespace, page.resource],
       class: "button",
     ) if valid_action? :show %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -42,7 +42,10 @@ It renders the `_table` partial to display details about the resources.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.new")} #{page.resource_name.titleize.downcase}",
+      t(
+        "administrate.actions.new_resource",
+        name: display_resource_name(page.resource_name).titleize.downcase
+      ),
       [:new, namespace, page.resource_path],
       class: "button",
     ) if valid_action? :new %>

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -15,7 +15,12 @@ to do the heavy lifting.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.new")} #{page.resource_name.titleize}" } %>
+<% content_for(:title) do %>
+  <%= t(
+    "administrate.actions.new_resource",
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -16,7 +16,7 @@ as well as a link to its edit page.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
 %>
 
-<% content_for(:title) { "#{t("administrate.actions.show")} #{page.page_title}" } %>
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
@@ -25,7 +25,7 @@ as well as a link to its edit page.
 
   <div>
     <%= link_to(
-      "#{t("administrate.actions.edit")} #{page.page_title}",
+      t("administrate.actions.edit_resource", name: page.page_title),
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action? :edit %>

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -5,8 +5,9 @@ ar:
       confirm: "هل أنت متأكد ؟"
       destroy: "حذف"
       edit: "تعديل"
-      show: "إظهار"
-      new: "جديد"
+      edit_resource: "تعديل %{name}"
+      show_resource: "إظهار %{name}"
+      new_resource: "جديد  %{resource}"
       back: "الى الخلف"
     controller:
       create:

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -24,6 +24,9 @@ ar:
         not_supported: "غير مدعمه \"Polymorphic\" هذه العلاقه"
       has_one:
         not_supported: "غير مدعمه \"HasOne\" هذه العلاقه"
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: مسح البحث
       label: بحث %{resource}

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -4,8 +4,9 @@ bs:
       confirm: Jeste li sigurni?
       destroy: Izbrisati
       edit: Izmjena
-      show: Pregled
-      new: Novi
+      edit_resource: Izmjena %{name}
+      show_resource: Pregled %{name}
+      new_resource: Novi %{resource}
       back: Nazad
     controller:
       create:

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -23,6 +23,9 @@ bs:
         not_supported: Polimorfne asocijacije još nisu podržane. Žao nam je!
       has_one:
         not_supported: Asocijacije HasOne još nije podržana. Žao nam je!
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Izbriši pretraživanje
       label: Pretraga %{resource}

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -24,6 +24,9 @@ da:
         not_supported: "Formularer med polymorphic relationships er ikke understøttede."
       has_one:
         not_supported: "Formularer med has_one associationer er ikke understøttede."
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Ryd søgning
       label: Søg %{resource}

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -5,8 +5,9 @@ da:
       confirm: Er du sikker?
       destroy: Slet
       edit: Rediger
-      show: Vis
-      new: Ny
+      edit_resource: Rediger %{name}
+      show_resource: Vis %{name}
+      new_resource: Ny %{resource}
       back: Tilbage
     controller:
       create:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -24,6 +24,9 @@ de:
         not_supported: Polymorphe Beziehungen werden nicht unterstützt.
       has_one:
         not_supported: HasOne Beziehungen werden nicht unterstützt.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Saubere Suche
       label: Suche %{resource}

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -5,8 +5,9 @@ de:
       confirm: Sind Sie sicher?
       destroy: Löschen
       edit: Editieren
-      show: Anzeigen
-      new: Neu
+      edit_resource: "%{name} editieren"
+      show_resource: "%{name} anzeigen"
+      new_resource: "%{resource} erstellen"
       back: Zurück
     controller:
       create:

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -5,8 +5,9 @@ en:
       confirm: Are you sure?
       destroy: Destroy
       edit: Edit
-      show: Show
-      new: New
+      edit_resource: Edit %{name}
+      show_resource: Show %{name}
+      new_resource: New %{name}
       back: Back
     controller:
       create:
@@ -23,6 +24,9 @@ en:
         not_supported: Polymorphic relationship forms are not supported.
       has_one:
         not_supported: HasOne relationship forms are not supported.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Clear search
       label: Search %{resource}

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -5,8 +5,9 @@ es:
       confirm: ¿Estás seguro?
       destroy: Destruir
       edit: Editar
-      show: Mostrar
-      new: Nuevo
+      edit_resource: Editar %{name}
+      show_resource: Mostrar %{name}
+      new_resource: Nuevo %{resource}
       back: Volver
     controller:
       create:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -24,6 +24,9 @@ es:
         not_supported: Los formularios con relaciones polimórficas no están soportados.
       has_one:
         not_supported: Los formularios con relaciones HasOne no están soportados.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Borrar búsqueda
       label: Buscar %{resource}

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -5,8 +5,9 @@ fr:
       confirm: Êtes-vous sûr ?
       destroy: Supprimer
       edit: Modifier
-      show: Détails
-      new: Création
+      edit_resource: Modifier %{name}
+      show_resource: Détails %{name}
+      new_resource: Création %{resource}
       back: Précédent
     controller:
       create:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -24,6 +24,9 @@ fr:
         not_supported: Les relations polymorphiques dans les formulaires ne sont pas supportées.
       has_one:
         not_supported: Les relations HasOne dans les formulaires ne sont pas supportées.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Effacer la recherche
       label: Chercher %{resource}

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -5,8 +5,9 @@ it:
       confirm: Sei sicuro?
       destroy: Elimina
       edit: Modifica
-      show: Visualizza
-      new: Nuovo
+      edit_resource: Modifica %{name}
+      show_resource: Visualizza %{name}
+      new_resource: Nuovo %{resource}
       back: Indietro
     controller:
       create:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -24,6 +24,9 @@ it:
         not_supported: Associazioni polimorfiche non ancora supportate. Spiacenti!
       has_one:
         not_supported: Associazioni HasOne non ancora supportate. Spiacenti!
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Cancella ricerca
       label: Ricerca %{resource}

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -5,8 +5,9 @@ ja:
       confirm: 本当によろしいですか？
       destroy: 削除
       edit: 編集
-      show: 参照
-      new: 新規
+      edit_resource: 編集 %{name}
+      show_resource: 参照 %{name}
+      new_resource: 新規 %{resource}
       back: 戻る
     controller:
       create:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -24,6 +24,9 @@ ja:
         not_supported: フォームでは「多：多」の関連をサポートしていません。
       has_one:
         not_supported: フォームでは「１：１」の関連をサポートしていません。
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: 検索をクリアする
       label: サーチ %{resource}

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -24,6 +24,9 @@ ko:
         not_supported: 상속 관계에 대한 양식은 제공되지 않습니다.
       has_one:
         not_supported: 일대일 관계에 대한 양식은 제공되지 않습니다.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: 검색 초기화
       label: "%{resource} 검색"

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -5,8 +5,9 @@ ko:
       confirm: 괜찮습니까?
       destroy: 삭제
       edit: 편집
-      show: 보여주기
-      new: 새로운
+      edit_resource: 편집 %{name}
+      show_resource: 보여주기 %{name}
+      new_resource: 새로운 %{resource}
       back: 뒤로
     controller:
       create:

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -24,6 +24,9 @@ nl:
         not_supported: Polymorphische relaties formulieren worden niet ondersteund.
       has_one:
         not_supported: HasOne relaties formulieren worden niet ondersteund.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: CDuidelijke zoek
       label: Zoeken %{resource}

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -5,8 +5,9 @@ nl:
       confirm: Weet u het zeker?
       destroy: Verwijder
       edit: Bewerk
-      show: Toon
-      new: Nieuw
+      edit_resource: Bewerk %{name}
+      show_resource: Toon %{name}
+      new_resource: Nieuw %{resource}
       back: Terug
     controller:
       create:

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -24,6 +24,9 @@ pl:
         not_supported: Relacje polimorficzne nie są obsługiwane.
       has_one:
         not_supported: Relacje jeden-do-jednego nie są obsługiwane.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Wyczyść wyszukiwanie
       label: Szukanie %{resource}

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -5,8 +5,9 @@ pl:
       confirm: Czy jesteś pewien?
       destroy: Usuń
       edit: Edytuj
-      show: Wyświetl
-      new: Nowy
+      edit_resource: Edytuj %{name}
+      show_resource: Wyświetl %{name}
+      new_resource: Nowy %{resource}
       back: Wstecz
     controller:
       create:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -6,8 +6,9 @@ pt-BR:
       confirm: Você tem certeza?
       destroy: Deletar
       edit: Editar
-      show: Visualizar
-      new: Criar
+      edit_resource: Editar %{name}
+      show_resource: Visualizar %{name}
+      new_resource: Criar %{resource}
       back: Voltar
     controller:
       create:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -25,6 +25,9 @@ pt-BR:
         not_supported: Relações polimórficas nos formulários não são suportadas.
       has_one:
         not_supported: Relações um para muitos nos formulários não são suportadas.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Limpar pesquisa
       label: Pesquisa %{resource}

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -6,8 +6,9 @@ pt:
       confirm: Tem certeza?
       destroy: Remover
       edit: Editar
-      show: Visualizar
-      new: Novo
+      edit_resource: Editar %{name}
+      show_resource: Visualizar %{name}
+      new_resource: Novo %{resource}
       back: Voltar atrás
     controller:
       create:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -25,6 +25,9 @@ pt:
         not_supported: Relações polimórficas nos formulários não são suportadas.
       has_one:
         not_supported: Relações um para muitos nos formulários não são suportadas.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Limpar pesquisa
       label: Pesquisa %{resource}

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -24,6 +24,9 @@ ru:
         not_supported: Полиморфные отношения в формах не поддерживаются.
       has_one:
         not_supported: HasOne отношения в формах не поддерживаются.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Очистить поиск
       label: Поиск %{resource}

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -5,8 +5,9 @@ ru:
       confirm: Вы уверены?
       destroy: Удалить
       edit: Редактировать
-      show: Показать
-      new: Новый
+      edit_resource: Редактировать %{name}
+      show_resource: Показать %{name}
+      new_resource: Новый %{resource}
       back: Вернуться назад
     controller:
       create:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -5,8 +5,9 @@ sv:
       confirm: Är du säker?
       destroy: Ta bort
       edit: Ändra
-      show: Visa
-      new: Ny
+      edit_resource: Ändra %{name}
+      show_resource: Visa %{name}
+      new_resource: Ny %{resource}
       back: Tillbaka
     controller:
       create:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -24,6 +24,9 @@ sv:
         not_supported: Formulär med polymorfiska relationer stöds inte.
       has_one:
         not_supported: Formulär med HasOne relationer stöds inte.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Rensa sökningen
       label: Sök %{resource}

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -5,8 +5,9 @@ uk:
       confirm: Ви впевнені?
       destroy: Видалити
       edit: Редагувати
-      show: Показати
-      new: Новий
+      edit_resource: Редагувати %{name}
+      show_resource: Показати %{name}
+      new_resource: Новий %{resource}
       back: Назад
     controller:
       create:

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -24,6 +24,9 @@ uk:
         not_supported: Поліморфні відношення у формах не підтримуються.
       has_one:
         not_supported: HasOne відношення у формах не підтримуються.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Очистити пошук
       label: пошук %{resource}

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -24,6 +24,9 @@ vi:
         not_supported: Quan hệ Polymorphic chưa được hỗ trợ.
       has_one:
         not_supported: Quan hệ HasOne chưa được hỗ trợ.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Tìm kiếm rõ ràng
       label: Tìm kiếm %{resource}

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -5,8 +5,9 @@ vi:
       confirm: Bạn có chắc không?
       destroy: Xóa
       edit: Sửa
-      show: Xem
-      new: Mới
+      edit_resource: Sửa %{name}
+      show_resource: Xem %{name}
+      new_resource: Mới %{resource}
       back: Trở lại
     controller:
       create:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -5,8 +5,9 @@ zh-CN:
       confirm: 确定?
       destroy: 删除
       edit: 编辑
-      show: 查看
-      new: 新建
+      edit_resource: 编辑 %{name}
+      show_resource: 查看 %{name}
+      new_resource: 新建 %{resource}
       back: 返回
     controller:
       create:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -24,6 +24,9 @@ zh-CN:
         not_supported: Polymorphic 关系暂不支持
       has_one:
         not_supported: HasOne 关系暂不支持.
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: 清除搜索
       label: 搜索 %{resource}

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -5,8 +5,9 @@ zh-TW:
       confirm: 確定？
       destroy: 刪除
       edit: 編輯
-      show: 檢視
-      new: 新增
+      edit_resource: 編輯 %{name}
+      show_resource: 檢視 %{name}
+      new_resource: 新增 %{resource}
       back: 返回
     controller:
       create:

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -24,6 +24,9 @@ zh-TW:
         not_supported: 表單尚未支援 Polymorphic 關聯。
       has_one:
         not_supported: 表單尚未支援 HasOne 關聯。
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: 清除搜索
       label: 搜索 %{resource}


### PR DESCRIPTION
I finally got around replacing/updating #785, which adds better I18n support for administrate.

---

- [x] Removes "hardcoded" placement of resource name for edit/new/show links (problematic on Arabic and other right-to-left languages since the positioning of the name will be flipped too).
- [x] Update `config/locale/administrate.en.yml` 
- [x] Includes the latest commit from `master`
- [x] Use `display_resource_name` consistently when calling `page.resource_name` in view templates
- [x] Update all other locale files
    * Any comments/suggestions on how I best should go about this?
    * If I use `i18n-tasks add-missing` other updates (formatting etc) are made in the locale files
    * Should we try to re-use the existing strings or do we deem that dangerous and think its better that translations are re-done by someone who actually understands the language? 😅 

⚠️ There is one expected test failure for `rspec ./spec/i18n_spec.rb:9 # I18n does not have missing keys` (see TODO)