### PR TITLE
Don't pluralise "New [resource]" buttons.

### DIFF
--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -44,7 +44,7 @@ It renders the `_table` partial to display details about the resources.
     <%= link_to(
       t(
         "administrate.actions.new_resource",
-        name: display_resource_name(page.resource_name).titleize.downcase
+        name: page.resource_name.titleize.downcase
       ),
       [:new, namespace, page.resource_path],
       class: "button",


### PR DESCRIPTION
In #1004 the handling of translation strings improved, but bought in a
change to the buttons for new resources. This started to pluralise them
when they shouldn't be.

So you'd have "New Line items", not "New Line item". This reverts that
change.