### PR TITLE
Add missing keys to Catalan.

### DIFF
--- a/config/locales/administrate.ca.yml
+++ b/config/locales/administrate.ca.yml
@@ -5,8 +5,9 @@ ca:
       confirm: Estàs segur?
       destroy: Destruir
       edit: Editar
-      show: Mostrar
-      new: Nou
+      edit_resource: Edita %{name}
+      show_resource: Mostra %{name}
+      new_resource: Nou %{name}
       back: Tornar
     controller:
       create:
@@ -19,6 +20,9 @@ ca:
       has_many:
         more: Mostrant %{count} de %{total_count}
         none: Cap
+    form:
+      error: error
+      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
     search:
       clear: Esborrar la cerca
       label: Cerca %{resource}


### PR DESCRIPTION
* Adds `{show,edit,new}_resource`.
* Adds form error/errors.

These are partly through Google Translate, but the pluralized form is just English currently.

/cc @6temes