### PR TITLE
Support association search for other types of association fields

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -69,11 +69,13 @@ module Administrate
     def association_search?(attribute)
       return unless attribute_types[attribute].respond_to?(:deferred_class)
 
-      [
-        Administrate::Field::BelongsTo,
-        Administrate::Field::HasMany,
-        Administrate::Field::HasOne,
-      ].include?(attribute_types[attribute].deferred_class)
+      association_classes.include?(attribute_types[attribute].deferred_class)
+    end
+    
+    def association_classes
+      @association_classes ||=
+        ObjectSpace.each_object(Class).
+          select { |klass| klass < Administrate::Field::Associative }
     end
 
     attr_reader :resolver, :term

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -71,7 +71,7 @@ module Administrate
 
       association_classes.include?(attribute_types[attribute].deferred_class)
     end
-    
+
     def association_classes
       @association_classes ||=
         ObjectSpace.each_object(Class).


### PR DESCRIPTION
*This issue and the proposed fix is very similar to https://github.com/thoughtbot/administrate/pull/1176*

Right now association search doesn't work for new types of association fields.

`Administrate::Search` hard-codes the possible types of association fields in a list to determine if association search should be used. This means that new types of fields cannot perform association search and things break.

My proposed solution (see `lib/administrate/search.rb`) does a programmatic search for field classes that inherit from `Administrate::Field::Associative`. This allows plugin authors not to worry about adding their new type to a list or any other sort of setup.

A potential problem with this approach is that it includes `Administrate::Field::Polymorphic` on the list. I don't know if this can cause problems down the line or not.


