### PR TITLE
Pin the capybara gem, until we can drop Ruby 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 
 group :test do
   gem "ammeter"
+  gem "capybara", "2.18.0"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,7 @@ DEPENDENCIES
   awesome_print
   bundler-audit
   byebug
+  capybara (= 2.18.0)
   database_cleaner
   dotenv-rails
   factory_bot_rails


### PR DESCRIPTION
Any `capybara` versions above 3.0.0 require a newer Ruby than 2.2.0, which
we will support in line with Rails requirements.