### PR TITLE
Ability to export an index page in CSV

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -12,12 +12,22 @@ module Administrate
       resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
-      render locals: {
-        resources: resources,
-        search_term: search_term,
-        page: page,
-        show_search_bar: show_search_bar?,
-      }
+      respond_to do |format|
+        format.html do
+          render locals: {
+            resources: resources,
+            search_term: search_term,
+            page: page,
+            show_search_bar: show_search_bar?,
+          }
+        end
+
+        format.csv do
+          name = params[:controller].sub(/^admin\//, '')
+          csv = Administrate::CSV.new(resources, page).generate
+          send_data csv, filename: "#{name}-#{Date.today}.csv"
+        end
+      end
     end
 
     def show

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -22,10 +22,12 @@ module Administrate
           }
         end
 
-        format.csv do
-          name = params[:controller].sub(/^admin\//, '')
-          csv = Administrate::CSV.new(resources, page, view_context).generate
-          send_data csv, filename: "#{name}-#{Date.today}.csv"
+        if show_action?(:export_csv, resources)
+          format.csv do
+            name = params[:controller].sub(/^admin\//, "")
+            csv = Administrate::CSV.new(resources, page, view_context).generate
+            send_data csv, filename: "#{name}-#{Date.today}.csv"
+          end
         end
       end
     end
@@ -178,7 +180,7 @@ module Administrate
 
     def show_search_bar?
       dashboard.attribute_types_for(
-        dashboard.all_attributes,
+        dashboard.all_attributes
       ).any? { |_name, attribute| attribute.searchable? }
     end
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -24,7 +24,7 @@ module Administrate
 
         format.csv do
           name = params[:controller].sub(/^admin\//, '')
-          csv = Administrate::CSV.new(resources, page).generate
+          csv = Administrate::CSV.new(resources, page, view_context).generate
           send_data csv, filename: "#{name}-#{Date.today}.csv"
         end
       end

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -9,11 +9,11 @@ module Administrate
                                            search_term).run
       resources = apply_resource_includes(resources)
       resources = order.apply(resources)
-      resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
       respond_to do |format|
         format.html do
+          resources = resources.page(params[:page]).per(records_per_page)
           render locals: {
             resources: resources,
             search_term: search_term,
@@ -23,6 +23,9 @@ module Administrate
         end
 
         if show_action?(:export_csv, resources)
+          if params[:page].present?
+            resources = resources.page(params[:page]).per(records_per_page)
+          end
           format.csv do
             name = params[:controller].sub(/^admin\//, "")
             csv = Administrate::CSV.new(resources, page, view_context).generate

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -24,7 +24,7 @@ module Administrate
       t(
         "helpers.label.#{resource_name}.#{attribute_name}",
         default: attribute_name.to_s,
-        ).titleize
+      ).titleize
     end
 
     def sort_order(order)

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -20,6 +20,13 @@ module Administrate
         )
     end
 
+    def attribute_title(resource_name, attribute_name)
+      t(
+        "helpers.label.#{resource_name}.#{attribute_name}",
+        default: attribute_name.to_s,
+        ).titleize
+    end
+
     def sort_order(order)
       case order
       when "asc" then "ascending"

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -57,13 +57,13 @@ to display a collection of resources in an HTML table.
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
-        <% collection_presenter.fields_for(resource).each do |attribute| %>
-          <td class="cell-data cell-data--<%= attribute.html_class %>">
+        <% collection_presenter.fields_for(resource).each do |field| %>
+          <td class="cell-data cell-data--<%= field.html_class %>">
             <% if show_action? :show, resource -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"
                  class="action-show"
                  >
-                <%= render_field attribute %>
+                <%= render_field field %>
               </a>
             <% end -%>
           </td>

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -31,10 +31,7 @@ to display a collection of resources in an HTML table.
         <%= link_to(sanitized_order_params(page, collection_field_name).merge(
           collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
-        <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: attr_name.to_s,
-        ).titleize %>
+        <%= attribute_title(collection_presenter.resource_name, attr_name) %>
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
                 <svg aria-hidden="true">

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -60,7 +60,7 @@ to display a collection of resources in an HTML table.
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
-        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+        <% collection_presenter.fields_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if show_action? :show, resource -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -45,7 +45,7 @@ It renders the `_table` partial to display details about the resources.
           t("administrate.actions.export_csv"),
           request.path + ".csv",
           class: "button"
-        ) if show_action?(:export_csv, nil)
+        ) if show_action?(:export_csv, resources)
     %>
     <%= link_to(
       t(

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -42,6 +42,12 @@ It renders the `_table` partial to display details about the resources.
 
   <div>
     <%= link_to(
+          t("administrate.actions.export_csv"),
+          request.path + ".csv",
+          class: "button"
+        ) if show_action?(:export_csv, nil)
+    %>
+    <%= link_to(
       t(
         "administrate.actions.new_resource",
         name: page.resource_name.titleize.downcase

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -36,10 +36,7 @@ as well as a link to its edit page.
   <dl>
     <% page.attributes.each do |attribute| %>
       <dt class="attribute-label" id="<%= attribute.name %>">
-      <%= t(
-        "helpers.label.#{resource_name}.#{attribute.name}",
-        default: attribute.name.titleize,
-      ) %>
+      <%= attribute_title(resource_name, attribute.name) %>
       </dt>
 
       <dd class="attribute-data attribute-data--<%=attribute.html_class%>"

--- a/app/views/fields/boolean/_index.html.erb
+++ b/app/views/fields/boolean/_index.html.erb
@@ -16,4 +16,4 @@ as a string representation of the boolean value.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Boolean
 %>
 
-<%= field.to_s %>
+<%= field.short_plain_text %>

--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -16,6 +16,4 @@ as a localized date & time string.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
 %>
 
-<% if field.data %>
-  <%= field.datetime %>
-<% end %>
+<%= field.short_plain_text %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -26,10 +26,7 @@ All fields of has_one relationship would be rendered
     <% field.nested_form.attributes.each do |attribute| -%>
       <div>
       <dt class="attribute-label">
-        <%= t(
-          "helpers.label.#{resource_name}.#{attribute.name}",
-          default: attribute.name.titleize,
-        ) %>
+        <%= attribute_title(resource_name, attribute.name) %>
       </dt>
       <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
         <%= attribute.data %>

--- a/app/views/fields/number/_index.html.erb
+++ b/app/views/fields/number/_index.html.erb
@@ -16,4 +16,4 @@ using the formatting options given in the resource's dashboard.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Number
 %>
 
-<%= field.to_s %>
+<%= field.short_plain_text %>

--- a/app/views/fields/password/_index.html.erb
+++ b/app/views/fields/password/_index.html.erb
@@ -15,4 +15,4 @@ By default, the attribute is rendered as a truncated string.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Password
 %>
 
-<%= field.truncate %>
+<%= field.short_plain_text %>

--- a/app/views/fields/select/_index.html.erb
+++ b/app/views/fields/select/_index.html.erb
@@ -13,4 +13,4 @@ to be displayed on a resource's index page.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Select
 %>
 
-<%= field.data %>
+<%= field.short_plain_text %>

--- a/app/views/fields/string/_index.html.erb
+++ b/app/views/fields/string/_index.html.erb
@@ -15,4 +15,4 @@ By default, the attribute is rendered as a truncated string.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
 %>
 
-<%= field.truncate %>
+<%= field.short_plain_text %>

--- a/app/views/fields/text/_index.html.erb
+++ b/app/views/fields/text/_index.html.erb
@@ -15,4 +15,4 @@ By default, the attribute is rendered as a truncated string.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
 %>
 
-<%= field.truncate %>
+<%= field.short_plain_text %>

--- a/app/views/fields/time/_index.html.erb
+++ b/app/views/fields/time/_index.html.erb
@@ -14,4 +14,4 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= field.data.strftime("%I:%M%p").to_s %>
+<%= field.short_plain_text %>

--- a/app/views/fields/time/_show.html.erb
+++ b/app/views/fields/time/_show.html.erb
@@ -14,4 +14,4 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= field.data.strftime("%I:%M%p").to_s %>
+<%= field.short_plain_text %>

--- a/config/locales/administrate.al.yml
+++ b/config/locales/administrate.al.yml
@@ -6,6 +6,7 @@ al:
       destroy: Fshij
       edit: Ndrysho
       edit_resource: Ndrysho %{name}
+      export_csv: Download as CSV
       show_resource: Trego %{name}
       new_resource: Të re %{name}
       back: Prapa

--- a/config/locales/administrate.al.yml
+++ b/config/locales/administrate.al.yml
@@ -6,7 +6,7 @@ al:
       destroy: Fshij
       edit: Ndrysho
       edit_resource: Ndrysho %{name}
-      export_csv: Download as CSV
+      export_csv: Shkarkoje si CSV
       show_resource: Trego %{name}
       new_resource: Të re %{name}
       back: Prapa

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -6,6 +6,7 @@ ar:
       destroy: "حذف"
       edit: "تعديل"
       edit_resource: "تعديل %{name}"
+      export_csv: "تحميل بصيغة CSV"
       show_resource: "إظهار %{name}"
       new_resource: "جديد  %{name}"
       back: "الى الخلف"

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -5,7 +5,7 @@ bs:
       destroy: Izbrisati
       edit: Izmjena
       edit_resource: Izmjena %{name}
-      export_csv: Download as CSV
+      export_csv: Preuzmite kao CSV
       show_resource: Pregled %{name}
       new_resource: Novi %{name}
       back: Nazad

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -5,6 +5,7 @@ bs:
       destroy: Izbrisati
       edit: Izmjena
       edit_resource: Izmjena %{name}
+      export_csv: Download as CSV
       show_resource: Pregled %{name}
       new_resource: Novi %{name}
       back: Nazad

--- a/config/locales/administrate.ca.yml
+++ b/config/locales/administrate.ca.yml
@@ -6,6 +6,7 @@ ca:
       destroy: Destruir
       edit: Editar
       edit_resource: Edita %{name}
+      export_csv: Descarrega CSV
       show_resource: Mostra %{name}
       new_resource: Nou %{name}
       back: Tornar

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -6,7 +6,7 @@ da:
       destroy: Slet
       edit: Rediger
       edit_resource: Rediger %{name}
-      export_csv: Download as CSV
+      export_csv: Download som CSV
       show_resource: Vis %{name}
       new_resource: Ny %{name}
       back: Tilbage

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -6,6 +6,7 @@ da:
       destroy: Slet
       edit: Rediger
       edit_resource: Rediger %{name}
+      export_csv: Download as CSV
       show_resource: Vis %{name}
       new_resource: Ny %{name}
       back: Tilbage

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -6,6 +6,7 @@ de:
       destroy: Löschen
       edit: Editieren
       edit_resource: "%{name} editieren"
+      export_csv: CSV herunterladen
       show_resource: "%{name} anzeigen"
       new_resource: "%{name} erstellen"
       back: Zurück

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -6,6 +6,7 @@ en:
       destroy: Destroy
       edit: Edit
       edit_resource: Edit %{name}
+      export_csv: Download as CSV
       show_resource: Show %{name}
       new_resource: New %{name}
       back: Back

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -6,6 +6,7 @@ es:
       destroy: Destruir
       edit: Editar
       edit_resource: Editar %{name}
+      export_csv: Descargar CSV
       show_resource: Mostrar %{name}
       new_resource: Nuevo %{name}
       back: Volver

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -6,6 +6,7 @@ fr:
       destroy: Supprimer
       edit: Modifier
       edit_resource: Modifier %{name}
+      export_csv: Télécharger le format CSV
       show_resource: Détails %{name}
       new_resource: Création %{name}
       back: Précédent

--- a/config/locales/administrate.id.yml
+++ b/config/locales/administrate.id.yml
@@ -6,6 +6,7 @@ id:
       destroy: Hapus
       edit: Perbarui
       edit_resource: Perbarui %{name}
+      export_csv: Unduh CSV
       show_resource: Tampilkan %{name}
       new_resource: "%{name} baru"
       back: Kembali

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -6,6 +6,7 @@ it:
       destroy: Elimina
       edit: Modifica
       edit_resource: Modifica %{name}
+      export_csv: Scarica in formato CSV
       show_resource: Visualizza %{name}
       new_resource: Nuovo %{name}
       back: Indietro

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -6,6 +6,7 @@ ja:
       destroy: 削除
       edit: 編集
       edit_resource: 編集 %{name}
+      export_csv: CSVファイルでダウンロード
       show_resource: 参照 %{name}
       new_resource: 新規 %{name}
       back: 戻る

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -6,6 +6,7 @@ ko:
       destroy: 삭제
       edit: 편집
       edit_resource: 편집 %{name}
+      export_csv: CSV 다운로드
       show_resource: 보여주기 %{name}
       new_resource: 새로운 %{name}
       back: 뒤로

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -6,6 +6,7 @@ nl:
       destroy: Verwijder
       edit: Bewerk
       edit_resource: Bewerk %{name}
+      export_csv: CSV downloaden
       show_resource: Toon %{name}
       new_resource: Nieuw %{name}
       back: Terug

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -6,7 +6,7 @@ pl:
       destroy: Usuń
       edit: Edytuj
       edit_resource: Edytuj %{name}
-      export_csv: Download as CSV
+      export_csv: Pobierz jako CSV
       show_resource: Wyświetl %{name}
       new_resource: Nowy %{name}
       back: Wstecz

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -6,6 +6,7 @@ pl:
       destroy: Usuń
       edit: Edytuj
       edit_resource: Edytuj %{name}
+      export_csv: Download as CSV
       show_resource: Wyświetl %{name}
       new_resource: Nowy %{name}
       back: Wstecz

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -7,6 +7,7 @@ pt-BR:
       destroy: Deletar
       edit: Editar
       edit_resource: Editar %{name}
+      export_csv: Baixar CSV
       show_resource: Visualizar %{name}
       new_resource: Criar %{name}
       back: Voltar

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -7,6 +7,7 @@ pt:
       destroy: Remover
       edit: Editar
       edit_resource: Editar %{name}
+      export_csv: Descarregar CSV
       show_resource: Visualizar %{name}
       new_resource: Novo %{name}
       back: Voltar atrás

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -6,6 +6,7 @@ ru:
       destroy: Удалить
       edit: Редактировать
       edit_resource: Редактировать %{name}
+      export_csv: Скачать как CSV
       show_resource: Показать %{name}
       new_resource: Новый %{name}
       back: Вернуться назад

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -6,6 +6,7 @@ sv:
       destroy: Ta bort
       edit: Ändra
       edit_resource: Ändra %{name}
+      export_csv: Ladda ned CSV
       show_resource: Visa %{name}
       new_resource: Ny %{name}
       back: Tillbaka

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -6,6 +6,7 @@ uk:
       destroy: Видалити
       edit: Редагувати
       edit_resource: Редагувати %{name}
+      export_csv: Завантажити як CSV
       show_resource: Показати %{name}
       new_resource: Новий %{name}
       back: Назад
@@ -21,8 +22,10 @@ uk:
         more: "%{count} із %{total_count}"
         none: Немає
     form:
-      error: error
-      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+      error:
+        one: таку помилку
+        many: такі помилки
+      errors: "Не вдалося зберегти %{resource_name} через %{pluralized_errors}:"
     search:
       clear: Очистити пошук
       label: пошук %{resource}

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -6,7 +6,7 @@ vi:
       destroy: Xóa
       edit: Sửa
       edit_resource: Sửa %{name}
-      export_csv: Download as CSV
+      export_csv: Tập tin CSV
       show_resource: Xem %{name}
       new_resource: Mới %{name}
       back: Trở lại

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -6,6 +6,7 @@ vi:
       destroy: Xóa
       edit: Sửa
       edit_resource: Sửa %{name}
+      export_csv: Download as CSV
       show_resource: Xem %{name}
       new_resource: Mới %{name}
       back: Trở lại

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -6,6 +6,7 @@ zh-CN:
       destroy: 删除
       edit: 编辑
       edit_resource: 编辑 %{name}
+      export_csv: 下载CSV
       show_resource: 查看 %{name}
       new_resource: 新建 %{name}
       back: 返回

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -6,6 +6,7 @@ zh-TW:
       destroy: 刪除
       edit: 編輯
       edit_resource: 編輯 %{name}
+      export_csv: 下載 CSV
       show_resource: 檢視 %{name}
       new_resource: 新增 %{name}
       back: 返回

--- a/lib/administrate/csv.rb
+++ b/lib/administrate/csv.rb
@@ -4,9 +4,10 @@ module Administrate
   class CSV
     attr_reader :page, :resources
 
-    def initialize(resources, page)
+    def initialize(resources, page, view_context)
       @resources = resources
       @page = page
+      @view_context = view_context
     end
 
     def generate
@@ -23,7 +24,7 @@ module Administrate
 
     def headers
       page.attribute_names.map do |attribute|
-        page.attribute_title(attribute)
+        view_context.attribute_title(attribute)
       end
     end
   end

--- a/lib/administrate/csv.rb
+++ b/lib/administrate/csv.rb
@@ -1,0 +1,30 @@
+require "csv"
+
+module Administrate
+  class CSV
+    attr_reader :page, :resources
+
+    def initialize(resources, page)
+      @resources = resources
+      @page = page
+    end
+
+    def generate
+      ::CSV.generate(headers: true) do |csv|
+        csv << headers
+
+        resources.find_each do |resource|
+          csv << page.fields_for(resource).map(&:short_plain_text)
+        end
+      end
+    end
+
+    private
+
+    def headers
+      page.attribute_names.map do |attribute|
+        page.attribute_title(attribute)
+      end
+    end
+  end
+end

--- a/lib/administrate/csv.rb
+++ b/lib/administrate/csv.rb
@@ -22,9 +22,11 @@ module Administrate
 
     private
 
+    attr_reader :view_context
+
     def headers
       page.attribute_names.map do |attribute|
-        view_context.attribute_title(attribute)
+        view_context.attribute_title(page.resource_name, attribute)
       end
     end
   end

--- a/lib/administrate/csv.rb
+++ b/lib/administrate/csv.rb
@@ -2,11 +2,11 @@ require "csv"
 
 module Administrate
   class CSV
-    attr_reader :page, :resources
+    attr_reader :collection_page, :resources
 
-    def initialize(resources, page, view_context)
+    def initialize(resources, collection_page, view_context)
       @resources = resources
-      @page = page
+      @collection_page = collection_page
       @view_context = view_context
     end
 
@@ -14,8 +14,13 @@ module Administrate
       ::CSV.generate(headers: true) do |csv|
         csv << headers
 
-        resources.find_each do |resource|
-          csv << page.fields_for(resource).map(&:short_plain_text)
+        block = lambda do |resource|
+          csv << collection_page.fields_for(resource).map(&:short_plain_text)
+        end
+        if resources.respond_to?(:find_each)
+          resources.find_each(&block)
+        else
+          resources.each(&block)
         end
       end
     end
@@ -25,8 +30,8 @@ module Administrate
     attr_reader :view_context
 
     def headers
-      page.attribute_names.map do |attribute|
-        view_context.attribute_title(page.resource_name, attribute)
+      collection_page.attribute_names.map do |attribute|
+        view_context.attribute_title(collection_page.resource_name, attribute)
       end
     end
   end

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -14,6 +14,7 @@ require "administrate/resource_resolver"
 require "administrate/search"
 require "administrate/namespace"
 require "administrate/namespace/resource"
+require "administrate/csv"
 
 module Administrate
   class Engine < ::Rails::Engine

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -7,12 +7,10 @@ module Administrate
         associated_dashboard.display_resource(data)
       end
 
+      alias_method :short_plain_text, :display_associated_resource
+
       def associated_class
         associated_class_name.constantize
-      end
-
-      def short_plain_text
-        display_associated_resource
       end
 
       protected

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -11,6 +11,10 @@ module Administrate
         associated_class_name.constantize
       end
 
+      def short_plain_text
+        display_associated_resource
+      end
+
       protected
 
       def associated_dashboard

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -7,7 +7,9 @@ module Administrate
         associated_dashboard.display_resource(data)
       end
 
-      alias_method :short_plain_text, :display_associated_resource
+      def short_plain_text
+        display_associated_resource
+      end
 
       def associated_class
         associated_class_name.constantize

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -40,6 +40,10 @@ module Administrate
         "/fields/#{self.class.field_type}/#{page}"
       end
 
+      def short_plain_text
+        to_s
+      end
+
       attr_reader :attribute, :data, :page, :resource
 
       protected

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -19,7 +19,7 @@ module Administrate
       end
 
       def short_plain_text
-        data ? datetime : ''
+        data ? datetime : ""
       end
 
       private

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -18,6 +18,10 @@ module Administrate
         )
       end
 
+      def short_plain_text
+        datetime.to_s if data
+      end
+
       private
 
       def format

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -19,7 +19,7 @@ module Administrate
       end
 
       def short_plain_text
-        datetime.to_s if data
+        data ? datetime : ''
       end
 
       private

--- a/lib/administrate/field/email.rb
+++ b/lib/administrate/field/email.rb
@@ -7,9 +7,7 @@ module Administrate
         true
       end
 
-      def short_plain_text
-        data
-      end
+      alias_method :short_plain_text, :data
     end
   end
 end

--- a/lib/administrate/field/email.rb
+++ b/lib/administrate/field/email.rb
@@ -6,6 +6,10 @@ module Administrate
       def self.searchable?
         true
       end
+
+      def short_plain_text
+        data
+      end
     end
   end
 end

--- a/lib/administrate/field/email.rb
+++ b/lib/administrate/field/email.rb
@@ -7,7 +7,9 @@ module Administrate
         true
       end
 
-      alias_method :short_plain_text, :data
+      def short_plain_text
+        data
+      end
     end
   end
 end

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -63,6 +63,10 @@ module Administrate
         @order ||= Administrate::Order.new(sort_by, direction)
       end
 
+      def short_plain_text
+        data.size.to_s
+      end
+
       private
 
       def includes

--- a/lib/administrate/field/password.rb
+++ b/lib/administrate/field/password.rb
@@ -11,6 +11,10 @@ module Administrate
         data.to_s.gsub(/./, character)[0...truncation_length]
       end
 
+      def short_plain_text
+        truncate
+      end
+
       private
 
       def truncation_length

--- a/lib/administrate/field/password.rb
+++ b/lib/administrate/field/password.rb
@@ -11,9 +11,7 @@ module Administrate
         data.to_s.gsub(/./, character)[0...truncation_length]
       end
 
-      def short_plain_text
-        truncate
-      end
+      alias_method :short_plain_text, :truncate
 
       private
 

--- a/lib/administrate/field/password.rb
+++ b/lib/administrate/field/password.rb
@@ -11,7 +11,9 @@ module Administrate
         data.to_s.gsub(/./, character)[0...truncation_length]
       end
 
-      alias_method :short_plain_text, :truncate
+      def short_plain_text
+        truncate
+      end
 
       private
 

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -11,7 +11,9 @@ module Administrate
         collection
       end
 
-      alias_method :short_plain_text, :data
+      def short_plain_text
+        data
+      end
 
       private
 

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -12,7 +12,7 @@ module Administrate
       end
 
       def short_plain_text
-        data
+        data.to_s
       end
 
       private

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -11,6 +11,10 @@ module Administrate
         collection
       end
 
+      def short_plain_text
+        data
+      end
+
       private
 
       def collection

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -11,9 +11,7 @@ module Administrate
         collection
       end
 
-      def short_plain_text
-        data
-      end
+      alias_method :short_plain_text, :data
 
       private
 

--- a/lib/administrate/field/string.rb
+++ b/lib/administrate/field/string.rb
@@ -11,7 +11,9 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
-      alias_method :short_plain_text, :truncate
+      def short_plain_text
+        truncate
+      end
 
       private
 

--- a/lib/administrate/field/string.rb
+++ b/lib/administrate/field/string.rb
@@ -1,24 +1,10 @@
-require_relative "base"
+require_relative "text"
 
 module Administrate
   module Field
-    class String < Field::Base
+    class String < Field::Text
       def self.searchable?
         true
-      end
-
-      def truncate
-        data.to_s[0...truncation_length]
-      end
-
-      def short_plain_text
-        truncate
-      end
-
-      private
-
-      def truncation_length
-        options.fetch(:truncate, 50)
       end
     end
   end

--- a/lib/administrate/field/string.rb
+++ b/lib/administrate/field/string.rb
@@ -11,9 +11,7 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
-      def short_plain_text
-        truncate
-      end
+      alias_method :short_plain_text, :truncate
 
       private
 

--- a/lib/administrate/field/string.rb
+++ b/lib/administrate/field/string.rb
@@ -11,6 +11,10 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
+      def short_plain_text
+        truncate
+      end
+
       private
 
       def truncation_length

--- a/lib/administrate/field/text.rb
+++ b/lib/administrate/field/text.rb
@@ -11,7 +11,9 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
-      alias_method :short_plain_text, :truncate
+      def short_plain_text
+        truncate
+      end
 
       private
 

--- a/lib/administrate/field/text.rb
+++ b/lib/administrate/field/text.rb
@@ -3,10 +3,6 @@ require_relative "base"
 module Administrate
   module Field
     class Text < Administrate::Field::Base
-      def self.searchable?
-        false
-      end
-
       def truncate
         data.to_s[0...truncation_length]
       end

--- a/lib/administrate/field/text.rb
+++ b/lib/administrate/field/text.rb
@@ -11,9 +11,7 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
-      def short_plain_text
-        truncate
-      end
+      alias_method :short_plain_text, :truncate
 
       private
 

--- a/lib/administrate/field/text.rb
+++ b/lib/administrate/field/text.rb
@@ -11,6 +11,10 @@ module Administrate
         data.to_s[0...truncation_length]
       end
 
+      def short_plain_text
+        truncate
+      end
+
       private
 
       def truncation_length

--- a/lib/administrate/field/text.rb
+++ b/lib/administrate/field/text.rb
@@ -3,6 +3,10 @@ require_relative "base"
 module Administrate
   module Field
     class Text < Administrate::Field::Base
+      def self.default_truncation_length
+        50
+      end
+
       def truncate
         data.to_s[0...truncation_length]
       end
@@ -14,7 +18,7 @@ module Administrate
       private
 
       def truncation_length
-        options.fetch(:truncate, 50)
+        options.fetch(:truncate, self.class.default_truncation_length)
       end
     end
   end

--- a/lib/administrate/field/time.rb
+++ b/lib/administrate/field/time.rb
@@ -3,6 +3,9 @@ require_relative "base"
 module Administrate
   module Field
     class Time < Base
+      def short_plain_text
+        data.strftime("%I:%M%p").to_s
+      end
     end
   end
 end

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -3,8 +3,6 @@ require_relative "base"
 module Administrate
   module Page
     class Collection < Page::Base
-      include ActionView::Helpers::TranslationHelper
-
       def attribute_names
         dashboard.collection_attributes
       end

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -3,11 +3,13 @@ require_relative "base"
 module Administrate
   module Page
     class Collection < Page::Base
+      include ActionView::Helpers::TranslationHelper
+
       def attribute_names
         dashboard.collection_attributes
       end
 
-      def attributes_for(resource)
+      def fields_for(resource)
         attribute_names.map do |attr_name|
           attribute_field(dashboard, resource, attr_name, :index)
         end

--- a/spec/administrate/views/fields/date_time/_index_spec.rb
+++ b/spec/administrate/views/fields/date_time/_index_spec.rb
@@ -7,8 +7,7 @@ describe "fields/date_time/_index", type: :view do
       "Administrate::Field::DateTime.with_options(
         format: #{Time::DATE_FORMATS[:default]}
       )",
-      data: product,
-      datetime: product.created_at,
+      short_plain_text: product.created_at
     )
 
     render(

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -20,6 +20,8 @@ describe "fields/has_one/_show", type: :view do
   end
 
   context "with an associated record" do
+    helper(Administrate::ApplicationHelper)
+
     it "renders a link to the record" do
       product = create(:product)
       product_path = polymorphic_path([:admin, product])

--- a/spec/example_app/app/policies/order_policy.rb
+++ b/spec/example_app/app/policies/order_policy.rb
@@ -20,4 +20,8 @@ class OrderPolicy < ApplicationPolicy
   def destroy?
     false
   end
+
+  def export_csv?
+    false
+  end
 end

--- a/spec/features/csv_export_spec.rb
+++ b/spec/features/csv_export_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "CSV export" do
+  let(:export_label) { t("administrate.actions.export_csv") }
+
+  before do
+    allow_any_instance_of(Admin::OrdersController).
+      to(receive(:show_action?).and_call_original)
+  end
+
+  context "when user is authorized to export CSV" do
+    before do
+      allow_any_instance_of(Admin::OrdersController).
+        to(receive(:show_action?).with(:export_csv, anything) { true })
+    end
+
+    it "shows button for exporting CSV" do
+      visit admin_orders_path
+
+      expect(page).to have_content(export_label)
+    end
+
+    it "downloads CSV" do
+      order = create(:order)
+      visit admin_orders_path(format: :csv)
+
+      expect(page.response_headers["Content-Disposition"]).
+        to include("attachment")
+      expect(page.source).to include(order.address_state.to_s)
+      expect(page.source).to include(order.total_price.to_s)
+    end
+  end
+
+  context "when user is not authorized to export CSV" do
+    before do
+      allow_any_instance_of(Admin::OrdersController).
+        to(receive(:show_action?).
+             with(:export_csv, anything) { false })
+    end
+
+    it "does not show button for exporting CSV" do
+      visit admin_orders_path
+
+      expect(page).to_not have_content(export_label)
+    end
+
+    it "does not download CSV" do
+      expect { visit admin_orders_path(format: :csv) }.
+        to(raise_error(ActionController::UnknownFormat))
+    end
+  end
+end

--- a/spec/features/csv_export_spec.rb
+++ b/spec/features/csv_export_spec.rb
@@ -21,13 +21,22 @@ describe "CSV export" do
     end
 
     it "downloads CSV" do
-      order = create(:order)
-      visit admin_orders_path(format: :csv)
+      order1 = create(:order, address_state: SecureRandom.hex)
+      order2 = create(:order, address_state: SecureRandom.hex)
+      visit admin_orders_path(format: :csv, per_page: 1, page: 2)
 
       expect(page.response_headers["Content-Disposition"]).
         to include("attachment")
-      expect(page.source).to include(order.address_state.to_s)
-      expect(page.source).to include(order.total_price.to_s)
+      expect(page.source).to_not include(order1.address_state)
+      expect(page.source).to include(order2.address_state)
+
+      visit admin_orders_path(format: :csv)
+      expect(page.source).to include(order1.address_state)
+      expect(page.source).to include(order2.address_state)
+
+      visit admin_orders_path(format: :csv, per_page: 1)
+      expect(page.source).to include(order1.address_state)
+      expect(page.source).to include(order2.address_state)
     end
   end
 

--- a/spec/lib/administrate/csv_spec.rb
+++ b/spec/lib/administrate/csv_spec.rb
@@ -8,7 +8,7 @@ describe Administrate::CSV do
       begin
         class Foo
           def datetime
-            Time.current
+            @datetime ||= Time.current
           end
 
           def string
@@ -40,7 +40,7 @@ describe Administrate::CSV do
           end
 
           def time
-            Time.current
+            @time ||= Time.current
           end
 
           def polymorphic
@@ -94,7 +94,8 @@ describe Administrate::CSV do
           end
         end
         csv = described_class.new([resource], collection_page, view_context_class.new)
-        expect(CSV.parse(csv.generate)[1]).to(
+        csv_row = CSV.parse(csv.generate)[1]
+        expect(csv_row).to(
           eq(collection_page.fields_for(resource).map(&:short_plain_text))
         )
       ensure

--- a/spec/lib/administrate/csv_spec.rb
+++ b/spec/lib/administrate/csv_spec.rb
@@ -5,99 +5,101 @@ require "rails_helper"
 describe Administrate::CSV do
   describe "#generate" do
     it "renders short plain values of fields" do
-      class Foo
-        def datetime
-          Time.current
+      begin
+        class Foo
+          def datetime
+            Time.current
+          end
+
+          def string
+            'string' * 100
+          end
+
+          def has_many_ids
+            [has_one.id]
+          end
+
+          def number
+            22.99
+          end
+
+          def email
+            "john@example.com"
+          end
+
+          def password
+            "secret"
+          end
+
+          def select
+            :one
+          end
+
+          def text
+            string
+          end
+
+          def time
+            Time.current
+          end
+
+          def polymorphic
+            Order.last
+          end
+
+          def belongs_to
+            Order.last
+          end
+
+          def has_one
+            Order.last
+          end
         end
 
-        def string
-          'string' * 100
+        class FooDashboard < Administrate::BaseDashboard
+          ATTRIBUTE_TYPES = {
+            datetime: Field::DateTime,
+            string: Field::String,
+            belongs_to: Field::BelongsTo.with_options(class_name: ::Order.name),
+            has_many: Field::HasMany.with_options(class_name: ::Order.name),
+            number: Field::Number.with_options(prefix: "$", decimals: 2),
+            email: Field::Email,
+            has_one: Field::HasOne.with_options(class_name: ::Order.name),
+            password: Field::Password,
+            polymorphic: Field::Polymorphic.with_options(classes: [::Order]),
+            select: Field::Select.with_options(collection: [:one, :two]),
+            text: Field::Text,
+            time: Field::Time,
+          }
+
+          COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys
         end
 
-        def has_many_ids
-          [has_one.id]
-        end
+        customer = Customer.create!(name: 'customer', email: 'customer@example.com')
+        Order.create!(
+          customer: customer,
+          address_line_one: Faker::Address.street_address,
+          address_line_two: Faker::Address.secondary_address,
+          address_city: Faker::Address.city,
+          address_state: Faker::Address.state_abbr,
+          address_zip: Faker::Address.zip,
+        )
 
-        def number
-          22.99
+        dashboard = FooDashboard.new
+        collection_page = Administrate::Page::Collection.new(dashboard)
+        resource = Foo.new
+        view_context_class = Class.new do
+          def attribute_title(_resource_name, attribute)
+            attribute
+          end
         end
-
-        def email
-          "john@example.com"
-        end
-
-        def password
-          "secret"
-        end
-
-        def select
-          :one
-        end
-
-        def text
-          string
-        end
-
-        def time
-          Time.current
-        end
-
-        def polymorphic
-          Order.last
-        end
-
-        def belongs_to
-          Order.last
-        end
-
-        def has_one
-          Order.last
-        end
+        csv = described_class.new([resource], collection_page, view_context_class.new)
+        expect(CSV.parse(csv.generate)[1]).to(
+          eq(collection_page.fields_for(resource).map(&:short_plain_text))
+        )
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
-
-      class FooDashboard < Administrate::BaseDashboard
-        ATTRIBUTE_TYPES = {
-          datetime: Field::DateTime,
-          string: Field::String,
-          belongs_to: Field::BelongsTo.with_options(class_name: ::Order.name),
-          has_many: Field::HasMany.with_options(class_name: ::Order.name),
-          number: Field::Number.with_options(prefix: "$", decimals: 2),
-          email: Field::Email,
-          has_one: Field::HasOne.with_options(class_name: ::Order.name),
-          password: Field::Password,
-          polymorphic: Field::Polymorphic.with_options(classes: [::Order]),
-          select: Field::Select.with_options(collection: [:one, :two]),
-          text: Field::Text,
-          time: Field::Time,
-        }
-
-        COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys
-      end
-
-      customer = Customer.create!(name: 'customer', email: 'customer@example.com')
-      order = Order.create!(
-        customer: customer,
-        address_line_one: Faker::Address.street_address,
-        address_line_two: Faker::Address.secondary_address,
-        address_city: Faker::Address.city,
-        address_state: Faker::Address.state_abbr,
-        address_zip: Faker::Address.zip,
-      )
-
-      dashboard = FooDashboard.new
-      collection_page = Administrate::Page::Collection.new(dashboard)
-      resource = Foo.new
-      view_context_class = Class.new do
-        def attribute_title(_resource_name, attribute)
-          attribute
-        end
-      end
-      csv = described_class.new([resource], collection_page, view_context_class.new)
-      expect(CSV.parse(csv.generate)[1]).to(
-        eq(collection_page.fields_for(resource).map(&:short_plain_text))
-      )
-    ensure
-      remove_constants :Foo, :FooDashboard
     end
   end
 end

--- a/spec/lib/administrate/csv_spec.rb
+++ b/spec/lib/administrate/csv_spec.rb
@@ -1,0 +1,103 @@
+require "administrate/base_dashboard"
+require "rails_helper"
+# require "example_app/app/dashboards/order_dashboard"
+
+describe Administrate::CSV do
+  describe "#generate" do
+    it "renders short plain values of fields" do
+      class Foo
+        def datetime
+          Time.current
+        end
+
+        def string
+          'string' * 100
+        end
+
+        def has_many_ids
+          [has_one.id]
+        end
+
+        def number
+          22.99
+        end
+
+        def email
+          "john@example.com"
+        end
+
+        def password
+          "secret"
+        end
+
+        def select
+          :one
+        end
+
+        def text
+          string
+        end
+
+        def time
+          Time.current
+        end
+
+        def polymorphic
+          Order.last
+        end
+
+        def belongs_to
+          Order.last
+        end
+
+        def has_one
+          Order.last
+        end
+      end
+
+      class FooDashboard < Administrate::BaseDashboard
+        ATTRIBUTE_TYPES = {
+          datetime: Field::DateTime,
+          string: Field::String,
+          belongs_to: Field::BelongsTo.with_options(class_name: ::Order.name),
+          has_many: Field::HasMany.with_options(class_name: ::Order.name),
+          number: Field::Number.with_options(prefix: "$", decimals: 2),
+          email: Field::Email,
+          has_one: Field::HasOne.with_options(class_name: ::Order.name),
+          password: Field::Password,
+          polymorphic: Field::Polymorphic.with_options(classes: [::Order]),
+          select: Field::Select.with_options(collection: [:one, :two]),
+          text: Field::Text,
+          time: Field::Time,
+        }
+
+        COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+      end
+
+      customer = Customer.create!(name: 'customer', email: 'customer@example.com')
+      order = Order.create!(
+        customer: customer,
+        address_line_one: Faker::Address.street_address,
+        address_line_two: Faker::Address.secondary_address,
+        address_city: Faker::Address.city,
+        address_state: Faker::Address.state_abbr,
+        address_zip: Faker::Address.zip,
+      )
+
+      dashboard = FooDashboard.new
+      collection_page = Administrate::Page::Collection.new(dashboard)
+      resource = Foo.new
+      view_context_class = Class.new do
+        def attribute_title(_resource_name, attribute)
+          attribute
+        end
+      end
+      csv = described_class.new([resource], collection_page, view_context_class.new)
+      expect(CSV.parse(csv.generate)[1]).to(
+        eq(collection_page.fields_for(resource).map(&:short_plain_text))
+      )
+    ensure
+      remove_constants :Foo, :FooDashboard
+    end
+  end
+end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -123,4 +123,11 @@ describe Administrate::Field::BelongsTo do
       end
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns title of associated resource" do
+      field = described_class.new(:customers, create(:customer), :view)
+      expect(field.short_plain_text).to eq(field.display_associated_resource)
+    end
+  end
 end

--- a/spec/lib/fields/boolean_spec.rb
+++ b/spec/lib/fields/boolean_spec.rb
@@ -36,4 +36,11 @@ describe Administrate::Field::Boolean do
       end
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns string" do
+      field = described_class.new(:boolean, true, :page)
+      expect(field.short_plain_text).to eq(field.to_s)
+    end
+  end
 end

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -132,4 +132,22 @@ describe Administrate::Field::DateTime do
       end
     end
   end
+
+  describe "#short_plain_text" do
+    context "when value is present" do
+      let(:field) { described_class.new(:start_date, Time.current, :show) }
+
+      it "returns datetime string" do
+        expect(field.short_plain_text).to eq(field.datetime)
+      end
+    end
+
+    context "when value is blank" do
+      let(:field) { described_class.new(:start_date, nil, :show) }
+
+      it "returns empty string" do
+        expect(field.short_plain_text).to eq ''
+      end
+    end
+  end
 end

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -146,7 +146,7 @@ describe Administrate::Field::DateTime do
       let(:field) { described_class.new(:start_date, nil, :show) }
 
       it "returns empty string" do
-        expect(field.short_plain_text).to eq ''
+        expect(field.short_plain_text).to eq ""
       end
     end
   end

--- a/spec/lib/fields/email_spec.rb
+++ b/spec/lib/fields/email_spec.rb
@@ -11,4 +11,12 @@ describe Administrate::Field::Email do
       expect(path).to eq("/fields/email/#{page}")
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns email" do
+      email = "foo@example.com"
+      field = described_class.new(:email, email, :page)
+      expect(field.short_plain_text).to eq(email)
+    end
+  end
 end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,6 +1,7 @@
 require "administrate/field/has_many"
 require "support/constant_helpers"
 require "support/mock_relation"
+require "rails_helper"
 
 describe Administrate::Field::HasMany do
   describe "#to_partial_path" do
@@ -204,6 +205,15 @@ describe Administrate::Field::HasMany do
 
         expect(field.selected_options).to be_nil
       end
+    end
+  end
+
+  describe "#short_plain_text" do
+    it "returns number of associated objects" do
+      number = 2
+      customers = MockRelation.new(create_list(:customer, number))
+      field = described_class.new(:customers, customers, :show)
+      expect(field.short_plain_text).to eq(number.to_s)
     end
   end
 end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -44,4 +44,11 @@ describe Administrate::Field::HasOne do
       expect(path).to eq("/fields/has_one/#{page}")
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns title of associated resource" do
+      field = described_class.new(:product_meta_tag, create(:product_meta_tag), :show)
+      expect(field.short_plain_text).to eq(field.display_associated_resource)
+    end
+  end
 end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -47,7 +47,11 @@ describe Administrate::Field::HasOne do
 
   describe "#short_plain_text" do
     it "returns title of associated resource" do
-      field = described_class.new(:product_meta_tag, create(:product_meta_tag), :show)
+      field = described_class.new(
+        :product_meta_tag,
+        create(:product_meta_tag),
+        :show
+      )
       expect(field.short_plain_text).to eq(field.display_associated_resource)
     end
   end

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -88,4 +88,11 @@ describe Administrate::Field::Number do
       Administrate::Field::Number.new(:number, num, :page, options)
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns same values as #to_s" do
+      int = Administrate::Field::Number.new(:quantity, 3, :show)
+      expect(int.short_plain_text).to eq int.to_s
+    end
+  end
 end

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -90,9 +90,9 @@ describe Administrate::Field::Number do
   end
 
   describe "#short_plain_text" do
-    it "returns same values as #to_s" do
-      int = Administrate::Field::Number.new(:quantity, 3, :show)
-      expect(int.short_plain_text).to eq int.to_s
+    it "returns same value as #to_s" do
+      field = described_class.new(:quantity, 4.2, :show)
+      expect(field.short_plain_text).to eq field.to_s
     end
   end
 end

--- a/spec/lib/fields/password_spec.rb
+++ b/spec/lib/fields/password_spec.rb
@@ -53,13 +53,20 @@ describe Administrate::Field::Password do
         expect(password.truncate).to eq(lorem(10, "-"))
       end
     end
+
+    def password_with_options(string, options)
+      Administrate::Field::Password.new(:string, string, :page, options)
+    end
+
+    def lorem(n, character = "•")
+      character * n
+    end
   end
 
-  def password_with_options(string, options)
-    Administrate::Field::Password.new(:string, string, :page, options)
-  end
-
-  def lorem(n, character = "•")
-    character * n
+  describe "#short_plain_text" do
+    it "returns #truncate" do
+      field = described_class.new(:short_secret, "c" * 30, :show)
+      expect(field.short_plain_text).to eq field.truncate
+    end
   end
 end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -72,4 +72,21 @@ describe Administrate::Field::Polymorphic do
       end
     end
   end
+
+  describe "#short_plain_text" do
+    it "returns title of associated resource" do
+      begin
+        Thing = Class.new
+        ThingDashboard = Class.new do
+          def display_resource(*)
+            :success
+          end
+        end
+        field = described_class.new(:foo, Thing.new, :show)
+        expect(field.short_plain_text).to eq(field.display_associated_resource)
+      ensure
+        remove_constants :Thing, :ThingDashboard
+      end
+    end
+  end
 end

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -48,4 +48,12 @@ describe Administrate::Field::String do
   def lorem(n)
     "a" * n
   end
+
+  describe "#short_plain_text" do
+    it "returns #truncate" do
+      string = "c" * (described_class.default_truncation_length + 1)
+      field = described_class.new(:string, string, :page)
+      expect(field.short_plain_text).to eq(field.truncate)
+    end
+  end
 end

--- a/spec/lib/fields/text_spec.rb
+++ b/spec/lib/fields/text_spec.rb
@@ -1,0 +1,11 @@
+require "administrate/field/text"
+
+describe Administrate::Field::Text do
+  describe "#short_plain_text" do
+    it "returns #truncate" do
+      string = "c" * (described_class.default_truncation_length + 1)
+      field = described_class.new(:string, string, :page)
+      expect(field.short_plain_text).to eq(field.truncate)
+    end
+  end
+end

--- a/spec/lib/fields/time_spec.rb
+++ b/spec/lib/fields/time_spec.rb
@@ -2,15 +2,23 @@ require "rails_helper"
 require "administrate/field/time"
 
 describe Administrate::Field::Time do
+  let(:page) { :show }
+  let(:time) { Time.zone.local(2000, 1, 1, 15, 45, 33) }
+  let(:field) do
+    field = Administrate::Field::Time.new(:time, time, page)
+  end
+
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
-      page = :show
-      time = Time.zone.local(2000, 1, 1, 15, 45, 33)
-      field = Administrate::Field::Time.new(:time, time, page)
-
       path = field.to_partial_path
 
       expect(path).to eq("/fields/time/#{page}")
+    end
+  end
+
+  describe "#short_plain_text" do
+    it "returns time in format 'hh:mm am/pm'" do
+      expect(field.short_plain_text).to eq time.strftime("%I:%M%p").to_s
     end
   end
 end

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -3,7 +3,7 @@ class MockRelation
     @data = data
   end
 
-  delegate :==, :empty?, :map, to: :@data
+  delegate :==, :empty?, :map, :size, to: :@data
 
   def page(n)
     self


### PR DESCRIPTION
Based on @BenMorganIO implementation from #782.

- [x] Show export button on index page if the action is allowed

- [x] Render into CSV same columns as on page. Render ALL records, not only those of current page.

- [x] Tests for CSV export

- [x] Tests for all field types rendered properly in CSV

- [x] Translations