### PR TITLE
Add a "back" link to the navigation

### DIFF
--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -41,3 +41,11 @@ input[type="submit"],
     }
   }
 }
+
+.button--alt {
+  background-color: transparent;
+  border: $base-border;
+  border-color: $blue;
+  color: $blue;
+  margin-bottom: $base-spacing;
+}

--- a/app/assets/stylesheets/administrate/components/_navigation.scss
+++ b/app/assets/stylesheets/administrate/components/_navigation.scss
@@ -2,9 +2,8 @@ $_navigation-link-padding: 0.6em;
 
 .navigation {
   flex: 1 0 10rem;
-  padding-bottom: $base-spacing;
-  padding-right: calc(#{$base-spacing} - #{$_navigation-link-padding});
-  padding-top: $base-spacing;
+  padding: $base-spacing;
+  padding-left: 0;
 }
 
 .navigation__link {

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -8,6 +8,8 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
+  <%= link_to "Back to app", root_url, class: "button button--alt" %> 
+
   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
     <%= link_to(
       display_resource_name(resource),

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 describe "navigation" do
+  it "has the link of back to application" do
+    visit admin_customers_path
+
+    navigation = find(".navigation")
+    expect(navigation).to have_link("Back to app")
+  end
+
   it "highlights the link to the current page's resource type" do
     visit admin_customers_path
 


### PR DESCRIPTION
This solves half of #271 by implementing a link to take the user back to
the main application. It's assumed that `root_url` without a namespace
returns the main application's root.