### PR TITLE
Make arrays of symbols match Rubocop requirement

### DIFF
--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -18,20 +18,20 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   #
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
-  COLLECTION_ATTRIBUTES = [
+  COLLECTION_ATTRIBUTES = %i[
 <%=
   attributes.first(COLLECTION_ATTRIBUTE_LIMIT).map do |attr|
-    "    :#{attr},"
+    "  #{attr}"
   end.join("\n")
 %>
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = [
+  SHOW_PAGE_ATTRIBUTES = %i[
 <%=
   attributes.map do |attr|
-    "    :#{attr},"
+    "  #{attr}"
   end.join("\n")
 %>
   ].freeze
@@ -39,10 +39,10 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [
+  FORM_ATTRIBUTES = %i[
 <%=
   form_attributes.map do |attr|
-    "    :#{attr},"
+    "  #{attr}"
   end.join("\n")
 %>
   ].freeze


### PR DESCRIPTION
Dashboards include arrays of symbols in the form `[:foo, :bar]`, which Rubocop (when using thoughtbot's configuration in particular) will recommend changing to `%i[foo bar]`. This alters the generated code to meet the required style.