### PR TITLE
Allow Authorization with Pundit Policy Namespacing

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -5,16 +5,22 @@ if Object.const_defined?("Pundit")
       include Pundit
 
       included do
+        def pundit_namespaces
+          []
+        end
+
         def scoped_resource
           policy_scope_admin super
         end
 
         def authorize_resource(resource)
-          authorize resource
+          namespaced_resource = pundit_namespaces << resource
+          authorize namespaced_resource
         end
 
         def show_action?(action, resource)
-          Pundit.policy!(pundit_user, resource).send("#{action}?".to_sym)
+          namespaced_resource = pundit_namespaces << resource
+          Pundit.policy!(pundit_user, namespaced_resource).send("#{action}?".to_sym)
         end
       end
 
@@ -23,8 +29,9 @@ if Object.const_defined?("Pundit")
       # Like the policy_scope method in stock Pundit, but allows the 'resolve'
       # to be overridden by 'resolve_admin' for a different index scope in Admin
       # controllers.
-      def policy_scope_admin(scope)
-        ps = Pundit::PolicyFinder.new(scope).scope!.new(pundit_user, scope)
+      def policy_scope_admin(resource)
+        namespaced_resource = pundit_namespaces << resource
+        ps = Pundit::PolicyFinder.new(namespaced_resource).scope!.new(pundit_user, resource)
         if ps.respond_to? :resolve_admin
           ps.resolve_admin
         else

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -7,6 +7,9 @@ describe Admin::OrdersController, type: :controller do
   context "with Punditize concern" do
     controller(Admin::OrdersController) do
       include Administrate::Punditize
+      def pundit_namespaces
+        [:admin]
+      end
       def pundit_user
         Customer.first # assume the user is the first Customer
       end

--- a/spec/example_app/app/policies/admin/order_policy.rb
+++ b/spec/example_app/app/policies/admin/order_policy.rb
@@ -1,4 +1,4 @@
-class OrderPolicy < ApplicationPolicy
+class Admin::OrderPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       scope.all


### PR DESCRIPTION
Fix https://github.com/thoughtbot/administrate/issues/1332

To use specific [Policy Namespacing](https://github.com/varvet/pundit#policy-namespacing) for administrate, like admin namespace policies for example, just define the pundit_namespaces in an array format, like below. It is also backward compatible with resolve_admin.

```
module Admin
  class ApplicationController < Administrate::ApplicationController
    include Administrate::Punditize
    def pundit_namespaces
      [:admin]
    end
  end
end
```