### PR TITLE
Use cross-DB way to cast search queries to strings

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -24,7 +24,7 @@ module Administrate
         table_name = ActiveRecord::Base.connection.
           quote_table_name(@scoped_resource.table_name)
         attr_name = ActiveRecord::Base.connection.quote_column_name(attr)
-        "LOWER(TEXT(#{table_name}.#{attr_name})) LIKE ?"
+        "LOWER(CAST(#{table_name}.#{attr_name} AS CHAR(256))) LIKE ?"
       end.join(" OR ")
     end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -52,8 +52,8 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "test")
         expected_query = [
-          "LOWER(TEXT(\"users\".\"name\")) LIKE ?"\
-          " OR LOWER(TEXT(\"users\".\"email\")) LIKE ?",
+          'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?'\
+          ' OR LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
           "%test%",
           "%test%",
         ]
@@ -73,8 +73,8 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "Тест Test")
         expected_query = [
-          "LOWER(TEXT(\"users\".\"name\")) LIKE ?"\
-          " OR LOWER(TEXT(\"users\".\"email\")) LIKE ?",
+          'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?'\
+          ' OR LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
           "%тест test%",
           "%тест test%",
         ]


### PR DESCRIPTION
Tested on:
- Postgres 10.2
- MariaDB 10.1
- Sqlite 3.22