### PR TITLE
Add note re: updating dashboards with new model attributes

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -110,7 +110,7 @@ Example:
 ```
 
 It's recommended that you make this change at the same time as you add the 
-attribute to the model
+attribute to the model.
 
 The alternative way to handle this is to re-run `rails g administrate:install` and 
 carefully pick through the diffs. This latter method is probably more cumbersome.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -109,8 +109,8 @@ Example:
   ].freeze
 ```
 
-It is recommended you make this change in the PR that also adds the attribute to 
-your model.
+It's recommended that you make this change at the same time as you add the 
+attribute to the model
 
 The alternative way to handle this is to re-run `rails g administrate:install` and 
 carefully pick through the diffs. This latter method is probably more cumbersome.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -73,6 +73,48 @@ namespace :admin do
 end
 ```
 
+## Keep Dashboards Updated as Model Attributes Change
+
+If you've installed Administrate and generated dashboards and _then_ 
+subsequently added attributes to your models you'll need to manually add 
+these additions (or removals) to your dashboards.
+
+Example:
+
+```ruby
+# app/dashboards/your_model_dashboard.rb
+
+  ATTRIBUTE_TYPES = {
+    # ...
+    the_new_attribute: Field::String,
+    # ...
+  }.freeze
+  
+  SHOW_PAGE_ATTRIBUTES = [
+    # ...
+    :the_new_attribute,
+    # ...
+  ].freeze
+
+  FORM_ATTRIBUTES = [
+    # ...
+    :the_new_attribute,
+    # ...
+  ].freeze
+  
+  COLLECTION_ATTRIBUTES = [
+    # ...
+    :the_new_attribute, # if you want it on the index, also.
+    # ...
+  ].freeze
+```
+
+It is recommended you make this change in the PR that also adds the attribute to 
+your model.
+
+The alternative way to handle this is to re-run `rails g administrate:install` and 
+carefully pick through the diffs. This latter method is probably more cumbersome.
+
 ## Rails API
 
 Since Rails 5.0, we've been able to have API only applications. Yet, sometimes


### PR DESCRIPTION
This change updates the docs with a reminder and example code to update already-existant dashboards after models change. This change was recommended in https://github.com/thoughtbot/administrate/issues/1025#issuecomment-349026731 by @nickcharlton 