### PR TITLE
Support Rails 5.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -19,3 +19,9 @@ appraise "rails51" do
   gem "actionview", "~> 5.1.0"
   gem "activerecord", "~> 5.1.0"
 end
+
+appraise "rails52" do
+  gem "actionpack", "~> 5.2.0"
+  gem "actionview", "~> 5.2.0"
+  gem "activerecord", "~> 5.2.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     administrate (0.9.0)
-      actionpack (>= 4.2, < 5.2)
-      actionview (>= 4.2, < 5.2)
-      activerecord (>= 4.2, < 5.2)
+      actionpack (>= 4.2, < 6.0)
+      actionview (>= 4.2, < 6.0)
+      activerecord (>= 4.2, < 6.0)
       autoprefixer-rails (>= 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (>= 4.0)
@@ -97,7 +97,7 @@ GEM
       i18n (>= 0.7)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21)
+    ffi (1.9.23)
     formulaic (0.4.0)
       activesupport
       capybara
@@ -144,7 +144,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    momentjs-rails (2.17.1)
+    momentjs-rails (2.20.1)
       railties (>= 3.1)
     multipart-post (2.0.0)
     nokogiri (1.8.2)
@@ -184,7 +184,7 @@ GEM
       rake
     raindrops (0.19.0)
     rake (12.3.0)
-    rb-fsevent (0.10.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
@@ -206,7 +206,7 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     safe_yaml (1.0.4)
-    sass (3.5.5)
+    sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,docs}/**/*", "LICENSE", "Rakefile"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "actionpack", ">= 4.2", "< 5.2"
-  s.add_dependency "actionview", ">= 4.2", "< 5.2"
-  s.add_dependency "activerecord", ">= 4.2", "< 5.2"
+  s.add_dependency "actionpack", ">= 4.2", "< 6.0"
+  s.add_dependency "actionview", ">= 4.2", "< 6.0"
+  s.add_dependency "activerecord", ">= 4.2", "< 6.0"
 
   s.add_dependency "autoprefixer-rails", ">= 6.0"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -11,4 +11,40 @@ module ControllerHelpers
     end
     locals
   end
+
+  def use_new_params_syntax?
+    Rails::VERSION::STRING >= "5.2"
+  end
+
+  def get(method, params = {})
+    if use_new_params_syntax?
+      super(method, params: params)
+    else
+      super
+    end
+  end
+
+  def post(method, params = {})
+    if use_new_params_syntax?
+      super(method, params: params)
+    else
+      super
+    end
+  end
+
+  def put(method, params = {})
+    if use_new_params_syntax?
+      super(method, params: params)
+    else
+      super
+    end
+  end
+
+  def delete(method, params = {})
+    if use_new_params_syntax?
+      super(method, params: params)
+    else
+      super
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1133.  I took the change from #1135, added an Appraisal for Rails 5.2, and handled an issue where `rspec-rails` requires controller specs to pass the request params in a different way, starting with Rails 5.2.  Admittedly, this feels like a hacky solution, but it does get us to a passing build.