### PR TITLE
Demonstrate / test controller #scoped_resource override

### DIFF
--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -9,6 +9,14 @@ describe Admin::CustomersController, type: :controller do
       expect(locals[:resources]).to eq([customer])
     end
 
+    it "applies any scope overrides" do
+      _hidden_customer = create(:customer, hidden: true)
+      visible_customer = create(:customer, hidden: false)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:resources]).to contain_exactly visible_customer
+    end
+
     it "passes the search term to the view" do
       locals = capture_view_locals do
         get :index, search: "foo"

--- a/spec/example_app/app/controllers/admin/customers_controller.rb
+++ b/spec/example_app/app/controllers/admin/customers_controller.rb
@@ -1,2 +1,7 @@
 class Admin::CustomersController < Admin::ApplicationController
+  private
+
+  def scoped_resource
+    Customer.where(hidden: false)
+  end
 end

--- a/spec/example_app/db/migrate/20180525115059_add_hidden_to_customers.rb
+++ b/spec/example_app/db/migrate/20180525115059_add_hidden_to_customers.rb
@@ -1,0 +1,5 @@
+class AddHiddenToCustomers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :customers, :hidden, :boolean, default: false, null: false
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031155447) do
+ActiveRecord::Schema.define(version: 20180525115059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20171031155447) do
     t.string "country_code"
     t.time "example_time"
     t.string "password"
+    t.boolean "hidden", default: false, null: false
   end
 
   create_table "line_items", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Relating to #320, this test demos how to provide a custom scope for the resources displayed in an Administrate controller's `#index` action.