### PR TITLE
Update loofah from 2.2.0 to 2.2.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     kgio (2.11.2)
     launchy (2.4.3)
       addressable (~> 2.3)
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.0)


### PR DESCRIPTION
Name: loofah
Version: 2.2.0
Advisory: CVE-2018-8048
Criticality: Unknown
URL: https://github.com/flavorjones/loofah/issues/144
Title: Loofah XSS Vulnerability
Solution: upgrade to >= 2.2.1