### PR TITLE
Left join in order to support searching both a belongs_to and a field…

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -13,7 +13,7 @@ module Administrate
       if @term.blank?
         @scoped_resource.all
       else
-        @scoped_resource.joins(tables_to_join).where(query, *search_terms)
+        @scoped_resource.left_joins(tables_to_join).where(query, *search_terms)
       end
     end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -134,14 +134,14 @@ describe Administrate::Search do
       it "joins with the correct association table to query" do
         allow(scoped_object).to receive(:where)
 
-        expect(scoped_object).to receive(:joins).with(%i(role address)).
+        expect(scoped_object).to receive(:left_joins).with(%i(role address)).
           and_return(scoped_object)
 
         search.run
       end
 
       it "builds the 'where' clause using the joined tables" do
-        allow(scoped_object).to receive(:joins).with(%i(role address)).
+        allow(scoped_object).to receive(:left_joins).with(%i(role address)).
           and_return(scoped_object)
 
         expect(scoped_object).to receive(:where).with(*expected_query)


### PR DESCRIPTION
… on the root entity

First, I love Administrate. ♥ Thank you for creating such a straightforward yet reasonably customizable dashboard. It hits the perfect sweet spot.

This PR is to fix a search issue I ran up against.

In the scenario, where I have configured search to both a belongs_to `searchable_field` AND some `other_field` in the root entity, the following happens:

1. I can successfully search the belongs_to `belongs_to.searchable_field` when the root entity's belongs_to is assigned
2. I can successfully search the belongs_to `belongs_to.searchable_field` when the root entity's belongs_to is null
3. I can successfully search the `other_field` when the root entity's belongs_to is assigned
4. I can NOT successfully search the `other_field` when the root entity's belongs_to is null

This PR fixes problem #4 (caused by an inner join) by using a left join.

Is this PR useful?
