### PR TITLE
Cast all search queries to text.

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -24,7 +24,7 @@ module Administrate
         table_name = ActiveRecord::Base.connection.
           quote_table_name(@scoped_resource.table_name)
         attr_name = ActiveRecord::Base.connection.quote_column_name(attr)
-        "lower(#{table_name}.#{attr_name}) LIKE ?"
+        "LOWER(TEXT(#{table_name}.#{attr_name})) LIKE ?"
       end.join(" OR ")
     end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -1,5 +1,4 @@
-require "spec_helper"
-require "support/constant_helpers"
+require "rails_helper"
 require "administrate/field/string"
 require "administrate/field/email"
 require "administrate/field/number"
@@ -45,7 +44,7 @@ describe Administrate::Search do
       end
     end
 
-    it "searches using lower() + LIKE for all searchable fields" do
+    it "searches using LOWER + LIKE for all searchable fields" do
       begin
         class User < ActiveRecord::Base; end
         scoped_object = User.default_scoped
@@ -53,8 +52,8 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "test")
         expected_query = [
-          "lower(\"users\".\"name\") LIKE ?"\
-          " OR lower(\"users\".\"email\") LIKE ?",
+          "LOWER(TEXT(\"users\".\"name\")) LIKE ?"\
+          " OR LOWER(TEXT(\"users\".\"email\")) LIKE ?",
           "%test%",
           "%test%",
         ]
@@ -66,7 +65,7 @@ describe Administrate::Search do
       end
     end
 
-    it "converts search term lower case for latin and cyrillic strings" do
+    it "converts search term LOWER case for latin and cyrillic strings" do
       begin
         class User < ActiveRecord::Base; end
         scoped_object = User.default_scoped
@@ -74,8 +73,8 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "Тест Test")
         expected_query = [
-          "lower(\"users\".\"name\") LIKE ?"\
-          " OR lower(\"users\".\"email\") LIKE ?",
+          "LOWER(TEXT(\"users\".\"name\")) LIKE ?"\
+          " OR LOWER(TEXT(\"users\".\"email\")) LIKE ?",
           "%тест test%",
           "%тест test%",
         ]


### PR DESCRIPTION
All Postgres versions since 8.4 require this to be a string. This casts
the table and column to be strings as it's possible that the column name
is nil.

Fixes #620.