### PR TITLE
Only define Punditize if Pundit has been loaded.

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -1,33 +1,35 @@
-module Administrate
-  module Punditize
-    extend ActiveSupport::Concern
-    include Pundit
+if Object.const_defined?("Pundit")
+  module Administrate
+    module Punditize
+      extend ActiveSupport::Concern
+      include Pundit
 
-    included do
-      def scoped_resource
-        policy_scope_admin super
+      included do
+        def scoped_resource
+          policy_scope_admin super
+        end
+
+        def authorize_resource(resource)
+          authorize resource
+        end
+
+        def show_action?(action, resource)
+          Pundit.policy!(pundit_user, resource).send("#{action}?".to_sym)
+        end
       end
 
-      def authorize_resource(resource)
-        authorize resource
-      end
+      private
 
-      def show_action?(action, resource)
-        Pundit.policy!(pundit_user, resource).send("#{action}?".to_sym)
-      end
-    end
-
-    private
-
-    # Like the policy_scope method in stock Pundit, but allows the 'resolve'
-    # to be overridden by 'resolve_admin' for a different index scope in Admin
-    # controllers.
-    def policy_scope_admin(scope)
-      ps = Pundit::PolicyFinder.new(scope).scope!.new(pundit_user, scope)
-      if ps.respond_to? :resolve_admin
-        ps.resolve_admin
-      else
-        ps.resolve
+      # Like the policy_scope method in stock Pundit, but allows the 'resolve'
+      # to be overridden by 'resolve_admin' for a different index scope in Admin
+      # controllers.
+      def policy_scope_admin(scope)
+        ps = Pundit::PolicyFinder.new(scope).scope!.new(pundit_user, scope)
+        if ps.respond_to? :resolve_admin
+          ps.resolve_admin
+        else
+          ps.resolve
+        end
       end
     end
   end


### PR DESCRIPTION
When the `RAILS_ENV` is set to `production`, the concern will be eagerly
loaded. As we `include Pundit` here, this means that it'll fail if
`pundit` isn't included in the bundle.

Fixes #1048.