### PR TITLE
Fix typo in customizing_dashboards.md

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -98,7 +98,7 @@ For example:
 ```ruby
   country: Field::BelongsTo.with_options(
     searchable: true,
-    seachable_field: 'name',
+    searchable_field: 'name',
   )
 ```
 


### PR DESCRIPTION
There is a typo in the Field::BelongsTo searchable example causing copy paste code to fail