### PR TITLE
UUID's should be rendered Field::String

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -13,7 +13,7 @@ module Administrate
         time: "Field::Time",
         text: "Field::Text",
         string: "Field::String",
-        uuid: "Field::String"
+        uuid: "Field::String",
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -13,6 +13,7 @@ module Administrate
         time: "Field::Time",
         text: "Field::Text",
         string: "Field::String",
+        uuid: "Field::String"
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {


### PR DESCRIPTION
If you're using a database with with an attribute set as UUID datatype, when generating the dashboards views you'll be presented with an exception error when visiting any of the dashboards views. When using a UUID attribute, it should be rendered in the view as a a [string](https://github.com/thoughtbot/administrate/compare/master...tarellel:patch-1#diff-e492ee93fe29bb4a62328c20d7d358b7R16). This prevents raising the exception error when processing the attributes in the [_collection.html.erb](https://github.com/thoughtbot/administrate/blob/b85abcf965ecc843ee9b25e3a2ea65dfeb1b0b3c/app/views/administrate/application/_collection.html.erb#L69) template with the the [render_field](https://github.com/thoughtbot/administrate/blob/053132c8112dab0a948570cccdbc4ecf4edc150a/app/helpers/administrate/application_helper.rb#L13) method.