### PR TITLE
Return a 404 when docs pages are not found.

### DIFF
--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -5,19 +5,36 @@ class DocsController < ApplicationController
   }.freeze
 
   def index
-    render_markdown "README"
+    render_page "README"
   end
 
   def show
-    render_markdown "docs/#{params[:page]}"
+    render_page "docs/#{params[:page]}"
   end
 
   private
 
-  def render_markdown(file)
-    text = File.read(Rails.root + "../../#{file}.md")
+  def render_page(name)
+    path = full_page_path(name)
+
+    if File.exist?(path)
+      render layout: "docs", html: render_markdown(path).html_safe
+    else
+      render file: "#{Rails.root}/public/404.html",
+             layout: false,
+             status: :not_found
+    end
+  end
+
+  def full_page_path(page)
+    Rails.root + "../../#{page}.md"
+  end
+
+  def render_markdown(path)
+    text = File.read(path)
     renderer = Redcarpet::Render::HTML
     markdown = Redcarpet::Markdown.new(renderer, REDCARPET_CONFIG)
-    render layout: "docs", html: markdown.render(text).html_safe
+
+    markdown.render(text)
   end
 end

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 describe "documentation navigation" do
+  it "shows a 404 for missing pages" do
+    visit "not_a_page"
+
+    expect(page).to have_http_status(:not_found)
+  end
+
   it "links to each documentation page" do
     visit root_path
     links = internal_documentation_links


### PR DESCRIPTION
Safari, at least, always tries to load a `apple-touch-icon.png` which
`DocumentationController` tries to find and render as markdown. This
leads to the prototype app having a lot of odd errors.