### PR TITLE
Support Sprockets 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ to see your new dashboard in action.
 
 For more detailed instructions or to make it work with Rails API-only applications, please go through the ['Getting Started` guide](https://administrate-prototype.herokuapp.com/getting_started).
 
+If your apps uses Sprockets 4, you'll need to add Administrate's assets to your `manifest.js` file. To do this, add these two lines to the file:
+
+```
+//= link administrate/application.css
+//= link administrate/application.js
+```
+
+Otherwise, your app will show you this error:
+
+```
+Asset `administrate/application.css` was not declared to be precompiled in production.
+Declare links to your assets in `app/assets/config/manifest.js`.
+```
+
+For more information on why this is necessary, see https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
 
 ## Create Additional Dashboards
 

--- a/spec/example_app/app/assets/config/manifest.js
+++ b/spec/example_app/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link administrate/application.css
+//= link administrate/application.js


### PR DESCRIPTION
### Objective

This PR should fix the CI build, which is currently failing for all appraisals with the following error:

```
Sprockets::Railtie::ManifestNeededError:
  Expected to find a manifest file in `app/assets/config/manifest.js`
  But did not, please create this file and use it to link any assets that need
  to be rendered by your app:

  Example:
    //= link_tree ../images
    //= link_directory ../javascripts .js
    //= link_directory ../stylesheets .css
```

### Details

This is due to Sprockets 4, which requires this `manifest.js` file. Sprockets 4 was published on 8 October 2019, the day after the last successful build.

From what I can tell, the only fix is having the client app listing Administrate's asset files in its `manifest.js` file. Therefore I'm creating one for the example app (used in the specs) and documenting this extra manual work in the readme.

For some detail on this manifest file, see https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs/

### But it passes on my machine!

If you run the specs locally with `bundle exec rake`, they'll probably pass. This is because the bundled `Gemfile.lock` has Sprockets pinned to version 3.7.2 currently. However if you run the appraisal specs with `bundle exec appraisal rake`, these may fail because the appraisal lockfiles are not under version control, and therefore will be regenerated on first run.

Note that a newly created Rails app won't have this issue at the time being. This is because Rails apps are still being generated to use the `sass` gem (despite its being end-of-life'd) and this depends on `sprockets < 4`. Using `sassc` in your app may land you Sprockets 4 though (you'd still have to explicitly `bundle update` to get it).

### Future options

I don't see a way to have Administrate provide an engine-level `manifest.js` instead of having the client application manually add it. I might be missing something though.

Another option would be having the Administrate generator add the required lines to the manifest files. I think we'd still have to document it in the readme, as that's bound to not be enough for many.