### PR TITLE
Change Albanian two-letter code to "sq" as per ISO 639-1

### DIFF
--- a/config/locales/administrate.sq.yml
+++ b/config/locales/administrate.sq.yml
@@ -1,5 +1,5 @@
 ---
-al:
+sq:
   administrate:
     actions:
       confirm: A jeni te sigurtë?


### PR DESCRIPTION
It would be logical if language codes correspond ISO 639-1.