### PR TITLE
Load huge result sets for belongs_to remotely

### DIFF
--- a/app/assets/javascripts/administrate/components/belongs_to_form.js
+++ b/app/assets/javascripts/administrate/components/belongs_to_form.js
@@ -1,0 +1,23 @@
+$(function() {
+  $(".field-unit--belongs-to select[data-remote-url]").each(function(index, field) {
+    $(field).selectize({
+      valueField: 'id',
+      labelField: 'name',
+      searchField: 'name',
+      preload: 'focus',
+      load: function(query, callback) {
+          if (!query.length) return callback();
+          $.ajax({
+              url: $(field).data('remote-url') + '?search=' + encodeURIComponent(query),
+              type: 'GET',
+              error: function(res) {
+                  callback();
+              },
+              success: function(res) {
+                  callback(res);
+              }
+          });
+      }
+    });
+  });
+});

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -23,7 +23,7 @@ module Administrate
         end
 
         format.json {
-          render json: resources.map { |resource| { name: dashboard.display_resource(resource), id: resource.send(resource_class.primary_key) } }
+          render json: resources_json(resources, dashboard, resource_class)
         }
       end
     end
@@ -152,6 +152,10 @@ module Administrate
       dashboard.attribute_types_for(
         dashboard.collection_attributes
       ).any? { |_name, attribute| attribute.searchable? }
+    end
+
+    def resources_json(resources, dashboard, resource_class)
+      resources.map { |resource| { name: dashboard.display_resource(resource), id: resource.send(resource_class.primary_key) } }
     end
   end
 end

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -12,12 +12,20 @@ module Administrate
       resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
-      render locals: {
-        resources: resources,
-        search_term: search_term,
-        page: page,
-        show_search_bar: show_search_bar?
-      }
+      respond_to do |format|
+        format.html do
+          render locals: {
+            resources: resources,
+            search_term: search_term,
+            page: page,
+            show_search_bar: show_search_bar?
+          }
+        end
+
+        format.json {
+          render json: resources.map { |resource| { name: dashboard.display_resource(resource), id: resource.send(resource_class.primary_key) } }
+        }
+      end
     end
 
     def show

--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -20,7 +20,11 @@ that displays all possible records to associate with.
   <%= f.label field.permitted_attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.select(field.permitted_attribute) do %>
-    <%= options_for_select(field.associated_resource_options, field.selected_option) %>
+  <% if field.associated_class.count > 20 && valid_action?(:index, field.associated_class) %>
+    <%= f.select(field.permitted_attribute, [], {}, { data: { "remote-url": url_for([namespace, field.associated_class, format: :json]) } }) %>
+  <% else %>
+    <%= f.select(field.permitted_attribute) do %>
+      <%= options_for_select(field.associated_resource_options, field.selected_option) %>
+    <% end %>
   <% end %>
 </div>

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -7,14 +7,14 @@ module Administrate
         associated_dashboard.display_resource(data)
       end
 
+      def associated_class
+        associated_class_name.constantize
+      end
+
       protected
 
       def associated_dashboard
         "#{associated_class_name}Dashboard".constantize.new
-      end
-
-      def associated_class
-        associated_class_name.constantize
       end
 
       def associated_class_name

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -19,6 +19,15 @@ describe "order form" do
     )
   end
 
+  context "with more than 20 customers" do
+    it "it loads the customers options remotely" do
+      create_list(:customer, 21)
+
+      visit new_admin_order_path
+      expect(find_field("Customer")["data-remote-url"]).not_to be_empty
+    end
+  end
+
   describe "belongs_to relationships" do
     it "has stored value selected" do
       create(:customer)


### PR DESCRIPTION
Started working on #430 and need some feedback, I hope the implementation makes sense.

The `Administrate::Search` doesn't handle cases where the select options name is the `id` (e.g., `"Order #22"`), should `id` be included in the query for all models or only for cases that is needed?