### PR TITLE
Nothing says they have to be in a specific order

### DIFF
--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -68,7 +68,7 @@ describe "order form" do
       visit edit_admin_order_path(order)
 
       expected = order.line_items.pluck(:id).map(&:to_s)
-      expect(find("#order_line_item_ids").value).to eq expected
+      expect(find("#order_line_item_ids").value).to match_array(expected)
     end
 
     def find_option(associated_model, field_id)


### PR DESCRIPTION
This should fix one of the flaky tests that fails randomly on CI.

I looked around for a bit and saw nothing that specified that line items had to be in a specific order. So either:

1. We accept this and spec for it.
2. We change the models to make line items be ordered by id.

I went for option 1.