### PR TITLE
Use new_resource in new action

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -27,7 +27,7 @@ module Administrate
     end
 
     def new
-      resource = resource_class.new
+      resource = new_resource
       authorize_resource(resource)
       render locals: {
         page: Administrate::Page::Form.new(dashboard, resource),


### PR DESCRIPTION
- Simplify making new form with prefilled associations
- Is supposed to close this issue https://github.com/thoughtbot/administrate/issues/220
- Now to have  simply override `new_resource` method instead of new action to init resource associations

P.S. Though, it works as expected on has_one association, when trying to build has_many association it doesn't work. The reason is that select is used on has_many form and only ids get send with the request. And because the record doesn't have an id it gets lost. I'm not sure if it's a bug and should be addressed or not, please let me know what you think.