### PR TITLE
Add word-break to attribute-data

### DIFF
--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -18,6 +18,7 @@
   margin-bottom: $base-spacing;
   margin-left: 2rem;
   width: calc(80% - 1rem);
+  word-break: break-word;
 }
 
 .attribute--nested {


### PR DESCRIPTION
Similar to #306 - but improves functionality.

Long values such as MD5 hashes are currently being outputted on a single line that expands the page for either `Field::String` or `Field::Text`.  This commit adds a `word-break` to `.attribute-data` which allows word-wrapping to occur while maintaining copy and paste-ability.

Before (page scrolls a lot and has 'h-align' padding to centre it:
![Screen Shot 2019-06-09 at 10 52 40 AM](https://user-images.githubusercontent.com/481907/59161861-f3bc8a00-8aa4-11e9-8e3d-58d640db672b.png)

After:
![Screen Shot 2019-06-09 at 10 52 54 AM](https://user-images.githubusercontent.com/481907/59161864-f6b77a80-8aa4-11e9-8b9b-2277a7066998.png)