### PR TITLE
Fix dashboard generator for attributes that are neither reflections nor columns

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -50,7 +50,9 @@ module Administrate
       end
 
       def attributes
-        klass.reflections.keys + klass.attribute_names - redundant_attributes
+        klass.reflections.keys +
+          klass.columns.map(&:name) -
+          redundant_attributes
       end
 
       def form_attributes

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -349,6 +349,29 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           remove_constants :Account, :Ticket
         end
       end
+
+      if ActiveRecord.version >= Gem::Version.new(5)
+        it "skips temporary attributes" do
+          begin
+            ActiveRecord::Schema.define do
+              create_table :accounts
+            end
+
+            class Account < ActiveRecord::Base
+              reset_column_information
+              attribute :tmp_attribute, :boolean
+            end
+
+            dashboard = file("app/dashboards/account_dashboard.rb")
+
+            run_generator ["account"]
+
+            expect(dashboard).not_to contain("tmp_attribute")
+          ensure
+            remove_constants :Account
+          end
+        end
+      end
     end
 
     describe "COLLECTION_ATTRIBUTES" do


### PR DESCRIPTION
Rails allow to define custom attribute. It's usually used for coersion but nothing prevents me to use it as attr_accessor. For such cases generator was failing with `undefined method 'has_one?' for nil:NilClass (NoMethodError)`

With this fix generator doesn't try to define what's that and relies on column names instead of attribute names.