### PR TITLE
Use Zeitwerk for loading models in Rails 6

### DIFF
--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -1,4 +1,9 @@
-Rails.application.eager_load!
+if defined?(Zeitwerk)
+  Zeitwerk::Loader.eager_load_all
+else
+  Rails.application.eager_load!
+end
+
 require "rails/generators/base"
 require "administrate/namespace"
 


### PR DESCRIPTION
In #1369, it's noted that under Rails 6, model loading is no longer
working. This is because Zeitwerk has replaced the original code
loading.

Here, we load the models using Zeitwerk, if it is available.