### PR TITLE
Drop rails_stdout_logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,5 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,6 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    rails_stdout_logging (0.0.5)
     railties (6.0.0)
       actionpack (= 6.0.0)
       activesupport (= 6.0.0)
@@ -274,7 +273,6 @@ DEPENDENCIES
   pry-rails
   pundit
   rack-timeout
-  rails_stdout_logging
   redcarpet
   rspec-rails
   sentry-raven

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -42,7 +42,6 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -42,7 +42,6 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end
 

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -42,7 +42,6 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -42,7 +42,6 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -40,7 +40,6 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
   gem "uglifier"
 end
 


### PR DESCRIPTION
We're well past when Rails needed this to run correctly on Heroku (Rails
5.0 included out of the box support) and it now shows a logger
deprecation warning, so remove it.