### PR TITLE
Add hardcoded development secret_key_base

### DIFF
--- a/spec/example_app/config/secrets.yml
+++ b/spec/example_app/config/secrets.yml
@@ -3,6 +3,7 @@ default: &default
 
 development:
   <<: *default
+  secret_key_base: 1a022e4f335d24af3d6bd622b9daef5a44808afbe16d4f1c8bed03675ab91ecd9c76ddc1a30f3fbb668b02c00abcba2ecc3714c95943b8f4af86289a2a46d5e1
 
 test:
   secret_key_base: test_secret


### PR DESCRIPTION
Adds hardcoded `secret_key_base` to `secrets.yml`. Generated via `SecureRandom.hex(64)`.

Related issue: https://github.com/thoughtbot/administrate/issues/929

/r @nickcharlton @tysongach 