### PR TITLE
Exclude routes that start with namespace that are not in the namespace

### DIFF
--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -12,7 +12,7 @@ module Administrate
 
     def routes
       @routes ||= all_routes.select do |controller, _action|
-        controller.starts_with?("#{namespace.to_s}/")
+        controller.starts_with?("#{namespace}/")
       end.map do |controller, action|
         [controller.gsub(/^#{namespace}\//, ""), action]
       end

--- a/lib/administrate/namespace.rb
+++ b/lib/administrate/namespace.rb
@@ -12,7 +12,7 @@ module Administrate
 
     def routes
       @routes ||= all_routes.select do |controller, _action|
-        controller.starts_with?(namespace.to_s)
+        controller.starts_with?("#{namespace.to_s}/")
       end.map do |controller, action|
         [controller.gsub(/^#{namespace}\//, ""), action]
       end

--- a/spec/administrate/namespace_spec.rb
+++ b/spec/administrate/namespace_spec.rb
@@ -9,6 +9,7 @@ describe Administrate::Namespace do
 
         Rails.application.routes.draw do
           namespace(:admin) { resources :customers }
+          resources :administrators
         end
 
         expect(namespace.resources.map(&:to_sym)).to eq [:customers]


### PR DESCRIPTION
Addresses #758 
Using the trailing slash when looking at for routes in the namespace ensures that only routes from the namespace will be used and not routes that start with the namespace. This stops the navigation looking for namespaced routes that do not exist. 
