### PR TITLE
Fix has one class name

### DIFF
--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -5,8 +5,9 @@ ar:
       confirm: "هل أنت متأكد ؟"
       destroy: "حذف"
       edit: "تعديل"
-      show: "إظهار"
-      new: "جديد"
+      edit_resource: "تعديل %{name}"
+      show_resource: "إظهار %{name}"
+      new_resource: "جديد  %{resource}"
       back: "الى الخلف"
     controller:
       create:

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -5,9 +5,8 @@ ar:
       confirm: "هل أنت متأكد ؟"
       destroy: "حذف"
       edit: "تعديل"
-      edit_resource: "تعديل %{name}"
-      show_resource: "إظهار %{name}"
-      new_resource: "جديد  %{resource}"
+      show: "إظهار"
+      new: "جديد"
       back: "الى الخلف"
     controller:
       create:
@@ -20,8 +19,6 @@ ar:
       has_many:
         more: إظهار %{count} من %{total_count}
         none: "لا يوجد"
-      has_one:
-        not_supported: "غير مدعمه \"HasOne\" هذه العلاقه"
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -4,8 +4,9 @@ bs:
       confirm: Jeste li sigurni?
       destroy: Izbrisati
       edit: Izmjena
-      show: Pregled
-      new: Novi
+      edit_resource: Izmjena %{name}
+      show_resource: Pregled %{name}
+      new_resource: Novi %{resource}
       back: Nazad
     controller:
       create:

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -4,9 +4,8 @@ bs:
       confirm: Jeste li sigurni?
       destroy: Izbrisati
       edit: Izmjena
-      edit_resource: Izmjena %{name}
-      show_resource: Pregled %{name}
-      new_resource: Novi %{resource}
+      show: Pregled
+      new: Novi
       back: Nazad
     controller:
       create:
@@ -19,8 +18,6 @@ bs:
       has_many:
         more: Prikazuje %{count} od %{total_count}
         none: Niko
-      has_one:
-        not_supported: Asocijacije HasOne još nije podržana. Žao nam je!
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.ca.yml
+++ b/config/locales/administrate.ca.yml
@@ -19,8 +19,6 @@ ca:
       has_many:
         more: Mostrant %{count} de %{total_count}
         none: Cap
-      has_one:
-        not_supported: Els formularis amb relacions "HasOne" no estàn suportats.
     search:
       clear: Esborrar la cerca
       label: Cerca %{resource}

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -5,9 +5,8 @@ da:
       confirm: Er du sikker?
       destroy: Slet
       edit: Rediger
-      edit_resource: Rediger %{name}
-      show_resource: Vis %{name}
-      new_resource: Ny %{resource}
+      show: Vis
+      new: Ny
       back: Tilbage
     controller:
       create:
@@ -20,8 +19,6 @@ da:
       has_many:
         more: "Viser %{count} af %{total_count}"
         none: Ingen
-      has_one:
-        not_supported: "Formularer med has_one associationer er ikke understøttede."
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -5,8 +5,9 @@ da:
       confirm: Er du sikker?
       destroy: Slet
       edit: Rediger
-      show: Vis
-      new: Ny
+      edit_resource: Rediger %{name}
+      show_resource: Vis %{name}
+      new_resource: Ny %{resource}
       back: Tilbage
     controller:
       create:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -5,9 +5,8 @@ de:
       confirm: Sind Sie sicher?
       destroy: Löschen
       edit: Editieren
-      edit_resource: "%{name} editieren"
-      show_resource: "%{name} anzeigen"
-      new_resource: "%{resource} erstellen"
+      show: Anzeigen
+      new: Neu
       back: Zurück
     controller:
       create:
@@ -20,8 +19,6 @@ de:
       has_many:
         more: "%{count} von %{total_count}"
         none: Keine
-      has_one:
-        not_supported: HasOne Beziehungen werden nicht unterstützt.
     form:
       error: error
       errors: "%{pluralized_errors} haben das Speichern dieses %{resource_name} verhindert:"

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -5,8 +5,9 @@ de:
       confirm: Sind Sie sicher?
       destroy: Löschen
       edit: Editieren
-      show: Anzeigen
-      new: Neu
+      edit_resource: "%{name} editieren"
+      show_resource: "%{name} anzeigen"
+      new_resource: "%{resource} erstellen"
       back: Zurück
     controller:
       create:

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -5,9 +5,8 @@ en:
       confirm: Are you sure?
       destroy: Destroy
       edit: Edit
