### PR TITLE
Singularize field name in HasMany index partial

### DIFF
--- a/app/views/fields/has_many/_index.html.erb
+++ b/app/views/fields/has_many/_index.html.erb
@@ -16,4 +16,4 @@ as a count of how many objects are associated through the relationship.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
 %>
 
-<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase) %>
+<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase.singularize) %>

--- a/spec/administrate/views/fields/has_many/_index_spec.rb
+++ b/spec/administrate/views/fields/has_many/_index_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe "fields/has_many/_index", type: :view do
+  context "without any associated records" do
+    it "displays the pluralized attribute name" do
+      has_many = double(
+        data: double(
+          size: 0,
+        ),
+        attribute: :teams,
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("0 teams")
+    end
+  end
+
+  context "with one associated record" do
+    it "displays the singularized attribute name" do
+      has_many = double(
+        data: double(
+          size: 1,
+        ),
+        attribute: :teams,
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("1 team")
+    end
+  end
+
+  context "with two associated records" do
+    it "displays the pluralized attribute name" do
+      has_many = double(
+        data: double(
+          size: 2,
+        ),
+        attribute: :teams,
+      )
+
+      render(
+        partial: "fields/has_many/index.html.erb",
+        locals: { field: has_many },
+      )
+
+      expect(rendered.strip).to eq("2 teams")
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1042.

`field.attribute` is already plural. Because of this, if `field.data.size == 1`, `pluralize` returns a string like "1 teams". To fix this, we call `singularize` on `field.attribute` before passing it to `pluralize`.