### PR TITLE
Fix loading of `Punditize`

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -1,6 +1,6 @@
-if Object.const_defined?("Pundit")
-  module Administrate
-    module Punditize
+module Administrate
+  module Punditize
+    if Object.const_defined?("Pundit")
       extend ActiveSupport::Concern
       include Pundit
 

--- a/spec/controllers/concerns/administrate/punditize_spec.rb
+++ b/spec/controllers/concerns/administrate/punditize_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+module Administrate
+  RSpec.describe Punditize do
+    it "exists when 'Pundit' is not defined" do
+      unload_constants do
+        expect { build_dummy }.not_to raise_error
+      end
+    end
+
+    def unload_constants
+      original = Pundit
+      Object.send(:remove_const, "Pundit")
+      Administrate.send(:remove_const, "Punditize")
+      load Rails.root.join(
+        "..",
+        "..",
+        "app",
+        "controllers",
+        "concerns",
+        "administrate",
+        "punditize.rb",
+      )
+
+      yield
+
+      Object.const_set("Pundit", original)
+    end
+
+    def dummy_class
+      Class.new do
+        include Administrate::Punditize
+      end
+    end
+
+    def build_dummy
+      stub_const("Dummy", dummy_class)
+      Dummy.new
+    end
+  end
+end


### PR DESCRIPTION
We were only defining the `Punditize` module if we had already defined `Pundit`. Setting `Punditize` like this broke autoloading in Rails when `Pundit` was not specified. We fixed the problem by always setting `Punditize` but keeping it empty if` Pundit` does not exist.

https://github.com/thoughtbot/administrate/issues/1339