### PR TITLE
Add id HTML attribute for rows on resources index page

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -55,7 +55,8 @@ to display a collection of resources in an HTML table.
 
   <tbody>
     <% resources.each do |resource| %>
-      <tr class="js-table-row"
+      <tr id="<%= dom_id(resource) %>"
+          class="js-table-row"
           tabindex="0"
           <% if valid_action? :show, collection_presenter.resource_name %>
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -14,7 +14,7 @@ module Features
   private
 
   def row_css_for(model)
-    "tr[data-url='#{url_for(model)}']"
+    "tr[id='#{model.model_name.param_key}_#{model.to_key.join('_')}']"
   end
 
   def clickable_table_elements
@@ -23,13 +23,5 @@ module Features
 
   def show_link_elements
     ".action-show"
-  end
-
-  def url_for(model)
-    "/" + [
-      :admin,
-      model.class.to_s.underscore.pluralize,
-      model.to_param,
-    ].join("/")
   end
 end


### PR DESCRIPTION
This change will allow referencing rows by id not by data-url which will be useful when a resource will not have show action and will have no data-url.