### PR TITLE
Hk minor german translation improvements

### DIFF
--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -24,7 +24,7 @@ de:
         not_supported: HasOne Beziehungen werden nicht unterstützt.
     form:
       error: error
-      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+      errors: "%{pluralized_errors} haben das Speichern dieses %{resource_name} verhindert:"
     search:
       clear: Suche zurücksetzen
       label: "%{resource} durchsuchen"

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -26,5 +26,5 @@ de:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
-      clear: Saubere Suche
-      label: Suche %{resource}
+      clear: Suche zurücksetzen
+      label: "%{resource} durchsuchen"


### PR DESCRIPTION
As suggested in #1004 this follows up on #1002 with the minor german improvements. Please keep in mind that the translation of the `form.errors` is mediocre at best, since the sentence would need many variations based on the number of errors and the gender of the resource and so on. But ah well.