### PR TITLE
Fix routes generator for Rails 6 zeitwerk autoloader

### DIFF
--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -9,6 +9,10 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def insert_dashboard_routes
+        if Rails.configuration.try(:autoloader) == :zeitwerk
+          Rails.autoloaders.main.eager_load
+        end
+
         if should_route_dashboard?
           route(dashboard_routes)
         end


### PR DESCRIPTION
The classic autoloader worked fine for looking up all models when running the routes generator.

Rails 6 introduces zeitwerk as the default autoloader and it does not load all the models until needed.

I did some inspection to see why Administrate was only loading only my Devise model and nothing else.

```ruby
> ActiveRecord::Base.descendants
=> [ApplicationRecord(abstract), User (call 'User.connection' to establish a connection)]
> Rails.autoloaders.main.eager_load
=> true
> ActiveRecord::Base.descendants
=> [ApplicationRecord(abstract), User (call 'User.connection' to establish a connection), Announcement (call 'Announcement.connection' to establish a connection), Notification (call 'Notification.connection' to establish a connection), Service (call 'Service.connection' to establish a connection)]
```

After the eager load, all the models are available. In the old / classic autoloader from Rails 5 and earlier, you'd get the second set of results the first time.

This fixes it so Rails 6 will generate all the models like it used to.