### PR TITLE
AR models should inherit from ApplicationRecord

### DIFF
--- a/spec/example_app/app/models/application_record.rb
+++ b/spec/example_app/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/spec/example_app/app/models/blog/post.rb
+++ b/spec/example_app/app/models/blog/post.rb
@@ -1,5 +1,5 @@
 module Blog
-  class Post < ActiveRecord::Base
+  class Post < ApplicationRecord
     validates :title, :body, presence: true
   end
 end

--- a/spec/example_app/app/models/country.rb
+++ b/spec/example_app/app/models/country.rb
@@ -1,3 +1,3 @@
-class Country < ActiveRecord::Base
+class Country < ApplicationRecord
   validates :code, :name, presence: true
 end

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -1,4 +1,4 @@
-class Customer < ActiveRecord::Base
+class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
   belongs_to :country, foreign_key: :country_code, primary_key: :code
   has_many :log_entries, as: :logeable

--- a/spec/example_app/app/models/line_item.rb
+++ b/spec/example_app/app/models/line_item.rb
@@ -1,4 +1,4 @@
-class LineItem < ActiveRecord::Base
+class LineItem < ApplicationRecord
   belongs_to :order
   belongs_to :product
 

--- a/spec/example_app/app/models/log_entry.rb
+++ b/spec/example_app/app/models/log_entry.rb
@@ -1,4 +1,4 @@
-class LogEntry < ActiveRecord::Base
+class LogEntry < ApplicationRecord
   belongs_to :logeable, polymorphic: true
 
   validate do |log_entry|

--- a/spec/example_app/app/models/order.rb
+++ b/spec/example_app/app/models/order.rb
@@ -1,4 +1,4 @@
-class Order < ActiveRecord::Base
+class Order < ApplicationRecord
   belongs_to :customer
 
   validates :customer, presence: true

--- a/spec/example_app/app/models/payment.rb
+++ b/spec/example_app/app/models/payment.rb
@@ -1,3 +1,3 @@
-class Payment < ActiveRecord::Base
+class Payment < ApplicationRecord
   belongs_to :order
 end

--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -1,4 +1,4 @@
-class Product < ActiveRecord::Base
+class Product < ApplicationRecord
   has_many :line_items, dependent: :destroy
   has_one :product_meta_tag, dependent: :destroy
 

--- a/spec/example_app/app/models/product_meta_tag.rb
+++ b/spec/example_app/app/models/product_meta_tag.rb
@@ -1,4 +1,4 @@
-class ProductMetaTag < ActiveRecord::Base
+class ProductMetaTag < ApplicationRecord
   belongs_to :product
 
   validates :meta_title, :meta_description, presence: true

--- a/spec/example_app/app/models/series.rb
+++ b/spec/example_app/app/models/series.rb
@@ -1,3 +1,3 @@
-class Series < ActiveRecord::Base
+class Series < ApplicationRecord
   validates :name, presence: true
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -25,7 +25,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             create_table(:foos) { |t| t.timestamps null: false }
           end
 
-          class Foo < ActiveRecord::Base
+          class Foo < ApplicationRecord
             reset_column_information
           end
 
@@ -47,7 +47,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             create_table(:foos) { |t| t.string :name }
           end
 
-          class Foo < ActiveRecord::Base
+          class Foo < ApplicationRecord
             reset_column_information
           end
 
@@ -67,7 +67,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             create_table(:foos) { |t| t.inet :ip_address }
           end
 
-          class Foo < ActiveRecord::Base
+          class Foo < ApplicationRecord
             reset_column_information
           end
 
@@ -91,7 +91,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       end
 
       it "looks for class_name options on has_many fields" do
-        class Customer < ActiveRecord::Base
+        class Customer < ApplicationRecord
           reset_column_information
           has_many :purchases, class_name: "Order", foreign_key: "purchase_id"
         end
@@ -113,7 +113,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class InventoryItem < ActiveRecord::Base
+          class InventoryItem < ApplicationRecord
             reset_column_information
           end
 
@@ -138,7 +138,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Shipment < ActiveRecord::Base
+          class Shipment < ApplicationRecord
             enum status: [:ready, :processing, :shipped]
             reset_column_information
           end
@@ -160,7 +160,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             create_table(:users) { |t| t.boolean :active }
           end
 
-          class User < ActiveRecord::Base
+          class User < ApplicationRecord
             reset_column_information
           end
 
@@ -185,7 +185,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Event < ActiveRecord::Base
+          class Event < ApplicationRecord
             reset_column_information
           end
 
@@ -214,7 +214,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Concert < ActiveRecord::Base
+          class Concert < ApplicationRecord
             reset_column_information
             has_many :tickets
             has_many :attendees, through: :tickets, source: :person
@@ -222,7 +222,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             has_many :numbers, through: :tickets
           end
 
-          class Ticket < ActiveRecord::Base
+          class Ticket < ApplicationRecord
             reset_column_information
             belongs_to :concert
             belongs_to :person
@@ -231,7 +231,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           end
 
           class Number; end
-          class Person < ActiveRecord::Base
+          class Person < ApplicationRecord
             reset_column_information
           end
 
