### PR TITLE
Translate resource name for create link on index page.

### DIFF
--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -44,7 +44,7 @@ It renders the `_table` partial to display details about the resources.
     <%= link_to(
       t(
         "administrate.actions.new_resource",
-        name: page.resource_name.titleize.downcase
+        name: class_from_resource(page.resource_name).model_name.human
       ),
       [:new, namespace, page.resource_path],
       class: "button",

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -18,7 +18,7 @@ to do the heavy lifting.
 <% content_for(:title) do %>
   <%= t(
     "administrate.actions.new_resource",
-    name: display_resource_name(page.resource_name).titleize
+    name: class_from_resource(page.resource_name).model_name.human
   ) %>
 <% end %>
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -44,7 +44,7 @@ describe "customer index page" do
 
   it "links to the new page" do
     visit admin_customers_path
-    click_on("New customer")
+    click_on("New Customer")
 
     expect(current_path).to eq(new_admin_customer_path)
   end

--- a/spec/features/line_items_spec.rb
+++ b/spec/features/line_items_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe "line item index page" do
 
   it "links to the new page" do
     visit admin_line_items_path
-    click_on("New line item")
+    click_on("New Line item")
 
-    expect(page).to have_header("New Line Item")
+    expect(page).to have_header("New Line item")
   end
 
   it "links back to line items" do
     visit admin_line_items_path
-    click_on("New line item")
+    click_on("New Line item")
 
     click_on("Back")
 

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -43,7 +43,7 @@ feature "log entries index page" do
 
   scenario "user clicks through to the new page" do
     visit admin_log_entries_path
-    click_on("New log entry")
+    click_on("New Log entry")
 
     expect(current_path).to eq(new_admin_log_entry_path)
   end

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -40,7 +40,7 @@ feature "order index page" do
 
   scenario "user clicks through to the new page" do
     visit admin_orders_path
-    click_on("New order")
+    click_on("New Order")
 
     expect(current_path).to eq(new_admin_order_path)
   end

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "product index page" do
 
   it "links to the new page" do
     visit admin_products_path
-    click_on("New product")
+    click_on("New Product")
 
     expect(current_path).to eq(new_admin_product_path)
   end


### PR DESCRIPTION
I am using administrate in ja local and realize resource name is not translated.
Can we replace it with translated ?

Place I meant here. (It is en local but)
![image](https://user-images.githubusercontent.com/7892834/47403951-73038480-d786-11e8-97ae-969fd680743b.png)
