### PR TITLE
Don't show navigation items if the user can't view the collection anyway

### DIFF
--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -9,10 +9,12 @@ as defined by the routes in the `admin/` namespace
 
 <nav class="navigation" role="navigation">
   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
-    <%= link_to(
-      display_resource_name(resource),
-      [namespace, resource_index_route_key(resource)],
-      class: "navigation__link navigation__link--#{nav_link_state(resource)}"
-    ) %>
+    <% if show_action? :index, class_from_resource(resource) %>
+      <%= link_to(
+        display_resource_name(resource),
+        [namespace, resource_index_route_key(resource)],
+        class: "navigation__link navigation__link--#{nav_link_state(resource)}"
+      ) %>
+    <% end %>
   <% end %>
 </nav>

--- a/spec/administrate/views/application/_navigation_spec.rb
+++ b/spec/administrate/views/application/_navigation_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "application/_navigation", type: :view do
+  let(:namespace) { "admin" }
+  let(:resource_name) { "Products" }
+
+  before(:each) do
+    allow(view).to receive(:display_resource_name) { |name| name.to_s.titleize }
+    allow(view).to receive(:class_from_resource) { |resource| resource }
+    allow(view).to receive(:resource_index_route_key) { Product }
+    allow(view).to receive(:nav_link_state) { :inactive }
+  end
+
+  context "if you are allowed to view this resource index" do
+    it "displays link" do
+      allow(view).to receive(:show_action?).and_return(true)
+      render_navigation
+      expect(view).to have_received(:display_resource_name).at_least(:once)
+      expect(rendered.strip).to include(resource_name)
+    end
+  end
+
+  context "if you are not allowed to view this resource index" do
+    it "doesn't display the link" do
+      allow(view).to receive(:show_action?).and_return(false)
+      render_navigation
+      expect(view).not_to have_received(:display_resource_name)
+      expect(rendered.strip).not_to include(resource_name)
+    end
+  end
+
+  def render_navigation
+    render(
+      partial: "administrate/application/navigation",
+      locals: { namespace: namespace },
+    )
+  end
+end


### PR DESCRIPTION
Per discussion on #1111, removes items from the left navigation if you aren't allowed the `index?` action on them.

I'm not 100% happy with the test for this, but this didn't fit well with the feature specs that were already in the app and I didn't want to drag a huge change into a small feature. Let me know if they still need work (and a hint of what you'd prefer would be appreciated).

Thanks!