### PR TITLE
Adds missing colon to name resouces on admin namespace of Rails API e…

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -149,7 +149,7 @@ You must also ensure that the all the required controller actions are available 
 ```ruby
 # routes.rb
 namespace :admin do
-  resources name, only: %i(index show new create edit update destroy)
+  resources :name, only: %i(index show new create edit update destroy)
 end
 
 # names_controller.rb


### PR DESCRIPTION
There is a missing semicolon in a controller name of Rails API settings that results in an error since it is a symbol