### PR TITLE
Pin `i18n-tasks`, until we can drop Ruby 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks"
+  gem "i18n-tasks", "0.9.24"
   gem "pry-rails"
   gem "rspec-rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ DEPENDENCIES
   faker
   formulaic
   globalid
-  i18n-tasks
+  i18n-tasks (= 0.9.24)
   launchy
   pg (= 0.21.0)
   poltergeist


### PR DESCRIPTION
Any `i18n-tasks` versions above 0.9.24 require a newer Ruby than 2.2.0, which
we will support in line with Rails requirements.