### PR TITLE
Use associated_class to render belongs_to links

### DIFF
--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -16,7 +16,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.attribute) %>
+  <% if valid_action?(:show, field.associated_class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -16,7 +16,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.attribute) %>
+  <% if valid_action?(:show, field.associated_class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -84,6 +84,9 @@ Defaults to `:#{attribute}_id`.
 `:scope` - Specifies a custom scope inside a callable. Useful for preloading.
 Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`
 
+`:class_name` - Specifies the name of the associated class.
+Defaults to `:#{attribute}.to_s.singularize.camelcase`.
+
 **Field::HasMany**
 
 `:limit` - Set the number of resources to display in the show view. Default is
@@ -96,6 +99,14 @@ Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`
 `:primary_key` - Specifies object's primary_key. Defaults to `:id`.
 
 `:foreign_key` - Specifies the name of the foreign key directly. Defaults to `:#{attribute}_id`
+
+`:class_name` - Specifies the name of the associated class.
+Defaults to `:#{attribute}.to_s.singularize.camelcase`.
+
+**Field::HasOne**
+
+`:class_name` - Specifies the name of the associated class.
+Defaults to `:#{attribute}.to_s.singularize.camelcase`.
 
 **Field::Number**
 

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -35,7 +35,6 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
-  gem "pundit"
 end
 
 group :staging, :production do

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -35,7 +35,6 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
-  gem "pundit"
 end
 
 group :staging, :production do

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -35,7 +35,6 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
-  gem "pundit"
 end
 
 group :staging, :production do

--- a/gemfiles/sass_3_4.gemfile
+++ b/gemfiles/sass_3_4.gemfile
@@ -33,7 +33,6 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
-  gem "pundit"
 end
 
 group :staging, :production do

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -7,14 +7,14 @@ module Administrate
         associated_dashboard.display_resource(data)
       end
 
+      def associated_class
+        associated_class_name.constantize
+      end
+
       protected
 
       def associated_dashboard
         "#{associated_class_name}Dashboard".constantize.new
-      end
-
-      def associated_class
-        associated_class_name.constantize
       end
 
       def associated_class_name

--- a/spec/administrate/views/fields/belongs_to/_index_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_index_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "fields/belongs_to/_index", type: :view do
+  let(:product) { create(:product) }
+  let(:product_path) { polymorphic_path([:admin, product]) }
+  let(:link) { "<a href=\"#{product_path}\">#{product.name}</a>" }
+  let(:associated_class) { "test_associated_class" }
+  let(:belongs_to) do
+    instance_double(
+      "Administrate::Field::BelongsTo",
+      associated_class: associated_class,
+      display_associated_resource: product.name,
+      data: product,
+    )
+  end
+
+  context "if associated resource has a show route" do
+    it "displays link" do
+      allow(view).to receive(:valid_action?).and_return(true)
+      render_belongs_to_index
+      expect(rendered.strip).to include(link)
+    end
+  end
+
+  context "if associated resource has no show route" do
+    it "displays link" do
+      allow(view).to receive(:valid_action?).and_return(false)
+      render_belongs_to_index
+      expect(rendered.strip).to_not include(link)
+    end
+  end
+
+  def render_belongs_to_index
+    render(
+      partial: "fields/belongs_to/index.html.erb",
+      locals: { field: belongs_to, namespace: "admin" },
+    )
+  end
+end

--- a/spec/administrate/views/fields/belongs_to/_show_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_show_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "fields/belongs_to/_show", type: :view do
+  let(:product) { create(:product) }
+  let(:product_path) { polymorphic_path([:admin, product]) }
+  let(:link) { "<a href=\"#{product_path}\">#{product.name}</a>" }
+  let(:associated_class) { "test_associated_class" }
+  let(:belongs_to) do
+    instance_double(
+      "Administrate::Field::BelongsTo",
+      associated_class: associated_class,
+      display_associated_resource: product.name,
+      data: product,
+    )
+  end
+
+  context "if associated resource has a show route" do
+    it "displays link" do
+      allow(view).to receive(:valid_action?).and_return(true)
+      render_belongs_to_show
+      expect(rendered.strip).to include(link)
+    end
+  end
+
+  context "if associated resource has no show route" do
+    it "displays link" do
+      allow(view).to receive(:valid_action?).and_return(false)
+      render_belongs_to_show
+      expect(rendered.strip).to_not include(link)
+    end
+  end
+
+  def render_belongs_to_show
+    render(
+      partial: "fields/belongs_to/show.html.erb",
+      locals: { field: belongs_to, namespace: "admin" },
+    )
+  end
+end


### PR DESCRIPTION
Use associated_class to render belongs_to links

The class_name option that allows an associative field to render the proper class / dashboard was not previously accounted for when validating whether or not to link to a belongs_to resource in the belongs_to index and show partials.

The following actions were taken:
- Add documentation for class_name in customizing_dashboards
- Make associated_class a public method for associative fields
- Call valid_action? with associated_class in belongs_to partials
- Test that valid_action? is called with correct value
- Test that the link is rendered when action is valid

Note:
- When running `appraisal install`, `gem pundit` was added several times
  to the gemfile
- The test that is failing is the same test that is failing on master
- This PR follows up on https://github.com/thoughtbot/administrate/issues/1050