### PR TITLE
Fix warning messages

### DIFF
--- a/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/app/assets/stylesheets/administrate/base/_typography.scss
@@ -23,7 +23,7 @@ p {
 
 a {
   color: $action-color;
-  text-decoration-skip: ink;
+  text-decoration-skip-ink: auto;
   transition: color $base-duration $base-timing;
 
   &:hover {

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -48,8 +48,8 @@ product_attributes = YAML.load_file(Rails.root.join('db/seeds/products.yml'))
 
 product_attributes.each do |attributes|
   attributes = attributes.merge product_meta_tag_attributes: {
-    meta_title: Faker::LordOfTheRings.character,
-    meta_description: Faker::LordOfTheRings.location,
+    meta_title: Faker::Movies::LordOfTheRings.character,
+    meta_description: Faker::Movies::LordOfTheRings.location,
   }
   Product.create! attributes.merge(price: 20 + rand(50))
 end


### PR DESCRIPTION
- Fix warning message related to the seed file
```
NOTE: Faker::LordOfTheRings.character is deprecated; use Faker::Movies::LordOfTheRings.character instead. It will be removed on or after 2019-01-01.
Faker::LordOfTheRings.character called from .../administrate/spec/example_app/db/seeds.rb:51
```
 

- Fix warning message relate to style

```
autoprefixer: administrate/app/assets/stylesheets/administrate/application.scss:1934:3: Replace text-decoration-skip: ink to text-decoration-skip-ink: auto, because spec had been changed
```