### PR TITLE
Allow parameters that are more permissive

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -33,11 +33,11 @@ module Administrate
     end
 
     def sanitized_order_params
-      params.permit(:search, :id, :order, :page, :per_page, :direction, :orders)
+      params.permit!
     end
 
     def clear_search_params
-      params.except(:search, :page).permit(:order, :direction, :per_page)
+      params.except(:search, :page).permit!
     end
   end
 end


### PR DESCRIPTION
When using the Clearance gem's backdoor to access views in
administrate, tests prematurely break because of the `as` parameter
used to do quick sign in. While it's probably fair that we don't want
persist that parameter through the GET request, it shouldn't matter
what parameters we pass in a GET request.

* Use `permit!` to allow anything through on a GET request