### PR TITLE
Update customizing_dashboards doc

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -135,9 +135,9 @@ Default is `false`.
 For example:
 
 ```ruby
-  cities: Field::HasMany(
+  cities: Field::HasMany.with_options(
     searchable: true,
-    seachable_field: 'name',
+    searchable_field: 'name',
   )
 ```
 
@@ -262,7 +262,7 @@ en:
     models:
       customer:
         one: Happy Customer
-        others: Happy Customers
+        other: Happy Customers
 ```
 
 ## Customizing Actions


### PR DESCRIPTION
Details:
- fix typos,
- add missing `.with_options` to `Field::BelongsTo` example