### PR TITLE
Fix Rails 6 deprecation warning

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -11,7 +11,7 @@ module Administrate
 
       order = "#{relation.table_name}.#{attribute} #{direction}"
 
-      return relation.reorder(order) if
+      return relation.reorder(Arel.sql(order)) if
         relation.columns_hash.keys.include?(attribute.to_s)
 
       relation


### PR DESCRIPTION
When that code runs (ordering the index page in administrate dashboard) I'm getting the following deprecation warning
`
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "[schema].[table].[column]". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql().
`