### PR TITLE
Add `scope` option to Fields::BelongsTo

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -80,6 +80,9 @@ than one column. e.g.: `"name, email DESC"`.
 `:foreign_key` - Specifies the name of the foreign key directly.
 Defaults to `:#{attribute}_id`.
 
+`:scope` - Specifies a custom scope inside a callable. Useful for preloading.
+Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`
+
 **Field::HasMany**
 
 `:limit` - Set the number of resources to display in the show view. Default is

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -24,8 +24,10 @@ module Administrate
       private
 
       def candidate_resources
+        scope = options[:scope] ? options[:scope].call : associated_class.all
+
         order = options.delete(:order)
-        order ? associated_class.order(order) : associated_class.all
+        order ? scope.reorder(order) : scope
       end
 
       def display_candidate_resource(resource)


### PR DESCRIPTION
When working with large datasets, simple `.all` can cause N+1 if related objects are used in `display_resource`. This PR allows to pass the scope explicitly.

The `scope` is passed in a callable to avoid arguments being resolved while preloading dashboards. I.e.
```ruby
  ATTRIBUTE_TYPES = {
    collection: Field::BelongsTo.with_options(
      scope: -> { Collection.where(created_at < Date.today).includes(:something) }),
```