### PR TITLE
Add dashboard configuration to (not) be displayed in navigation

### DIFF
--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -8,7 +8,7 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
-  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+  <% Administrate::Navigation.new(namespace).resources.each do |resource| %>
     <%= link_to(
       display_resource_name(resource),
       [namespace, resource_index_route_key(resource)],

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -43,8 +43,18 @@ Rails.application.routes.draw do
  end
 ```
 
-The routes can be customized to show or hide
-different models on the dashboard.
+Removing resources from the routes will hide them on the dashboard.
+
+There might be situations where resources shall be hidden in the navigation
+but still be nested in another resource. In this case you keep the route but configure the dashboard to not be displayed in the navigation.
+
+```ruby
+class LineItemDashboard < Administrate::BaseDashboard
+  configure do |config|
+    config.navigation = false
+  end
+end
+```
 
 Each `FooDashboard` specifies which attributes should be displayed
 on the admin dashboard for the `Foo` resource.

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -17,6 +17,20 @@ module Administrate
   class BaseDashboard
     include Administrate
 
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield configuration
+      end
+
+      def display_in_navigation?
+        configuration.navigation == true
+      end
+    end
+
     def attribute_types
       self.class::ATTRIBUTE_TYPES
     end
@@ -86,6 +100,14 @@ module Administrate
         next key if association_classes.include?(field)
         key if association_classes.include?(field.try(:deferred_class))
       end.compact
+    end
+
+    class Configuration
+      attr_accessor :navigation
+
+      def initialize
+        @navigation = true
+      end
     end
   end
 end

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -14,6 +14,7 @@ require "administrate/resource_resolver"
 require "administrate/search"
 require "administrate/namespace"
 require "administrate/namespace/resource"
+require "administrate/navigation"
 
 module Administrate
   class Engine < ::Rails::Engine

--- a/lib/administrate/namespace/resource.rb
+++ b/lib/administrate/namespace/resource.rb
@@ -3,6 +3,9 @@ module Administrate
     class Resource
       attr_reader :namespace, :resource
 
+      delegate :display_in_navigation?, to: :dashboard_class
+      delegate :dashboard_class, to: :resource_resolver
+
       def initialize(namespace, resource)
         @namespace = namespace
         @resource = resource
@@ -22,6 +25,12 @@ module Administrate
 
       def path
         name.to_s.gsub("/", "_")
+      end
+
+      private
+
+      def resource_resolver
+        @resource_resolver ||= ResourceResolver.new("#{namespace}/#{resource}")
       end
     end
   end

--- a/lib/administrate/navigation.rb
+++ b/lib/administrate/navigation.rb
@@ -1,0 +1,10 @@
+module Administrate
+  class Navigation
+    attr_reader :resources
+
+    def initialize(namespace)
+      namespace = Administrate::Namespace.new(namespace)
+      @resources = namespace.resources.select(&:display_in_navigation?)
+    end
+  end
+end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,12 +1,36 @@
 require "rails_helper"
 
 describe "navigation" do
+  let(:navigation) { find(".navigation") }
+
   it "highlights the link to the current page's resource type" do
     visit admin_customers_path
 
     active_link = find(".navigation__link--active")
 
     expect(active_link.text).to eq "Customers"
+  end
+
+  it "displays links to resources from admin namespace" do
+    visit admin_root_path
+
+    expect(navigation).to have_link("Customers")
+    expect(navigation).to have_link("Line Items")
+    expect(navigation).to have_link("Log Entries")
+    expect(navigation).to have_link("Products")
+    expect(navigation).to have_link("Product Meta Tags")
+    expect(navigation).to have_link("Payments")
+    expect(navigation).to have_link("Series")
+    expect(navigation).to have_link("Blog/Posts")
+  end
+
+  it "does not display links to resources configured to not be rendered in navigation" do
+    LineItemDashboard.configuration.navigation = false
+
+    visit admin_root_path
+    expect(navigation).not_to have_link("Line Items")
+
+    LineItemDashboard.configuration.navigation = true # Reset to default
   end
 
   it "displays translated name of model" do
@@ -24,7 +48,6 @@ describe "navigation" do
     with_translations(:en, translations) do
       visit admin_customers_path
 
-      navigation = find(".navigation")
       expect(navigation).to have_link("Users")
       expect(page).to have_header("Users")
     end


### PR DESCRIPTION
+ Introduces general configuration for Dashboards.
+ By default every Dashboard is configured to be displayed in the navigation.

How to remove a Dashboard from navigation:

```
class LineItemDashboard < Administrate::BaseDashboard
  configure do |config|
    config.navigation = false
  end
end
```