### PR TITLE
Make the resource action "show" optional

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -57,18 +57,21 @@ to display a collection of resources in an HTML table.
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           tabindex="0"
-          <% if valid_action? :show, collection_presenter.resource_name %>
+          <% if valid_action?(:show, collection_presenter.resource_name) %>
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if show_action? :show, resource -%>
-              <a href="<%= polymorphic_path([namespace, resource]) -%>"
-                 class="action-show"
-                 >
-                <%= render_field attribute %>
-              </a>
+              <%=
+                link_to_if(
+                  valid_action?(:show, collection_presenter.resource_name),
+                  render_field(attribute),
+                  [namespace, resource],
+                  class: "action-show",
+                )
+              %>
             <% end -%>
           </td>
         <% end %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -16,7 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to(
+  <%= link_to_if(
+    valid_action?(:show, field.associated_class),
     field.display_associated_resource,
     [namespace, field.data],
   ) %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -18,7 +18,8 @@ All fields of has_one relationship would be rendered
 <% if field.data %>
   <fieldset class="attribute--nested">
     <legend>
-      <%= link_to(
+      <%= link_to_if(
+        valid_action?(:show, field.associated_class),
         field.display_associated_resource,
         [namespace, field.data],
       ) %>

--- a/app/views/fields/polymorphic/_index.html.erb
+++ b/app/views/fields/polymorphic/_index.html.erb
@@ -17,7 +17,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%= link_to(
+  <%= link_to_if(
+    valid_action?(:show, field.attribute),
     field.display_associated_resource,
     [namespace, field.data]
   ) %>

--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -17,12 +17,9 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.attribute) %>
-    <%= link_to(
-      field.display_associated_resource,
-      [namespace, field.data],
-    ) %>
-  <% else %>
-    <%= field.display_associated_resource %>
-  <% end %>
+  <%= link_to_if(
+    valid_action?(:show, field.attribute),
+    field.display_associated_resource,
+    [namespace, field.data],
+  ) %>
 <% end %>

--- a/spec/administrate/views/application/_collection_spec.rb
+++ b/spec/administrate/views/application/_collection_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "administrate/application/_collection", type: :view do
+  let(:authorization_predicate) { true }
+  let(:default_namespace) { "admin" }
+
+  context "without valid show action" do
+    it "renders record attributes without show links" do
+      product = create(:product, name: "administrate")
+      product_path = polymorphic_path([:admin, product])
+      collection_presenter = double(
+        :collection_presenter,
+        attribute_types: {},
+        resource_name: "product",
+      )
+      name_attribute = double(
+        :name_attribute,
+        html_class: "string",
+      )
+      allow(collection_presenter).to receive(:attributes_for).
+        with(product).
+        and_return([name_attribute])
+      allow(view).to receive(:valid_action?).and_return(true)
+      allow(view).to receive(:valid_action?).
+        with(:show, "product").
+        and_return(false)
+      allow(view).to receive(:show_action?).and_return(authorization_predicate)
+      allow(view).to receive(:namespace).and_return(default_namespace)
+      allow(view).to receive(:render_field).
+        with(name_attribute).
+        and_return(product.name)
+
+      render(
+        "administrate/application/collection",
+        collection_presenter: collection_presenter,
+        resources: [product],
+        table_title: "page-title",
+      )
+
+      expect(rendered).to_not include(
+        "<a class=\"action-show\" href=\"#{product_path}\">#{product.name}</a>",
+      )
+    end
+
+    it "renders record row without js link" do
+      product = create(:product)
+      product_path = polymorphic_path([:admin, product])
+      collection_presenter = double(
+        :collection_presenter,
+        attribute_types: {},
+        resource_name: "product",
+      )
+      allow(collection_presenter).to receive(:attributes_for).
+        with(product).
+        and_return([])
+      allow(view).to receive(:valid_action?).and_return(true)
+      allow(view).to receive(:valid_action?).
+        with(:show, "product").
+        and_return(false)
+      allow(view).to receive(:show_action?).and_return(authorization_predicate)
+      allow(view).to receive(:namespace).and_return(default_namespace)
+
+      render(
+        "administrate/application/collection",
+        collection_presenter: collection_presenter,
+        resources: [product],
+        table_title: "page-title",
+      )
+
+      expect(rendered).to_not have_xpath("//tr[data-url=\"#{product_path}\"]")
+    end
+  end
+end

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -14,6 +14,26 @@ describe "fields/has_one/_index", type: :view do
     end
   end
 
+  context "without valid show action" do
+    it "renders record without a link" do
+      product = create(:product)
+      has_one = instance_double(
+        "Administrate::Field::HasOne",
+        data: product,
+        display_associated_resource: product.name,
+        associated_class: "Product",
+      )
+      allow(view).to receive(:valid_action?).and_return(false)
+
+      render(
+        partial: "fields/has_one/index.html.erb",
+        locals: { field: has_one, namespace: "admin" },
+      )
+
+      expect(rendered.strip).to eq(product.name)
+    end
+  end
+
   context "with an associated record" do
     it "renders a link to the record" do
       product = create(:product)
@@ -22,7 +42,9 @@ describe "fields/has_one/_index", type: :view do
         "Administrate::Field::HasOne",
         data: product,
         display_associated_resource: product.name,
+        associated_class: "Product",
       )
+      allow(view).to receive(:valid_action?).and_return(true)
 
       render(
         partial: "fields/has_one/index.html.erb",

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -19,6 +19,38 @@ describe "fields/has_one/_show", type: :view do
     end
   end
 
+  context "without valid show action" do
+    it "renders record without a link" do
+      product = create(:product)
+      product_path = polymorphic_path([:admin, product])
+      has_one = instance_double(
+        "Administrate::Field::HasOne",
+        display_associated_resource: product.name,
+        data: product,
+        nested_form: nested_form,
+        associated_class: "Product",
+      )
+      allow(view).to receive(:valid_action?).and_return(false)
+
+      render(
+        partial: "fields/has_one/show.html.erb",
+        locals: {
+          field: has_one,
+          namespace: "admin",
+          resource_name: "product_meta_tag",
+        },
+      )
+
+      link = "<a href=\"#{product_path}\">#{product.name}</a>"
+      field_name = "Meta Title"
+      field_value = "Very Nice Title"
+      expect(rendered.strip).to_not include(link)
+      expect(rendered.strip).to include(product.name)
+      expect(rendered.strip).to include(field_name)
+      expect(rendered.strip).to include(field_value)
+    end
+  end
+
   context "with an associated record" do
     it "renders a link to the record" do
       product = create(:product)
@@ -28,7 +60,9 @@ describe "fields/has_one/_show", type: :view do
         display_associated_resource: product.name,
         data: product,
         nested_form: nested_form,
+        associated_class: "Product",
       )
+      allow(view).to receive(:valid_action?).and_return(true)
 
       render(
         partial: "fields/has_one/show.html.erb",
@@ -46,20 +80,20 @@ describe "fields/has_one/_show", type: :view do
       expect(rendered.strip).to include(field_name)
       expect(rendered.strip).to include(field_value)
     end
+  end
 
-    def nested_form
-      instance_double(
-        "Administrate::Page::Show",
-        resource: double(
-          class: ProductMetaTag,
-        ),
-        attributes: [double(
-          html_class: "string",
-          name: "meta_title",
-          data: "Very Nice Title",
-        )],
-        resource_name: "Product Tag",
-      )
-    end
+  def nested_form
+    instance_double(
+      "Administrate::Page::Show",
+      resource: double(
+        class: ProductMetaTag,
+      ),
+      attributes: [double(
+        html_class: "string",
+        name: "meta_title",
+        data: "Very Nice Title",
+      )],
+     resource_name: "Product Tag",
+    )
   end
 end

--- a/spec/administrate/views/fields/polymorphic/_index_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_index_spec.rb
@@ -14,6 +14,26 @@ describe "fields/polymorphic/_index", type: :view do
     end
   end
 
+  context "without valid show action" do
+    it "renders record without a link" do
+      product = create(:product)
+      polymorphic = instance_double(
+        "Administrate::Field::Polymorphic",
+        data: product,
+        display_associated_resource: product.name,
+        attribute: "productable",
+      )
+      allow(view).to receive(:valid_action?).and_return(false)
+
+      render(
+        partial: "fields/polymorphic/index.html.erb",
+        locals: { field: polymorphic, namespace: "admin" },
+      )
+
+      expect(rendered.strip).to eq(product.name)
+    end
+  end
+
   context "with an associated record" do
     it "renders a link to the record" do
       product = create(:product)
@@ -22,7 +42,9 @@ describe "fields/polymorphic/_index", type: :view do
         "Administrate::Field::Polymorphic",
         data: product,
         display_associated_resource: product.name,
+        attribute: "productable",
       )
+      allow(view).to receive(:valid_action?).and_return(true)
 
       render(
         partial: "fields/polymorphic/index.html.erb",

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -20,6 +20,27 @@ describe "fields/polymorphic/_show", type: :view do
     end
   end
 
+  context "without valid show action" do
+    it "renders record without a link" do
+      product = create(:product)
+      polymorphic = instance_double(
+        "Administrate::Field::Polymorphic",
+        display_associated_resource: product.name,
+        associated_class: "Product",
+        data: product,
+        attribute: "product",
+      )
+      allow(view).to receive(:valid_action?).and_return(false)
+
+      render(
+        partial: "fields/polymorphic/show.html.erb",
+        locals: { field: polymorphic, namespace: "admin" },
+      )
+
+      expect(rendered.strip).to eq(product.name)
+    end
+  end
+
   context "with an associated record" do
     it "renders a link to the record" do
       product = create(:product)
@@ -27,10 +48,10 @@ describe "fields/polymorphic/_show", type: :view do
       polymorphic = instance_double(
         "Administrate::Field::Polymorphic",
         display_associated_resource: product.name,
+        associated_class: "Product",
         data: product,
         attribute: "product",
       )
-
       allow(view).to receive(:valid_action?).and_return(true)
 
       render(


### PR DESCRIPTION
This will allow to ommit show routes and actions
for admin resources.

Consider to conditionally change update/create redirects
to index action if no show action provided.