### PR TITLE
Patch Rails 4.2 tests to work with Ruby 2.6.

### DIFF
--- a/spec/support/patch_rails_42_action_controller_test_response.rb
+++ b/spec/support/patch_rails_42_action_controller_test_response.rb
@@ -1,0 +1,13 @@
+if RUBY_VERSION >= "2.6.0"
+  if Rails.version < "5"
+    module ActionController
+      class TestResponse < ActionDispatch::TestResponse
+        def recycle!
+          @mon_mutex_owner_object_id = nil
+          @mon_mutex = nil
+          initialize
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
An issue with reusing the `TestResponse` object occurs with Ruby 2.6 and
causes `already initialized` exceptions to be thrown.

This monkey-patch fixes this for Rails 4.2.

It's expected that Rails 4.2 will be dropped by administrate when Rails
6 is released, and this patch should be removed.

https://github.com/rails/rails/issues/34790