### PR TITLE
Refactor ApplicationController#index

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -3,13 +3,6 @@ module Administrate
     protect_from_forgery with: :exception
 
     def index
-      search_term = params[:search].to_s.strip
-      resources = Administrate::Search.new(scoped_resource,
-                                           dashboard_class,
-                                           search_term).run
-      resources = apply_resource_includes(resources)
-      resources = order.apply(resources)
-      resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
       render locals: {
@@ -123,6 +116,22 @@ module Administrate
 
     def scoped_resource
       resource_class.default_scoped
+    end
+    
+    def search_term
+      params[:search].to_s.strip
+    end
+    
+    def resources
+      resources = Administrate::Search.new(
+        scoped_resource,
+        dashboard_class,
+        search_term
+      ).run
+      
+      resources = apply_resource_includes(resources)
+      resources = order.apply(resources)
+      resources.page(params[:page]).per(records_per_page)
     end
 
     def apply_resource_includes(relation)

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -117,7 +117,7 @@ module Administrate
     def scoped_resource
       resource_class.default_scoped
     end
-    
+
     def search_term
       params[:search].to_s.strip
     end

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -126,7 +126,7 @@ module Administrate
       resources = Administrate::Search.new(
         scoped_resource,
         dashboard_class,
-        search_term
+        search_term,
       ).run
 
       resources = apply_resource_includes(resources)

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -121,14 +121,14 @@ module Administrate
     def search_term
       params[:search].to_s.strip
     end
-    
+
     def resources
       resources = Administrate::Search.new(
         scoped_resource,
         dashboard_class,
         search_term
       ).run
-      
+
       resources = apply_resource_includes(resources)
       resources = order.apply(resources)
       resources.page(params[:page]).per(records_per_page)


### PR DESCRIPTION
This PR refactors `ApplicationController#index` as it's doing too much work. I moved `resources` and `search_term` to their own methods.

Note: It seems there are some vulnerabilities in a couple of gems that are causing the specs to fail.