### PR TITLE
Fix another issue with non-guaranteed order

### DIFF
--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -138,6 +138,6 @@ RSpec.describe "customer show page" do
   end
 
   def ids_in_table
-    all('tr td:first-child').map(&:text).map(&:to_i)
+    all("tr td:first-child").map(&:text).map(&:to_i)
   end
 end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -6,25 +6,25 @@ RSpec.describe "customer show page" do
       customer = create(:customer)
       orders = create_list(:order, 4, customer: customer)
       order_ids = orders.map(&:id)
-      ids_in_page_1 = ids_in_page_2 = nil
+      ids_in_page1 = ids_in_page2 = nil
 
       visit admin_customer_path(customer)
 
-      within('.attribute-data--has-many') do
-        ids_in_page_1 = ids_in_table
-        expect(ids_in_page_1.count).to eq 2
-        expect(order_ids).to include(*ids_in_page_1)
+      within(".attribute-data--has-many") do
+        ids_in_page1 = ids_in_table
+        expect(ids_in_page1.count).to eq 2
+        expect(order_ids).to include(*ids_in_page1)
       end
 
       click_on("Next ›")
 
-      within('.attribute-data--has-many') do
-        ids_in_page_2 = ids_in_table
-        expect(ids_in_page_2.count).to eq 2
-        expect(order_ids).to include(*ids_in_page_2)
+      within(".attribute-data--has-many") do
+        ids_in_page2 = ids_in_table
+        expect(ids_in_page2.count).to eq 2
+        expect(order_ids).to include(*ids_in_page2)
       end
 
-      ids_in_table = (ids_in_page_1 + ids_in_page_2).uniq
+      ids_in_table = (ids_in_page1 + ids_in_page2).uniq
       expect(ids_in_table).to match_array(order_ids)
     end
   end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -2,45 +2,30 @@ require "rails_helper"
 
 RSpec.describe "customer show page" do
   describe "displays the customers orders paginated" do
-    context "when a page is not specified" do
-      it "displays the first page of results" do
-        customer = create(:customer)
-        orders = create_list(:order, 4, customer: customer)
-        first_page = orders.first(2)
-        second_page = orders.last(2)
+    it "displays the first page by default, other pages when specified" do
+      customer = create(:customer)
+      orders = create_list(:order, 4, customer: customer)
+      order_ids = orders.map(&:id)
+      ids_in_page_1 = ids_in_page_2 = nil
 
-        visit admin_customer_path(customer)
+      visit admin_customer_path(customer)
 
-        within('.attribute-data--has-many') do
-          first_page.each do |order|
-            expect(page).to have_order_row(order.id)
-          end
-          second_page.each do |order|
-            expect(page).not_to have_order_row(order.id)
-          end
-        end
+      within('.attribute-data--has-many') do
+        ids_in_page_1 = ids_in_table
+        expect(ids_in_page_1.count).to eq 2
+        expect(order_ids).to include(*ids_in_page_1)
       end
-    end
 
-    context "when the second page is specified" do
-      it "displays the second page of results" do
-        customer = create(:customer)
-        orders = create_list(:order, 4, customer: customer)
-        first_page = orders.first(2)
-        second_page = orders.last(2)
+      click_on("Next ›")
 
-        visit admin_customer_path(customer)
-        click_on("Next ›")
-
-        within('.attribute-data--has-many') do
-          first_page.each do |order|
-            expect(page).not_to have_order_row(order.id)
-          end
-          second_page.each do |order|
-            expect(page).to have_order_row(order.id)
-          end
-        end
+      within('.attribute-data--has-many') do
+        ids_in_page_2 = ids_in_table
+        expect(ids_in_page_2.count).to eq 2
+        expect(order_ids).to include(*ids_in_page_2)
       end
+
+      ids_in_table = (ids_in_page_1 + ids_in_page_2).uniq
+      expect(ids_in_table).to match_array(order_ids)
     end
   end
 
@@ -152,7 +137,7 @@ RSpec.describe "customer show page" do
     end
   end
 
-  def have_order_row(id)
-    have_css('tr td:first-child', text: id)
+  def ids_in_table
+    all('tr td:first-child').map(&:text).map(&:to_i)
   end
 end


### PR DESCRIPTION
Similar to https://github.com/thoughtbot/administrate/pull/1076, these two test are flaky because they expect records to be in a specific order.

In this case the fix is a bit more involved. I had to merge two examples in one to preserve the original meaning of the tests. It may raise some eyebrows.

Thoughts?