### PR TITLE
Fix multiple association pagination

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -7,7 +7,7 @@ module Administrate
       resources = Administrate::Search.new(scoped_resource,
                                            dashboard_class,
                                            search_term).run
-      resources = apply_resource_includes(resources)
+      resources = apply_collection_includes(resources)
       resources = order.apply(resources)
       resources = resources.page(params[:page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
@@ -125,8 +125,8 @@ module Administrate
       resource_class.default_scoped
     end
 
-    def apply_resource_includes(relation)
-      resource_includes = dashboard.association_includes
+    def apply_collection_includes(relation)
+      resource_includes = dashboard.collection_includes
       return relation if resource_includes.empty?
       relation.includes(*resource_includes)
     end

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -33,7 +33,7 @@ module Administrate
     end
 
     def sanitized_order_params(page, current_field_name)
-      collection_names = page.association_includes + [current_field_name]
+      collection_names = page.item_includes + [current_field_name]
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -58,13 +58,12 @@ module Administrate
       "#{resource.class} ##{resource.id}"
     end
 
-    def association_includes
-      collection_attributes.map do |key|
-        field = self.class::ATTRIBUTE_TYPES[key]
+    def collection_includes
+      attribute_includes(collection_attributes)
+    end
 
-        next key if association_classes.include?(field)
-        key if association_classes.include?(field.try(:deferred_class))
-      end.compact
+    def item_includes
+      attribute_includes(show_page_attributes)
     end
 
     private
@@ -77,6 +76,15 @@ module Administrate
       @association_classes ||=
         ObjectSpace.each_object(Class).
           select { |klass| klass < Administrate::Field::Associative }
+    end
+
+    def attribute_includes(attributes)
+      attributes.map do |key|
+        field = self.class::ATTRIBUTE_TYPES[key]
+
+        next key if association_classes.include?(field)
+        key if association_classes.include?(field.try(:deferred_class))
+      end.compact
     end
   end
 end

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -66,7 +66,7 @@ module Administrate
       private
 
       def includes
-        associated_dashboard.association_includes
+        associated_dashboard.collection_includes
       end
 
       def candidate_resources

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -15,8 +15,12 @@ module Administrate
         @resource_path ||= resource_name.gsub("/", "_")
       end
 
-      def association_includes
-        dashboard.try(:association_includes) || []
+      def collection_includes
+        dashboard.try(:collection_includes) || []
+      end
+
+      def item_includes
+        dashboard.try(:item_includes) || []
       end
 
       protected

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe "customer show page" do
       ids_in_table = (ids_in_page1 + ids_in_page2).uniq
       expect(ids_in_table).to match_array(order_ids)
     end
+
+    it "when these are not a collection field and there's another paginable association" do
+      original_collection_attributes = CustomerDashboard::COLLECTION_ATTRIBUTES
+      allow_any_instance_of(CustomerDashboard).to receive(:collection_attributes).and_return(original_collection_attributes - [:orders])
+
+      customer = create(:customer)
+      create_list(:order, 4, customer: customer)
+      create_list(:log_entry, 1, logeable: customer)
+
+      visit admin_customer_path(customer)
+      click_on("Next ›")
+    end
   end
 
   it "displays the customer's title attribute as the header" do


### PR DESCRIPTION
### What's the problem?

Say we have a dashboard:

* With two has_many associations.
* Only one of them listed in the collection (eg: the table in index page).
* Both listed in the show page.

Now lets say:

1. Go to the show page.
2. Of the two associations, click to paginate on the one that does not appear in the collection listing.

You'll get an unpermitted parameters exception.

## Why does it do that?

The root of the problem is at `app/views/administrate/application/_collection.html.erb`:

1. In this template, the headers are rendered as links that allow users to change the order of the records.
2. To do this, these links must include query params.
3. There might be query params in play already that we don't want to lose, so we have to *add* to the existing query params.
4. Because we need the list of query params currently in play, we have to read these from `params`.
5. `params` is an instance of `ActionController::Parameters`, so we can't simply merge as it was a Hash. We need to read each desired param explicitly with `#permit`. (OK, we could to `#to_unsafe_h`, but that's bad form).

When doing 5, the explicit list of params that are permitted is extracted from `COLLECTION_ATTRIBUTES`, leaving out those attributes that appear in the show page and not in the collection.

## How am I fixing it?

To be honest, I could just merge with `#to_unsafe_h` and be done with it, but I feel bad about it. On the other hand, I don't know what the problem would be. This is reading params to create a query string, not to generate SQL, so it shouldn't be a security concern. Perhaps I'm missing something?

Anyway, I'm creating a distinction between "includes" (ie: has_many associations) that are part of the collection or of the individual item's show page; then I'm using the latter when reading the query params for those links.