### PR TITLE
Add fetch default value for options hash

### DIFF
--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -30,7 +30,7 @@ module Administrate
       end
 
       def classes
-        options.fetch(:classes) || []
+        options.fetch(:classes, [])
       end
 
       private

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -51,4 +51,25 @@ describe Administrate::Field::Polymorphic do
       expect(field.selected_global_id).to eq(nil)
     end
   end
+
+  describe "#classes" do
+    let(:field) { Administrate::Field::Polymorphic.new(:foo, "hello", :show) }
+
+    context "not present in options" do
+      it "returns an empty array" do
+        allow(field).to receive(:options).and_return({})
+
+        expect(field.send(:classes)).to eq([])
+      end
+    end
+
+    context "present in options" do
+      it "returns an present value" do
+        classes = ["one", "two", "three"]
+        allow(field).to receive(:options).and_return(classes: classes)
+
+        expect(field.send(:classes)).to eq(classes)
+      end
+    end
+  end
 end


### PR DESCRIPTION
As stated in the [documentation](https://github.com/thoughtbot/administrate/commit/8329b214cea4eada8febbf1552dcbe7e3b9a9153#diff-6f1e8f63b36ca03a54fed082fc955a49R125), a `Field::Polymorphic` should default its classes to an empty array.

- [x] Default `classes` for a `Field::Polymorphic`
- [x] Add spec coverage