### PR TITLE
Update nokogiri from 1.8.4 to 1.8.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parser (2.5.1.2)
       ast (~> 2.4.0)


### PR DESCRIPTION
Now CircleCI build failed due to nokogiri vulnerability, so fix it.
fail build -> https://circleci.com/gh/thoughtbot/administrate/3789 etc.

```
Name: nokogiri
Version: 1.8.4
Advisory: CVE-2018-14404
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1785
Title: Nokogiri gem, via libxml2, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.8.5

Vulnerabilities found!
```