### PR TITLE
There's a spec that requires consistent ordering here

### DIFF
--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -7,7 +7,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     email_subscriber: Field::Boolean,
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
     name: Field::String,
-    orders: Field::HasMany.with_options(limit: 2),
+    orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
     country: Field::BelongsTo.with_options(

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "customer show page" do
-  describe "displays the customers orders paginated" do
+  describe "paginates customers' orders" do
     it "displays the first page by default, other pages when specified" do
       customer = create(:customer)
       orders = create_list(:order, 4, customer: customer)


### PR DESCRIPTION
https://github.com/thoughtbot/administrate/issues/1114 points out that `spec/features/show_page_spec.rb:28` may fail randomly (rarely, but it can). This is probably because the spec navigates a paginated list, but we are not specifying an order for this list.

This should fix the problem... if that is indeed the issue here. We can revisit if we see this failing randomly again.

Additionally, I rephrased that spec's description, to something that sounded a bit better to me.