### PR TITLE
Option for Date(Time) objects be **in a timezone**

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -124,6 +124,14 @@ Or, to display a distance in kilometers:
 `:classes` - Specify a list of classes whose objects will be used to populate select boxes for editing this polymorphic field.
 Default is `[]`.
 
+**Field::DateTime**
+
+`:format` - Specify what format, using `strftime` you would like `DateTime`
+objects to display as.
+
+`:timezone` - Specify which timezone `Date` and `DateTime` objects are based
+in.
+
 **Field::Select**
 
 `:collection` - Specify the array or range to select from.  Defaults to `[]`.

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -4,17 +4,28 @@ module Administrate
   module Field
     class DateTime < Base
       def date
-        I18n.localize(data.to_date, format: format)
+        I18n.localize(
+          data.in_time_zone(timezone).to_date,
+          format: format,
+        )
       end
 
       def datetime
-        I18n.localize(data, format: format, default: data)
+        I18n.localize(
+          data.in_time_zone(timezone),
+          format: format,
+          default: data,
+        )
       end
 
       private
 
       def format
         options.fetch(:format, :default)
+      end
+
+      def timezone
+        options.fetch(:timezone, "UTC")
       end
     end
   end

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -46,6 +46,19 @@ describe Administrate::Field::DateTime do
         end
       end
     end
+
+    context "with `timezone` option set to New York & early DateTime" do
+      it "displays previous day because of the time difference" do
+        start_date = DateTime.parse("2015-12-25 02:15:45")
+        options_field = Administrate::Field::DateTime.
+          with_options(format: :short, timezone: "America/New_York")
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.date).to eq("Dec 24")
+        end
+      end
+    end
   end
 
   describe "#datetime" do
@@ -75,6 +88,18 @@ describe Administrate::Field::DateTime do
 
         with_translations(:en, formats) do
           expect(field.datetime).to eq("10:15")
+        end
+      end
+    end
+
+    context "with `timezone` option" do
+      it "displays the datetime for the specified timezone" do
+        options_field = Administrate::Field::DateTime.
+          with_options(format: "%H:%M", timezone: "America/New_York")
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats) do
+          expect(field.datetime).to eq("05:15")
         end
       end
     end


### PR DESCRIPTION
Often times a layperson using a dashboard can be misled when they look
at a record's creation/update time and not realize it's rooted in the
UTC timezone. This commit adds the option to display `Field::DateTime`
fields as being within a provided timezone.

Also - update the documentation to contain the two options for that
field: `:format` and `:timezone`.

Note: By default the timezone in that field is not explicitly set as
UTC.