### PR TITLE
Make the resource action "show" optional

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -64,11 +64,14 @@ to display a collection of resources in an HTML table.
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if show_action? :show, resource -%>
-              <a href="<%= polymorphic_path([namespace, resource]) -%>"
-                 class="action-show"
-                 >
-                <%= render_field attribute %>
-              </a>
+              <%=
+                link_to_if(
+                  valid_action?(:show, resource.class),
+                  render_field(attribute),
+                  [namespace, resource],
+                  class: 'actions-show'
+                )
+              %>
             <% end -%>
           </td>
         <% end %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -16,7 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to(
+  <%= link_to_if(
+    valid_action?(:show, field.associated_class)),
     field.display_associated_resource,
     [namespace, field.data],
   ) %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -18,7 +18,8 @@ All fields of has_one relationship would be rendered
 <% if field.data %>
   <fieldset class="attribute--nested">
     <legend>
-      <%= link_to(
+      <%= link_to_if(
+        valid_action?(:show, field.associated_class)),
         field.display_associated_resource,
         [namespace, field.data],
       ) %>

--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -17,7 +17,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to(
+  <%= link_to_if(
+    valid_action?(:show, field.associated_class),
     field.display_associated_resource,
     [namespace, field.data]
   ) %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -17,7 +17,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.attribute) %>
+  <% if valid_action?(:show, field.associated_class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],


### PR DESCRIPTION
This will allow to omit show routes and actions for admin resources.

We should consider to make a conditionally change of update/create redirects to index action if no show action is not provided. It will be handy if administrate will be able to automatically handle the show action absence.