### PR TITLE
Update README to show support for Ruby 2.4 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To accomplish these goals, Administrate follows a few guiding principles:
 ## Getting Started
 
 Administrate supports Rails from 4.2, up to 5.0 and beyond. We support Ruby
-2.2.9 and up.
+2.4 and up.
 
 Add Administrate to your Gemfile and re-bundle:
 


### PR DESCRIPTION
Based on changes made in #1318 the README now reflects the correct Ruby versions this gem supports