-      edit_resource: Edit %{name}
-      show_resource: Show %{name}
-      new_resource: New %{name}
+      show: Show
+      new: New
       back: Back
     controller:
       create:
@@ -20,8 +19,6 @@ en:
       has_many:
         more: Showing %{count} of %{total_count}
         none: None
-      has_one:
-        not_supported: HasOne relationship forms are not supported.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -5,8 +5,9 @@ en:
       confirm: Are you sure?
       destroy: Destroy
       edit: Edit
-      show: Show
-      new: New
+      edit_resource: Edit %{name}
+      show_resource: Show %{name}
+      new_resource: New %{name}
       back: Back
     controller:
       create:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -20,8 +20,6 @@ es:
       has_many:
         more: Mostrando %{count} de %{total_count}
         none: Ninguno
-      has_one:
-        not_supported: Los formularios con relaciones HasOne no están soportados.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -5,9 +5,8 @@ fr:
       confirm: Êtes-vous sûr ?
       destroy: Supprimer
       edit: Modifier
-      edit_resource: Modifier %{name}
-      show_resource: Détails %{name}
-      new_resource: Création %{resource}
+      show: Détails
+      new: Création
       back: Précédent
     controller:
       create:
@@ -20,8 +19,6 @@ fr:
       has_many:
         more: "%{count} sur %{total_count}"
         none: Aucun
-      has_one:
-        not_supported: Les relations HasOne dans les formulaires ne sont pas supportées.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -5,8 +5,9 @@ fr:
       confirm: Êtes-vous sûr ?
       destroy: Supprimer
       edit: Modifier
-      show: Détails
-      new: Création
+      edit_resource: Modifier %{name}
+      show_resource: Détails %{name}
+      new_resource: Création %{resource}
       back: Précédent
     controller:
       create:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -20,8 +20,6 @@ it:
       has_many:
         more: Visualizzo %{count} di %{total_count}
         none: Nessuno
-      has_one:
-        not_supported: Associazioni HasOne non ancora supportate. Spiacenti!
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -5,8 +5,9 @@ ja:
       confirm: 本当によろしいですか？
       destroy: 削除
       edit: 編集
-      show: 参照
-      new: 新規
+      edit_resource: 編集 %{name}
+      show_resource: 参照 %{name}
+      new_resource: 新規 %{resource}
       back: 戻る
     controller:
       create:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -5,9 +5,8 @@ ja:
       confirm: 本当によろしいですか？
       destroy: 削除
       edit: 編集
-      edit_resource: 編集 %{name}
-      show_resource: 参照 %{name}
-      new_resource: 新規 %{resource}
+      show: 参照
+      new: 新規
       back: 戻る
     controller:
       create:
@@ -20,8 +19,6 @@ ja:
       has_many:
         more: "%{total_count} 件中 %{count} 件表示"
         none: データがありません
-      has_one:
-        not_supported: フォームでは「１：１」の関連をサポートしていません。
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -20,8 +20,6 @@ ko:
       has_many:
         more: "%{total_count} 개 중에서 %{count} 개"
         none: 없음
-      has_one:
-        not_supported: 일대일 관계에 대한 양식은 제공되지 않습니다.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -20,8 +20,6 @@ nl:
       has_many:
         more: Resultaat %{count} van %{total_count}
         none: Geen
-      has_one:
-        not_supported: HasOne relaties formulieren worden niet ondersteund.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -20,8 +20,6 @@ pl:
       has_many:
         more: Wyświetlanie %{count} z %{total_count}
         none: Brak
-      has_one:
-        not_supported: Relacje jeden-do-jednego nie są obsługiwane.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -21,8 +21,6 @@ pt-BR:
       has_many:
         more: "Exibindo %{count} de %{total_count}"
         none: Nenhum
-      has_one:
-        not_supported: Relações um para muitos nos formulários não são suportadas.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -21,8 +21,6 @@ pt:
       has_many:
         more: "Mostrando %{count} de %{total_count}"
         none: Nenhum
-      has_one:
-        not_supported: Relações um para muitos nos formulários não são suportadas.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -20,8 +20,6 @@ ru:
       has_many:
         more: "%{count} из %{total_count}"
         none: Нет
-      has_one:
-        not_supported: HasOne отношения в формах не поддерживаются.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -20,8 +20,6 @@ sv:
       has_many:
         more: "%{count} av %{total_count}"
         none: Inga
-      has_one:
-        not_supported: Formulär med HasOne relationer stöds inte.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -20,8 +20,6 @@ uk:
       has_many:
         more: "%{count} із %{total_count}"
         none: Немає
