### PR TITLE
include time for date_time field in index

### DIFF
--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -17,5 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= field.date %>
+  <%= field.datetime %>
 <% end %>

--- a/spec/administrate/views/fields/date_time/_index_spec.rb
+++ b/spec/administrate/views/fields/date_time/_index_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "fields/date_time/_index", type: :view do
+  it "renders date_time" do
+    product = create(:product)
+    date_time = instance_double(
+         "Administrate::Field::DateTime.with_options(format: #{Time::DATE_FORMATS[:default]})",
+         data: product,
+         datetime: product.created_at
+    )
+
+    render(
+        partial: "fields/date_time/index.html.erb",
+        locals: { field: date_time, namespace: "admin" },
+    )
+  end
+end

--- a/spec/administrate/views/fields/date_time/_index_spec.rb
+++ b/spec/administrate/views/fields/date_time/_index_spec.rb
@@ -4,14 +4,16 @@ describe "fields/date_time/_index", type: :view do
   it "renders date_time" do
     product = create(:product)
     date_time = instance_double(
-         "Administrate::Field::DateTime.with_options(format: #{Time::DATE_FORMATS[:default]})",
-         data: product,
-         datetime: product.created_at
+      "Administrate::Field::DateTime.with_options(
+        format: #{Time::DATE_FORMATS[:default]}
+      )",
+      data: product,
+      datetime: product.created_at,
     )
 
     render(
-        partial: "fields/date_time/index.html.erb",
-        locals: { field: date_time, namespace: "admin" },
+      partial: "fields/date_time/index.html.erb",
+      locals: { field: date_time, namespace: "admin" },
     )
   end
 end


### PR DESCRIPTION
#710 

Just modifies the index view template for the date_time field to display the time (as well as the date) as is being done in the show template.