### PR TITLE
Pin the XPath gem, until we can drop Ruby 2.2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,11 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "poltergeist"
+  gem "pundit"
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
-  gem "pundit"
+  gem "xpath", "3.1.0"
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ DEPENDENCIES
   uglifier
   unicorn
   webmock
+  xpath (= 3.1.0)
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
Any `path` versions above 3.1.0 require a newer Ruby than 2.2.0, which
we will support in line with Rails requirements.