### PR TITLE
Search through association fields

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -87,6 +87,24 @@ Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`
 `:class_name` - Specifies the name of the associated class.
 Defaults to `:#{attribute}.to_s.singularize.camelcase`.
 
+`:searchable` - Specify if the attribute should be considered when searching.
+Default is `false`.
+
+`searchable_field` - Specify which column to use on the search, only applies
+if `searchable` is `true`
+
+For example:
+
+```ruby
+  country: Field::BelongsTo(
+    searchable: true,
+    seachable_field: 'name',
+  )
+```
+
+with this, you will be able to search through the column `name` from the
+association `belongs_to :country`, from your model.
+
 **Field::HasMany**
 
 `:limit` - Set the number of resources to display in the show view. Default is
@@ -107,6 +125,24 @@ Defaults to `:#{attribute}.to_s.singularize.camelcase`.
 
 `:class_name` - Specifies the name of the associated class.
 Defaults to `:#{attribute}.to_s.singularize.camelcase`.
+
+`:searchable` - Specify if the attribute should be considered when searching.
+Default is `false`.
+
+`searchable_field` - Specify which column to use on the search, only applies if
+`searchable` is `true`
+
+For example:
+
+```ruby
+  cities: Field::HasMany(
+    searchable: true,
+    seachable_field: 'name',
+  )
+```
+
+with this, you will be able to search through the column `name` from the
+association `has_many :cities`, from your model.
 
 **Field::Number**
 

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -25,6 +25,10 @@ module Administrate
         options.fetch(:searchable, deferred_class.searchable?)
       end
 
+      def searchable_field
+        options.fetch(:searchable_field)
+      end
+
       def permitted_attribute(attr, _options = nil)
         options.fetch(:foreign_key,
           deferred_class.permitted_attribute(attr, options))

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -9,7 +9,9 @@ module Administrate
       return order_by_association(relation) unless
         reflect_association(relation).nil?
 
-      return relation.reorder("#{attribute} #{direction}") if
+      order = "#{relation.table_name}.#{attribute} #{direction}"
+
+      return relation.reorder(order) if
         relation.columns_hash.keys.include?(attribute.to_s)
 
       relation

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -13,7 +13,7 @@ module Administrate
       if @term.blank?
         @scoped_resource.all
       else
-        @scoped_resource.where(query, *search_terms)
+        @scoped_resource.joins(tables_to_join).where(query, *search_terms)
       end
     end
 
@@ -21,9 +21,9 @@ module Administrate
 
     def query
       search_attributes.map do |attr|
-        table_name = ActiveRecord::Base.connection.
-          quote_table_name(@scoped_resource.table_name)
-        attr_name = ActiveRecord::Base.connection.quote_column_name(attr)
+        table_name = query_table_name(attr)
+        attr_name = column_to_query(attr)
+
         "LOWER(CAST(#{table_name}.#{attr_name} AS CHAR(256))) LIKE ?"
       end.join(" OR ")
     end
@@ -40,6 +40,40 @@ module Administrate
 
     def attribute_types
       @dashboard_class::ATTRIBUTE_TYPES
+    end
+
+    def query_table_name(attr)
+      if association_search?(attr)
+        ActiveRecord::Base.connection.quote_table_name(attr.to_s.pluralize)
+      else
+        ActiveRecord::Base.connection.
+          quote_table_name(@scoped_resource.table_name)
+      end
+    end
+
+    def column_to_query(attr)
+      if association_search?(attr)
+        ActiveRecord::Base.connection.
+          quote_column_name(attribute_types[attr].searchable_field)
+      else
+        ActiveRecord::Base.connection.quote_column_name(attr)
+      end
+    end
+
+    def tables_to_join
+      attribute_types.keys.select do |attribute|
+        attribute_types[attribute].searchable? && association_search?(attribute)
+      end
+    end
+
+    def association_search?(attribute)
+      return unless attribute_types[attribute].respond_to?(:deferred_class)
+
+      [
+        Administrate::Field::BelongsTo,
+        Administrate::Field::HasMany,
+        Administrate::Field::HasOne,
+      ].include?(attribute_types[attribute].deferred_class)
     end
 
     attr_reader :resolver, :term

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -10,8 +10,12 @@ class CustomerDashboard < Administrate::BaseDashboard
     orders: Field::HasMany.with_options(limit: 2),
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
-    country: Field::BelongsTo.
-      with_options(primary_key: :code, foreign_key: :country_code),
+    country: Field::BelongsTo.with_options(
+      primary_key: :code,
+      foreign_key: :country_code,
+      searchable: true,
+      searchable_field: "name",
+    ),
     password: Field::Password,
   }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :customer do
+    country
     sequence(:name) { |n| "Customer #{n}" }
     email { name.downcase.gsub(" ", "_") + "@example.com" }
 
@@ -60,5 +61,10 @@ FactoryBot.define do
 
   factory :series do
     sequence(:name) { |n| "Series #{n}" }
+  end
+
+  factory :country do
+    sequence(:name) { |n| "Country #{n}" }
+    sequence(:code) { |n| "C#{n}" }
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -42,6 +42,21 @@ feature "Search" do
     expect(page).to have_content(mismatch.email)
   end
 
+  scenario "admin searches across associations fields", :js do
+    country = create(:country, name: "Brazil", code: "BR")
+    country_match = create(:customer, country: country)
+    mismatch = create(:customer)
+
+    visit admin_customers_path
+
+    fill_in :search, with: "Brazil"
+    submit_search
+
+    expect(page).to have_content(country_match.email)
+    expect(page).to have_content(country.name)
+    expect(page).not_to have_content(mismatch.email)
+  end
+
   def clear_search
     find(".search__clear-link").click
   end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -36,7 +36,7 @@ describe Administrate::Order do
 
         ordered = order.apply(relation)
 
-        expect(relation).to have_received(:reorder).with("name asc")
+        expect(relation).to have_received(:reorder).with("table_name.name asc")
         expect(ordered).to eq(relation)
       end
 
@@ -47,7 +47,7 @@ describe Administrate::Order do
 
         ordered = order.apply(relation)
 
-        expect(relation).to have_received(:reorder).with("name desc")
+        expect(relation).to have_received(:reorder).with("table_name.name desc")
         expect(ordered).to eq(relation)
       end
     end
@@ -171,6 +171,7 @@ describe Administrate::Order do
     double(
       klass: double(reflect_on_association: nil),
       columns_hash: { column.to_s => :column_info },
+      table_name: "table_name",
     )
   end
 


### PR DESCRIPTION
After searching the documentation I didn't find anything about searching using the `association` fields, and also I didn't find any open PR related to this, so I decided to open this PR.

The approach I used was using `with_options`, when declaring a field on the dashboard, and added a new option called `searchable_field`.

The dashboard will look like this:

```
class StateDashboard < Administrate::BaseDashboard 
....
country: Administrate::Fields::BelongsTo.with_options(searchable: true, searchable_field: 'name')
....
```