### PR TITLE
Fix new_resource interpolation variable name in translations

### DIFF
--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -7,7 +7,7 @@ ar:
       edit: "تعديل"
       edit_resource: "تعديل %{name}"
       show_resource: "إظهار %{name}"
-      new_resource: "جديد  %{resource}"
+      new_resource: "جديد  %{name}"
       back: "الى الخلف"
     controller:
       create:

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -6,7 +6,7 @@ bs:
       edit: Izmjena
       edit_resource: Izmjena %{name}
       show_resource: Pregled %{name}
-      new_resource: Novi %{resource}
+      new_resource: Novi %{name}
       back: Nazad
     controller:
       create:

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -7,7 +7,7 @@ da:
       edit: Rediger
       edit_resource: Rediger %{name}
       show_resource: Vis %{name}
-      new_resource: Ny %{resource}
+      new_resource: Ny %{name}
       back: Tilbage
     controller:
       create:

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -7,7 +7,7 @@ de:
       edit: Editieren
       edit_resource: "%{name} editieren"
       show_resource: "%{name} anzeigen"
-      new_resource: "%{resource} erstellen"
+      new_resource: "%{name} erstellen"
       back: Zurück
     controller:
       create:

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -7,7 +7,7 @@ es:
       edit: Editar
       edit_resource: Editar %{name}
       show_resource: Mostrar %{name}
-      new_resource: Nuevo %{resource}
+      new_resource: Nuevo %{name}
       back: Volver
     controller:
       create:

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -7,7 +7,7 @@ fr:
       edit: Modifier
       edit_resource: Modifier %{name}
       show_resource: Détails %{name}
-      new_resource: Création %{resource}
+      new_resource: Création %{name}
       back: Précédent
     controller:
       create:

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -7,7 +7,7 @@ it:
       edit: Modifica
       edit_resource: Modifica %{name}
       show_resource: Visualizza %{name}
-      new_resource: Nuovo %{resource}
+      new_resource: Nuovo %{name}
       back: Indietro
     controller:
       create:

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -7,7 +7,7 @@ ja:
       edit: 編集
       edit_resource: 編集 %{name}
       show_resource: 参照 %{name}
-      new_resource: 新規 %{resource}
+      new_resource: 新規 %{name}
       back: 戻る
     controller:
       create:

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -7,7 +7,7 @@ ko:
       edit: 편집
       edit_resource: 편집 %{name}
       show_resource: 보여주기 %{name}
-      new_resource: 새로운 %{resource}
+      new_resource: 새로운 %{name}
       back: 뒤로
     controller:
       create:

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -7,7 +7,7 @@ nl:
       edit: Bewerk
       edit_resource: Bewerk %{name}
       show_resource: Toon %{name}
-      new_resource: Nieuw %{resource}
+      new_resource: Nieuw %{name}
       back: Terug
     controller:
       create:

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -7,7 +7,7 @@ pl:
       edit: Edytuj
       edit_resource: Edytuj %{name}
       show_resource: Wyświetl %{name}
-      new_resource: Nowy %{resource}
+      new_resource: Nowy %{name}
       back: Wstecz
     controller:
       create:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -8,7 +8,7 @@ pt-BR:
       edit: Editar
       edit_resource: Editar %{name}
       show_resource: Visualizar %{name}
-      new_resource: Criar %{resource}
+      new_resource: Criar %{name}
       back: Voltar
     controller:
       create:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -8,7 +8,7 @@ pt:
       edit: Editar
       edit_resource: Editar %{name}
       show_resource: Visualizar %{name}
-      new_resource: Novo %{resource}
+      new_resource: Novo %{name}
       back: Voltar atrás
     controller:
       create:

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -7,7 +7,7 @@ ru:
       edit: Редактировать
       edit_resource: Редактировать %{name}
       show_resource: Показать %{name}
-      new_resource: Новый %{resource}
+      new_resource: Новый %{name}
       back: Вернуться назад
     controller:
       create:

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -7,7 +7,7 @@ sv:
       edit: Ändra
       edit_resource: Ändra %{name}
       show_resource: Visa %{name}
-      new_resource: Ny %{resource}
+      new_resource: Ny %{name}
       back: Tillbaka
     controller:
       create:

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -7,7 +7,7 @@ uk:
       edit: Редагувати
       edit_resource: Редагувати %{name}
       show_resource: Показати %{name}
-      new_resource: Новий %{resource}
+      new_resource: Новий %{name}
       back: Назад
     controller:
       create:

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -7,7 +7,7 @@ vi:
       edit: Sửa
       edit_resource: Sửa %{name}
       show_resource: Xem %{name}
-      new_resource: Mới %{resource}
+      new_resource: Mới %{name}
       back: Trở lại
     controller:
       create:

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -7,7 +7,7 @@ zh-CN:
       edit: 编辑
       edit_resource: 编辑 %{name}
       show_resource: 查看 %{name}
-      new_resource: 新建 %{resource}
+      new_resource: 新建 %{name}
       back: 返回
     controller:
       create:

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -7,7 +7,7 @@ zh-TW:
       edit: 編輯
       edit_resource: 編輯 %{name}
       show_resource: 檢視 %{name}
-      new_resource: 新增 %{resource}
+      new_resource: 新增 %{name}
       back: 返回
     controller:
       create:


### PR DESCRIPTION
The translations of the I18n key `new_resource` have an incorrect variable name, causing a "missing interpolation argument" error