### PR TITLE
Update ffi from 1.9.23 to 1.9.25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
   ruby-2.3:
     <<: *default_job
     docker:
-      - image: circleci/ruby:2.3-node-browsers
+      - image: circleci/ruby:2.3-node-browsers-legacy
         environment:
           PGHOST: localhost
           PGUSER: administrate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       i18n (>= 0.7)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     formulaic (0.4.0)
       activesupport
       capybara


### PR DESCRIPTION
Name: ffi
Version: 1.9.23
Advisory: CVE-2018-1000201
Criticality: High
URL: https://github.com/ffi/ffi/releases/tag/1.9.24
Title: ruby-ffi DDL loading issue on Windows OS
Solution: upgrade to >= 1.9.24