### PR TITLE
Update bundle to fix tests on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks"
   gem "pry-rails"
+  gem "puma"
   gem "rspec-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,13 +62,13 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (10.0.0)
-    capybara (2.18.0)
+    capybara (3.1.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
     cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -152,8 +152,8 @@ GEM
     parser (2.5.0.0)
       ast (~> 2.4.0)
     pg (0.21.0)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
+    poltergeist (1.18.0)
+      capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     pry (0.11.3)
@@ -162,10 +162,11 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.2)
+    puma (3.11.4)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.4)
-    rack-test (0.8.2)
+    rack (2.0.5)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rack-timeout (0.4.2)
     rails-dom-testing (2.0.3)
@@ -277,6 +278,7 @@ DEPENDENCIES
   pg (= 0.21.0)
   poltergeist
   pry-rails
+  puma
   pundit
   rack-timeout
   rails_stdout_logging

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -85,6 +85,6 @@ feature "Search" do
   end
 
   def order_row_match(order)
-    %r{#{order.id} #{order.customer.name} }
+    %r{#{order.id}\t #{order.customer.name}\t }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,8 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
+
+Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :poltergeist
 Capybara.register_driver :poltergeist do |app|
   options = { phantomjs_options: ["--load-images=no"] }


### PR DESCRIPTION
It actually requires only Capybara to be updated, but why not update all then.

I don't know if there is any difference which `Capybara.server` to use. Webrick just don't need adding new dependency to Gemfile.