### PR TITLE
Add additional Rubies using Workflows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,71 @@
-version: 2
+---
+default_job: &default_job
+  working_directory: ~/administrate
+  steps:
+    - checkout
+
+    # Restore Cached Dependencies
+    - type: cache-restore
+      name: Restore bundle cache
+      key: administrate-{{ checksum "Gemfile.lock" }}
+
+    # Bundle install dependencies
+    - run: bundle install --path vendor/bundle
+
+    # Install Appraisal gemfiles
+    - run: bundle exec appraisal install
+
+    # Cache Dependencies
+    - type: cache-save
+      name: Store bundle cache
+      key: administrate-{{ checksum "Gemfile.lock" }}
+      paths:
+        - vendor/bundle
+
+    # Wait for DB
+    - run: dockerize -wait tcp://localhost:5432 -timeout 1m
+
+    # Setup the environment
+    - run: cp .sample.env .env
+
+    # Setup the database
+    - run: bundle exec rake db:setup
+
+    # Run the tests
+    - run: bundle exec rake
+    - run: bundle exec appraisal rake
+
 jobs:
-  build:
-    working_directory: ~/administrate
+  ruby-2.3:
+    <<: *default_job
+    docker:
+      - image: circleci/ruby:2.3-node-browsers
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:9.5-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby23
+          POSTGRES_PASSWORD: ""
+
+  ruby-2.4:
+    <<: *default_job
+    docker:
+      - image: circleci/ruby:2.4.3-node-browsers
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:9.5-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby24
+          POSTGRES_PASSWORD: ""
+
+  ruby-2.5:
+    <<: *default_job
     docker:
       - image: circleci/ruby:2.5.0-node-browsers
         environment:
@@ -11,38 +75,13 @@ jobs:
       - image: postgres:9.5-alpine
         environment:
           POSTGRES_USER: administrate
-          POSTGRES_DB: administrate-prototype_test
+          POSTGRES_DB: ruby25
           POSTGRES_PASSWORD: ""
-    steps:
-      - checkout
 
-      # Restore Cached Dependencies
-      - type: cache-restore
-        name: Restore bundle cache
-        key: administrate-{{ checksum "Gemfile.lock" }}
-
-      # Bundle install dependencies
-      - run: bundle install --path vendor/bundle
-
-      # Install Appraisal gemfiles
-      - run: bundle exec appraisal install
-
-      # Cache Dependencies
-      - type: cache-save
-        name: Store bundle cache
-        key: administrate-{{ checksum "Gemfile.lock" }}
-        paths:
-          - vendor/bundle
-
-      # Wait for DB
-      - run: dockerize -wait tcp://localhost:5432 -timeout 1m
-
-      # Setup the environment
-      - run: cp .sample.env .env
-
-      # Setup the database
-      - run: bundle exec rake db:setup
-
-      # Run the tests
-      - run: bundle exec rake
-      - run: bundle exec appraisal rake
+workflows:
+  version: 2
+  multiple-rubies:
+    jobs:
+      - ruby-2.5
+      - ruby-2.4
+      - ruby-2.3


### PR DESCRIPTION
A recent issue (#1010) highlighted a deprecation under certain Ruby
versions that we should be aware of. So far, we've been using CircleCI
for running tests and previously they didn't support multiple builds.

With Circle CI 2.0, Workflows allows for something like this to be setup. This
uses YAML inheritance to share a job definition across multiple build
types (defined as different Docker configurations).

This introduces Ruby 2.3 and 2.4.3 in addition to 2.5.0 and using Postgres 9.5.

Notable caveat to this approach is that you must set different databases
for each environment (here named like the Ruby versions) to avoid test
state-based errors.