### PR TITLE
Revert "Bundle with bundler 2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   xpath (= 3.2.0)
 
 BUNDLED WITH
-   2.0.2
+   1.17.3


### PR DESCRIPTION
Bundler 2.0 doesn't work with Appraisal and continues to cause a few
other problems. So switch back to 1.17.

This reverts commit 3db05f9127fa53594c50557abaa05c2dcf52ff76.