### PR TITLE
Configure Capybara to use webrick

### DIFF
--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -85,6 +85,6 @@ feature "Search" do
   end
 
   def order_row_match(order)
-    %r{#{order.id} #{order.customer.name} }
+    /#{order.id}\s+#{order.customer.name}\s+/
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,3 +36,5 @@ Capybara.register_driver :poltergeist do |app|
   options = { phantomjs_options: ["--load-images=no"] }
   Capybara::Poltergeist::Driver.new(app, options)
 end
+
+Capybara.server = :webrick


### PR DESCRIPTION
Capybara 3.x switches to Puma by default, which breaks the build because the Appraisal gemfiles don't specify a Capybara version, yet don't include Puma.