### PR TITLE
Test/demo scope overrides and update comments

### DIFF
--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -28,9 +28,10 @@ class Admin::FoosController < Admin::ApplicationController
   # def find_resource(param)
   #   Foo.find_by!(slug: param)
   # end
-  #
+
   # Override this if you have certain roles that require a subset
   # this will be used to set the records shown on the `index` action.
+  #
   # def scoped_resource
   #  if current_user.super_admin?
   #    resource_class

--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,18 +1,31 @@
 module <%= namespace.classify %>
   class <%= class_name.pluralize %>Controller < <%= namespace.classify %>::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
     #
-    # def index
-    #   super
-    #   @resources = <%= class_name %>.
-    #     page(params[:page]).
-    #     per(10)
+    # def update
+    #   foo = Foo.find(params[:id])
+    #   foo.update(params[:foo])
+    #   send_foo_updated_email
     # end
 
-    # Define a custom finder by overriding the `find_resource` method:
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
     # def find_resource(param)
-    #   <%= class_name %>.find_by!(slug: param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #  if current_user.super_admin?
+    #    resource_class
+    #  else
+    #    resource_class.with_less_stuff
+    #  end
     # end
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -9,6 +9,14 @@ describe Admin::CustomersController, type: :controller do
       expect(locals[:resources]).to eq([customer])
     end
 
+    it "applies any scope overrides" do
+      _hidden_customer = create(:customer, hidden: true)
+      visible_customer = create(:customer, hidden: false)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:resources]).to contain_exactly visible_customer
+    end
+
     it "passes the search term to the view" do
       locals = capture_view_locals do
         get :index, search: "foo"

--- a/spec/example_app/app/controllers/admin/customers_controller.rb
+++ b/spec/example_app/app/controllers/admin/customers_controller.rb
@@ -1,2 +1,7 @@
 class Admin::CustomersController < Admin::ApplicationController
+  private
+
+  def scoped_resource
+    Customer.where(hidden: false)
+  end
 end

--- a/spec/example_app/db/migrate/20180525115059_add_hidden_to_customers.rb
+++ b/spec/example_app/db/migrate/20180525115059_add_hidden_to_customers.rb
@@ -1,0 +1,5 @@
+class AddHiddenToCustomers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :customers, :hidden, :boolean, default: false, null: false
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031155447) do
+ActiveRecord::Schema.define(version: 20180525115059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20171031155447) do
     t.string "country_code"
     t.time "example_time"
     t.string "password"
+    t.boolean "hidden", default: false, null: false
   end
 
   create_table "line_items", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Relating to #320, this test demos how to provide a custom scope for the resources displayed in an Administrate controller's `#index` action.

It also updates the comments in the controller template which are out of date; referencing instance variables (such as `@resources`) which aren't in use any more (pointed out by @vasco [here](https://github.com/thoughtbot/administrate/issues/320#issuecomment-421645553)).

This PR replaces #1167