### PR TITLE
Fix error in suggested translation key

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -262,7 +262,7 @@ en:
     models:
       customer:
         one: Happy Customer
-        others: Happy Customers
+        other: Happy Customers
 ```
 
 ## Customizing Actions


### PR DESCRIPTION
Rails expects `other` key and not `others`.