### PR TITLE
Fix Time fields bug which occurs when Time value is nil

### DIFF
--- a/app/views/fields/time/_index.html.erb
+++ b/app/views/fields/time/_index.html.erb
@@ -14,4 +14,6 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= field.data.strftime("%I:%M%p").to_s %>
+<% if field.data %>
+  <%= field.data.strftime("%I:%M%p").to_s %>
+<% end %>

--- a/app/views/fields/time/_show.html.erb
+++ b/app/views/fields/time/_show.html.erb
@@ -14,4 +14,6 @@ By default, the attribute is rendered as a text tag.
 
 %>
 
-<%= field.data.strftime("%I:%M%p").to_s %>
+<% if field.data %>
+  <%= field.data.strftime("%I:%M%p").to_s %>
+<% end %>

--- a/spec/administrate/views/fields/time/_index_spec.rb
+++ b/spec/administrate/views/fields/time/_index_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe "fields/time/_index", type: :view do
+  context "time value is nil" do
+    it "display nothing" do
+      time = double(data: nil)
+
+      render(
+        partial: "fields/time/index.html.erb",
+        locals: { field: time },
+      )
+
+      expect(rendered.strip).to eq("")
+    end
+  end
+  context "time value is set" do
+    it "renders time" do
+      example_time = "12:34:00"
+      customer = create(:customer, example_time: example_time)
+      time = instance_double(
+        "Administrate::Field::Time",
+        data: customer.example_time,
+      )
+      render(
+        partial: "fields/time/index.html.erb",
+        locals: { field: time, namespace: "admin" },
+      )
+
+      expect(rendered.strip).to eq("12:34PM")
+    end
+  end
+end


### PR DESCRIPTION
When there are null-allowed Time column on DB,
https://github.com/thoughtbot/administrate/blob/8d86f9f0833aed9394ef1bd1f0edef1de4e89b83/app/views/fields/time/_index.html.erb#L17

This code can raise error, because`undefined method 'strftime' for nil:NilClass` if `field.data` is nil

so I add code to check if time value is nill and some specs

please check it.


and,
CircleCi tests failed due to dependencies vulnerability.
please check this, too. https://github.com/thoughtbot/administrate/pull/1225