### PR TITLE
Use Show Page Attributes When Rendering a has_one Relationship On Another Record's Show Page

### DIFF
--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -4,7 +4,7 @@
 This partial renders a has_one relationship,
 to be displayed on a resource's show page.
 
-All fields of has_one relationship would be rendered
+All show page attributes of has_one relationship would be rendered
 
 ## Local variables:
 
@@ -23,7 +23,7 @@ All fields of has_one relationship would be rendered
         [namespace, field.data],
       ) %>
     </legend>
-    <% field.nested_form.attributes.each do |attribute| -%>
+    <% field.nested_show.attributes.each do |attribute| -%>
       <div>
       <dt class="attribute-label">
         <%= t(
@@ -32,7 +32,7 @@ All fields of has_one relationship would be rendered
         ) %>
       </dt>
       <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
-        <%= attribute.data %>
+        <%= render_field attribute %>
       </dd>
       </div>
     <% end -%>

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -24,6 +24,13 @@ module Administrate
         )
       end
 
+      def nested_show
+        @nested_show ||= Administrate::Page::Show.new(
+          resolver.dashboard_class.new,
+          data || resolver.resource_class.new,
+        )
+      end
+
       private
 
       def resolver

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -27,7 +27,7 @@ describe "fields/has_one/_show", type: :view do
         "Administrate::Field::HasOne",
         display_associated_resource: product.name,
         data: product,
-        nested_form: nested_form,
+        nested_show: nested_show,
       )
 
       render(
@@ -40,24 +40,16 @@ describe "fields/has_one/_show", type: :view do
       )
 
       link = "<a href=\"#{product_path}\">#{product.name}</a>"
-      field_name = "Meta Title"
-      field_value = "Very Nice Title"
       expect(rendered.strip).to include(link)
-      expect(rendered.strip).to include(field_name)
-      expect(rendered.strip).to include(field_value)
     end
 
-    def nested_form
+    def nested_show
       instance_double(
         "Administrate::Page::Show",
         resource: double(
           class: ProductMetaTag,
         ),
-        attributes: [double(
-          html_class: "string",
-          name: "meta_title",
-          data: "Very Nice Title",
-        )],
+        attributes: [],
         resource_name: "Product Tag",
       )
     end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -9,12 +9,29 @@ describe Administrate::Field::HasOne do
   describe "#nested_form" do
     it "returns a form" do
       product_meta_tag = double
-      field = Administrate::Field::HasOne.new(:product_meta_tag,
-        product_meta_tag, :show)
-
+      field = Administrate::Field::HasOne.new(
+        :product_meta_tag,
+        product_meta_tag,
+        :show,
+      )
       form = field.nested_form
 
       expect(form).to be_present
+    end
+  end
+
+  describe "#nested_show" do
+    it "returns a Show" do
+      product_meta_tag = double
+      field = Administrate::Field::HasOne.new(
+        :product_meta_tag,
+        product_meta_tag,
+        :show,
+      )
+
+      show = field.nested_show
+
+      expect(show).to be_a(Administrate::Page::Show)
     end
   end
 
@@ -36,9 +53,11 @@ describe Administrate::Field::HasOne do
     it "returns a partial based on the page being rendered" do
       page = :show
       product_meta_tag = double
-      field = Administrate::Field::HasOne.new(:product_meta_tag,
-        product_meta_tag, page)
-
+      field = Administrate::Field::HasOne.new(
+        :product_meta_tag,
+        product_meta_tag,
+        :show,
+      )
       path = field.to_partial_path
 
       expect(path).to eq("/fields/has_one/#{page}")


### PR DESCRIPTION
When rendering a `has_one` relationship on the show page for a record, we're presently displaying the form attributes of the child record (as defined in the `FORM_ATTRIBUTES` constant from the child record's dashboard file).

I think it makes more sense to use the child record's show page attributes (as defined in the `SHOW_PAGE_ATTRIBUTES` constant from the child record's dashboard file). That just fits better when rendering a record on a show page.

Furthermore, using the form attributes can lead to displaying odd attributes such as "Password Confirmation".

This pull request makes the necessary changes to use the show page attributes of the child record instead of the form attributes.

It also makes use of the `render_field` helper to render each field a little more nicely than the raw data rendering we're doing right now.

**Current**
![snip20181207_5_edited](https://user-images.githubusercontent.com/6520489/49816982-53bbb900-fd2c-11e8-82d3-f1f5e042af8e.png)

**Changed by This Pull Request**
![snip20181207_8](https://user-images.githubusercontent.com/6520489/49816625-80bb9c00-fd2b-11e8-9c9e-880c8b71e455.png)