-      has_one:
-        not_supported: HasOne відношення у формах не підтримуються.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -20,8 +20,6 @@ vi:
       has_many:
         more: "%{count} trên %{total_count}"
         none: Không
-      has_one:
-        not_supported: Quan hệ HasOne chưa được hỗ trợ.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -20,8 +20,6 @@ zh-CN:
       has_many:
         more: 显示所有 %{total_count} 中 %{count} 条
         none: 无
-      has_one:
-        not_supported: HasOne 关系暂不支持.
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -20,8 +20,6 @@ zh-TW:
       has_many:
         more: 顯示 %{total_count} 筆中的 %{count} 筆資料
         none: 無
-      has_one:
-        not_supported: 表單尚未支援 HasOne 關聯。
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -24,7 +24,7 @@ module Administrate
         @options = options
       end
 
-      def self.permitted_attribute(attr, options=nil)
+      def self.permitted_attribute(attr, _options = nil)
         attr
       end
 

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -24,7 +24,7 @@ module Administrate
         @options = options
       end
 
-      def self.permitted_attribute(attr)
+      def self.permitted_attribute(attr, options=nil)
         attr
       end
 

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -3,7 +3,7 @@ require_relative "associative"
 module Administrate
   module Field
     class BelongsTo < Associative
-      def self.permitted_attribute(attr)
+      def self.permitted_attribute(attr, options=nil)
         :"#{attr}_id"
       end
 

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -3,7 +3,7 @@ require_relative "associative"
 module Administrate
   module Field
     class BelongsTo < Associative
-      def self.permitted_attribute(attr, options=nil)
+      def self.permitted_attribute(attr, _options = nil)
         :"#{attr}_id"
       end
 

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -26,8 +26,8 @@ module Administrate
       end
 
       def permitted_attribute(attr, _options = nil)
-        self.options.fetch(:foreign_key,
-          deferred_class.permitted_attribute(attr, self.options))
+        options.fetch(:foreign_key,
+          deferred_class.permitted_attribute(attr, options))
       end
 
       delegate :html_class, to: :deferred_class

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -25,8 +25,9 @@ module Administrate
         options.fetch(:searchable, deferred_class.searchable?)
       end
 
-      def permitted_attribute(attr, options=nil)
-        self.options.fetch(:foreign_key, deferred_class.permitted_attribute(attr, self.options))
+      def permitted_attribute(attr, _options = nil)
+        self.options.fetch(:foreign_key,
+          deferred_class.permitted_attribute(attr, self.options))
       end
 
       delegate :html_class, to: :deferred_class

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -25,8 +25,8 @@ module Administrate
         options.fetch(:searchable, deferred_class.searchable?)
       end
 
-      def permitted_attribute(attr)
-        options.fetch(:foreign_key, deferred_class.permitted_attribute(attr))
+      def permitted_attribute(attr, options=nil)
+        self.options.fetch(:foreign_key, deferred_class.permitted_attribute(attr, self.options))
       end
 
       delegate :html_class, to: :deferred_class

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -7,8 +7,8 @@ module Administrate
     class HasMany < Associative
       DEFAULT_LIMIT = 5
 
