### PR TITLE
Switch to sassc-rails.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise "sass-3-4" do
-  gem "sass", "~> 3.4"
-end
-
 appraise "rails42" do
   gem "actionpack", "~> 4.2.0"
   gem "actionview", "~> 4.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
       momentjs-rails (~> 2.8)
-      sass-rails (~> 5.0)
+      sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
 
 GEM
@@ -106,7 +106,7 @@ GEM
       i18n
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hashdiff (0.3.7)
+    hashdiff (0.3.8)
     highline (2.0.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -188,9 +188,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     redcarpet (3.4.0)
     regexp_parser (1.4.0)
     rspec-core (3.8.0)
@@ -210,18 +207,16 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    safe_yaml (1.0.4)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    safe_yaml (1.0.5)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.0)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selectize-rails (0.12.6)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
@@ -296,4 +291,4 @@ DEPENDENCIES
   xpath (= 3.2.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
   s.add_dependency "momentjs-rails", "~> 2.8"
-  s.add_dependency "sass-rails", "~> 5.0"
+  s.add_dependency "sassc-rails", "~> 2.1"
   s.add_dependency "selectize-rails", "~> 0.6"
 
   s.description = <<-DESCRIPTION

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -2,7 +2,7 @@ require "datetime_picker_rails"
 require "jquery-rails"
 require "kaminari"
 require "momentjs-rails"
-require "sass-rails"
+require "sassc-rails"
 require "selectize-rails"
 require "sprockets/railtie"
 


### PR DESCRIPTION
Ruby Sass will reach end of life on 26th Match 2019. This switches to
`sassc-rails` and drops the appraisal for Sass 3.4.

Currently, `sassc-rails` still has `sass` as a dependency hence this is still
included in the `Gemfile.lock`.

See: https://github.com/rails/sass-rails/issues/420

Fixes #1196.