@@ -254,7 +254,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           ActiveRecord::Schema.define do
             create_table(:comments) { |t| t.references :post }
           end
-          class Comment < ActiveRecord::Base
+          class Comment < ApplicationRecord
             belongs_to :post
           end
 
@@ -278,8 +278,8 @@ describe Administrate::Generators::DashboardGenerator, :generator do
               t.references :recipient
             end
           end
-          class User < ActiveRecord::Base; end
-          class Invitation < ActiveRecord::Base
+          class User < ApplicationRecord; end
+          class Invitation < ApplicationRecord
             belongs_to :sender, class_name: "User"
             belongs_to :recipient, class_name: "User"
           end
@@ -304,7 +304,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
               t.references :commentable, polymorphic: true
             end
           end
-          class Comment < ActiveRecord::Base
+          class Comment < ApplicationRecord
             belongs_to :commentable, polymorphic: true
           end
 
@@ -330,12 +330,12 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Account < ActiveRecord::Base
+          class Account < ApplicationRecord
             reset_column_information
             has_one :profile
           end
 
-          class Ticket < ActiveRecord::Base
+          class Ticket < ApplicationRecord
             reset_column_information
             belongs_to :account
           end
@@ -357,7 +357,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
               create_table :accounts
             end
 
-            class Account < ActiveRecord::Base
+            class Account < ApplicationRecord
               reset_column_information
               attribute :tmp_attribute, :boolean
             end
@@ -383,7 +383,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Foo < ActiveRecord::Base
+          class Foo < ApplicationRecord
             reset_column_information
           end
 
@@ -414,7 +414,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
             end
           end
 
-          class Foo < ActiveRecord::Base
+          class Foo < ApplicationRecord
             reset_column_information
           end
 
@@ -440,7 +440,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
           end
         end
 
-        class Foo < ActiveRecord::Base
+        class Foo < ApplicationRecord
           reset_column_information
         end
 
@@ -468,7 +468,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     it "subclasses Admin::ApplicationController by default" do
       begin
         ActiveRecord::Schema.define { create_table :foos }
-        class Foo < ActiveRecord::Base; end
+        class Foo < ApplicationRecord; end
 
         run_generator ["foo"]
         load file("app/controllers/admin/foos_controller.rb")
@@ -484,7 +484,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     it "uses the given namespace to create controllers" do
       begin
         ActiveRecord::Schema.define { create_table :foos }
-        class Foo < ActiveRecord::Base; end
+        class Foo < ApplicationRecord; end
         module Manager
           class ApplicationController < Administrate::ApplicationController; end
         end

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -52,7 +52,7 @@ describe Administrate::Generators::RoutesGenerator, :generator do
 
     it "skips models that aren't backed by the database with a warning" do
       begin
-        class ModelWithoutDBTable < ActiveRecord::Base; end
+        class ModelWithoutDBTable < ApplicationRecord; end
         routes = file("config/routes.rb")
 
         output = run_generator
@@ -69,7 +69,7 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       ActiveRecord::Migration.suppress_messages do
         ActiveRecord::Schema.define { create_table(:foos) }
       end
-      _unnamed_model = Class.new(ActiveRecord::Base) do
+      _unnamed_model = Class.new(ApplicationRecord) do
         def self.table_name
           :foos
         end
@@ -86,7 +86,7 @@ describe Administrate::Generators::RoutesGenerator, :generator do
       routes = file("config/routes.rb")
 
       begin
-        class AbstractModel < ActiveRecord::Base
+        class AbstractModel < ApplicationRecord
           self.abstract_class = true
         end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -33,7 +33,7 @@ describe Administrate::Search do
   describe "#run" do
     it "returns all records when no search term" do
       begin
-        class User < ActiveRecord::Base; end
+        class User < ApplicationRecord; end
         scoped_object = User.default_scoped
         search = Administrate::Search.new(scoped_object,
                                           MockDashboard,
@@ -48,7 +48,7 @@ describe Administrate::Search do
 
     it "returns all records when search is empty" do
       begin
-        class User < ActiveRecord::Base; end
+        class User < ApplicationRecord; end
         scoped_object = User.default_scoped
         search = Administrate::Search.new(scoped_object,
                                           MockDashboard,
@@ -63,7 +63,7 @@ describe Administrate::Search do
 
     it "searches using LOWER + LIKE for all searchable fields" do
       begin
-        class User < ActiveRecord::Base; end
+        class User < ApplicationRecord; end
         scoped_object = User.default_scoped
         search = Administrate::Search.new(scoped_object,
                                           MockDashboard,
@@ -88,7 +88,7 @@ describe Administrate::Search do
 
     it "converts search term LOWER case for latin and cyrillic strings" do
       begin
-        class User < ActiveRecord::Base; end
+        class User < ApplicationRecord; end
         scoped_object = User.default_scoped
         search = Administrate::Search.new(scoped_object,
                                           MockDashboard,


### PR DESCRIPTION
In investigating #581, we released the `ApplicationRecord` change
introduced in Rails 5 did not happen in our `example_app` models.