### PR TITLE
humanize has_many form label

### DIFF
--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -20,7 +20,7 @@ and is augmented with [Selectize].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute_key, field.attribute %>
+  <%= f.label field.attribute_key, field.attribute.to_s.humanize %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>

--- a/app/views/fields/has_many/_form.html.erb
+++ b/app/views/fields/has_many/_form.html.erb
@@ -20,7 +20,10 @@ and is augmented with [Selectize].
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.attribute_key, field.attribute.to_s.humanize %>
+  <%= f.label field.attribute_key, 
+      t("helpers.label.#{resource_name}.#{field.attribute_key}", 
+          default: field.attribute.to_s.humanize) %>
+
 </div>
 <div class="field-unit__field">
   <%= f.select(field.attribute_key, nil, {}, multiple: true) do %>

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -2,20 +2,46 @@ require "rails_helper"
 require "administrate/field/has_many"
 
 describe "fields/has_many/_form", type: :view do
+  
   describe "the field label" do
-    it "displays the association name" do
-      has_many = Administrate::Field::HasMany.new(:associated_objects, [],
-        :some_page)
 
+    let(:has_many) { 
+      Administrate::Field::HasMany.new(:associated_objects, [], :some_page)
+    }
+
+    before do
       allow(has_many).to receive(:associated_resource_options).and_return([])
-
+      allow(view).to receive(:resource_name).and_return(:customer)
+    end
+  
+    it "displays the association name" do
       render(
         partial: "fields/has_many/form.html.erb",
         locals: { f: fake_form_builder, field: has_many },
       )
-
       expect(rendered).to include("Associated objects")
     end
+  
+    it "displays the translation" do
+      translations = {
+        helpers: {
+          label: {
+            customer: {
+              associated_object_ids: "Custom Associated Objects"
+            },
+          },
+        },
+      }
+
+      with_translations(:en, translations) do
+        render(
+          partial: "fields/has_many/form.html.erb",
+          locals: { f: fake_form_builder, field: has_many },
+        )
+        expect(rendered).to include("Custom Associated Objects")
+      end
+    end
+
   end
 
   def fake_form_builder

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -1,27 +1,28 @@
 require "rails_helper"
+require "administrate/field/has_many"
 
 describe "fields/has_many/_form", type: :view do
   describe "the field label" do
     it "displays the association name" do
-      has_many = double(
-        attribute_key: :associated_object_ids,
-        attribute: :associated_objects,
-      )
+      has_many = Administrate::Field::HasMany.new(:associated_objects, [],
+        :some_page)
+
+      allow(has_many).to receive(:associated_resource_options).and_return([])
 
       render(
         partial: "fields/has_many/form.html.erb",
         locals: { f: fake_form_builder, field: has_many },
       )
 
-      expect(rendered).to include("Associated Objects")
+      expect(rendered).to include("Associated objects")
     end
   end
 
   def fake_form_builder
-    double("Form Builder").as_null_object.tap do |form_builder|
-      allow(form_builder).to receive(:label) do |*args|
-        args.second.to_s.titleize
-      end
-    end
+    object_name = "some object"
+    object = double("object", associated_object_ids: [])
+    template = ActionController::Base.new.view_context
+    options = {}
+    ActionView::Helpers::FormBuilder.new(object_name, object, template, options)
   end
 end


### PR DESCRIPTION
The has_many field form label displays in underscore case. The second argument to the `label_tag` helper should be the display text, but here `field.attribute` is a symbol. Other fields, like the string field, aren't affected because the label tag helper in the string form partial only receives one argument. When the `label_tag` helper only receives one argument, it calls `.to_s.humanize` on it to create the display text, so that's what I've added to the has_many form partial.