### PR TITLE
Fix Typo In Getting Started Guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,7 +144,7 @@ config.middleware.use ActionDispatch::Session::CookieStore, config.session_optio
 config.middleware.use ::Rack::MethodOverride
 ```
 
-You must also ensure that the all the required controller actions are available and accessible as routes since generators in API-only applications only generate some of the required actions. Here is an example:
+You must also ensure that all the required controller actions are available and accessible as routes since generators in API-only applications only generate some of the required actions. Here is an example:
 
 ```ruby
 # routes.rb


### PR DESCRIPTION
Fixes a small typo in the getting started guide.