### PR TITLE
Translate error message to Japanese

### DIFF
--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -21,8 +21,8 @@ ja:
         more: "%{total_count} 件中 %{count} 件表示"
         none: データがありません
     form:
-      error: error
-      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+      error: エラー
+      errors: "%{pluralized_errors}のため%{resource_name}を保存できません。"
     search:
       clear: 検索をクリアする
       label: サーチ %{resource}


### PR DESCRIPTION
I18n file for Japanese didn't contain properly translated error messages so I added them.