### PR TITLE
Numbers are already searchable

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -10,7 +10,7 @@ require "administrate/dashboard/base"
 
 class CustomerDashboard < Administrate::Dashboard::Base
   ATTRIBUTE_TYPES = {
-    id: Field::Integer,
+    id: Field::Number,
     name: Field::String,
     email: Field::String,
     created_at: Field::DateTime,

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -146,6 +146,10 @@ association `has_many :cities`, from your model.
 
 **Field::Number**
 
+`:searchable` - Specify if the attribute should be considered when searching.
+Note that currently number fields are searched like text, which may yield
+more results than expected. Default is `false`.
+
 `:decimals` - Set the number of decimals to display. Defaults to `0`.
 
 `:prefix` - Prefixes the number with a string. Defaults to `""`.

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -2,7 +2,7 @@ require "administrate/base_dashboard"
 
 class OrderDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    id: Field::Number,
+    id: Field::Number.with_options(searchable: true),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     address_line_one: Field::String,

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -16,6 +16,20 @@ feature "Search" do
     expect(page).not_to have_content(mismatch.email)
   end
 
+  scenario "admin searches for order by id", :js do
+    # Long, predictable ids to avoid simple numbers matching more than one thing
+    target, *rest = 4.times.map{|i| create(:order, id: (i+1).to_s * 7) }.shuffle
+
+    visit admin_orders_path
+    fill_in :search, with: target.id
+    submit_search
+
+    expect(page).to have_css("table tr", text: order_row_match(target))
+    rest.each do |order|
+      expect(page).not_to have_css("table tr", text: order_row_match(order))
+    end
+  end
+
   scenario "admin searches across different fields", :js do
     query = "dan"
     name_match = create(:customer, name: "Dan Croak", email: "foo@bar.com")
@@ -67,5 +81,9 @@ feature "Search" do
 
   def submit_search
     page.execute_script("$('.search').submit()")
+  end
+
+  def order_row_match(order)
+    %r{#{order.id} #{order.customer.name} }
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -18,7 +18,8 @@ feature "Search" do
 
   scenario "admin searches for order by id", :js do
     # Long, predictable ids to avoid simple numbers matching more than one thing
-    target, *rest = 4.times.map{|i| create(:order, id: (i+1).to_s * 7) }.shuffle
+    orders = Array.new(4) { |i| create(:order, id: (i + 1).to_s * 7) }
+    target, *rest = orders.shuffle
 
     visit admin_orders_path
     fill_in :search, with: target.id

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -9,6 +9,7 @@ require "administrate/search"
 
 class MockDashboard
   ATTRIBUTE_TYPES = {
+    id: Administrate::Field::Number.with_options(searchable: true),
     name: Administrate::Field::String,
     email: Administrate::Field::Email,
     phone: Administrate::Field::Number,
@@ -68,8 +69,12 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "test")
         expected_query = [
-          'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?'\
-          ' OR LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          [
+            'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
+            'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?',
+            'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          ].join(" OR "),
+          "%test%",
           "%test%",
           "%test%",
         ]
@@ -89,8 +94,12 @@ describe Administrate::Search do
                                           MockDashboard,
                                           "Тест Test")
         expected_query = [
-          'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?'\
-          ' OR LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          [
+            'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
+            'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?',
+            'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          ].join(" OR "),
+          "%тест test%",
           "%тест test%",
           "%тест test%",
         ]

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
-require "administrate/field/string"
+require "administrate/field/belongs_to"
 require "administrate/field/email"
+require "administrate/field/has_many"
+require "administrate/field/has_one"
 require "administrate/field/number"
+require "administrate/field/string"
 require "administrate/search"
 
 class MockDashboard


### PR DESCRIPTION
PR https://github.com/thoughtbot/administrate/pull/1083 arose from a need to look up records by id. I was having a look at it, and realised that I'm not so sure it should be merged in its current state, as I'm starting to think that it looks a bit shoehorned, especially after the recent changes to the search code. I need more time to look into this, and I haven't had much of that lately.

While I was pondering this, I realised that it's already possible to search within number fields, by passing `searchable: true` as an argument to the field. This PR tests and documents this.

Note that this number search is not perfect. Since it searches through numbers as if they were text, it will match substrings of longer numbers, and similarly unexpected results. It will do for most cases though, so it's worth capturing it in the docs.