### PR TITLE
Fix collection filters example in dashboard template

### DIFF
--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -55,7 +55,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # in the search field:
   #
   #   COLLECTION_FILTERS = {
-  #     open: ->(resources) { where(open: true) }
+  #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 


### PR DESCRIPTION
If implemented according to the current template, it will be `NoMethodError`.
Fix the template as in the following link.
https://github.com/thoughtbot/administrate/blob/master/spec/example_app/app/dashboards/customer_dashboard.rb#L36
http://administrate-prototype.herokuapp.com/customizing_dashboards