-      def self.permitted_attribute(attribute)
-        { "#{attribute.to_s.singularize}_ids".to_sym => [] }
+      def self.permitted_attribute(attr, options=nil)
+        { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 
       def associated_collection

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -7,7 +7,7 @@ module Administrate
     class HasMany < Associative
       DEFAULT_LIMIT = 5
 
-      def self.permitted_attribute(attr, options=nil)
+      def self.permitted_attribute(attr, _options = nil)
         { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -3,25 +3,32 @@ require_relative "associative"
 module Administrate
   module Field
     class HasOne < Associative
-      def initialize(attribute, data, page, options = {})
-        resolver = Administrate::ResourceResolver.new("admin/#{attribute}")
-        @nested_form = Administrate::Page::Form.new(
+      def nested_form
+        @nested_form ||= Administrate::Page::Form.new(
           resolver.dashboard_class.new,
           data || resolver.resource_class.new,
         )
-
-        super
       end
 
-      def self.permitted_attribute(attr)
+      def self.permitted_attribute(attr, options=nil)
+        associated_class_name =
+          if options.present?
+            options.fetch(:class_name, attr.to_s.singularize.camelcase)
+          else
+            attr
+          end  
         related_dashboard_attributes =
-          Administrate::ResourceResolver.new("admin/#{attr}").
+          Administrate::ResourceResolver.new("admin/#{associated_class_name}").
             dashboard_class.new.permitted_attributes + [:id]
 
         { "#{attr}_attributes": related_dashboard_attributes }
       end
 
-      attr_reader :nested_form
+      private
+
+      def resolver
+        @resolver ||= Administrate::ResourceResolver.new("admin/#{associated_class_name}")
+      end
     end
   end
 end

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -12,7 +12,7 @@ module Administrate
 
       def self.permitted_attribute(attr, options = nil)
         associated_class_name =
-          if options.present?
+          if options
             options.fetch(:class_name, attr.to_s.singularize.camelcase)
           else
             attr

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -10,13 +10,13 @@ module Administrate
         )
       end
 
-      def self.permitted_attribute(attr, options=nil)
+      def self.permitted_attribute(attr, options = nil)
         associated_class_name =
           if options.present?
             options.fetch(:class_name, attr.to_s.singularize.camelcase)
           else
             attr
-          end  
+          end
         related_dashboard_attributes =
           Administrate::ResourceResolver.new("admin/#{associated_class_name}").
             dashboard_class.new.permitted_attributes + [:id]
@@ -27,7 +27,8 @@ module Administrate
       private
 
       def resolver
-        @resolver ||= Administrate::ResourceResolver.new("admin/#{associated_class_name}")
+        @resolver ||=
+          Administrate::ResourceResolver.new("admin/#{associated_class_name}")
       end
     end
   end

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -11,7 +11,7 @@ module Administrate
         end
       end
 
-      def self.permitted_attribute(attr, options=nil)
+      def self.permitted_attribute(attr, _options = nil)
         { attr => %i{type value} }
       end
 

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -11,7 +11,7 @@ module Administrate
         end
       end
 
-      def self.permitted_attribute(attr)
+      def self.permitted_attribute(attr, options=nil)
         { attr => %i{type value} }
       end
 

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -20,7 +20,7 @@ describe Administrate::Field::Deferred do
         deferred.permitted_attribute(:foo)
 
         expect(Administrate::Field::String).
-          to have_received(:permitted_attribute).with(:foo)
+          to have_received(:permitted_attribute).with(:foo, {})
       end
     end
   end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -1,7 +1,37 @@
 require "administrate/field/has_one"
 require "support/constant_helpers"
+require "rails_helper"
+require "administrate/resource_resolver"
+require "administrate/page"
+require "administrate/page/form"
 
 describe Administrate::Field::HasOne do
+  describe "#nested_form" do
+    it "returns a form" do
+      product_meta_tag = double
+      field = Administrate::Field::HasOne.new(:product_meta_tag,
+        product_meta_tag, :show)
+
+      form = field.nested_form
+
+      expect(form).to be_present
+    end
+  end
+
+  describe ".permitted_attribute" do
+    context 'with custom class_name' do
+      it "returns attributes from correct dashboard" do
+        field = Administrate::Field::Deferred.
+          new(Administrate::Field::HasOne.with_options(class_name: :product_meta_tag))
+
+        field_name = 'seo_meta_tag'
+        attributes = field.permitted_attribute(field_name)
+        expect(attributes[:"#{field_name}_attributes"]).
+          to eq([:meta_title, :meta_description, :id])
+      end
+    end
+  end
+
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
       page = :show

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -19,15 +19,15 @@ describe Administrate::Field::HasOne do
   end
 
   describe ".permitted_attribute" do
-    context 'with custom class_name' do
+    context "with custom class_name" do
       it "returns attributes from correct dashboard" do
-        field = Administrate::Field::Deferred.
-          new(Administrate::Field::HasOne.with_options(class_name: :product_meta_tag))
+        field = Administrate::Field::Deferred.new(Administrate::Field::HasOne.
+            with_options(class_name: :product_meta_tag))
 
-        field_name = 'seo_meta_tag'
+        field_name = "seo_meta_tag"
         attributes = field.permitted_attribute(field_name)
         expect(attributes[:"#{field_name}_attributes"]).
-          to eq([:meta_title, :meta_description, :id])
+          to eq(%i(meta_title meta_description id))
       end
     end
   end


### PR DESCRIPTION
Related issue: https://github.com/thoughtbot/administrate/issues/951

Currently, when passing `class_name` option to `has_one` field it does not infer correct class name for the dashboard which results in exception. 
This PR modifies `has_one` class to use `associative` to get the correct dashboard name.
Additionally, it fixes `permitted_attributes` method, which required me to modify the signature and pass `options` from `Deferred` attribute.

In scope of this I've also removed old locale keys for `has_one.not_supported` string.

/r @nickcharlton @tysongach 