### PR TITLE
Fix acceptance tests on Linux

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -13,7 +13,7 @@ $(function() {
       var dataUrl = $(event.target).closest("tr").data("url");
       var selection = window.getSelection().toString();
       if (selection.length === 0 && dataUrl) {
-        window.location = dataUrl;
+        window.location.pathname = dataUrl;
       }
     }
   };


### PR DESCRIPTION
Currently, several acceptance specs fail in my Debian machine. The errors suggest that some pages don't have some expected content, and while the specs are running we get a mysterious message that looks like this:

```
Not allowed to load local resource: file:///admin/log_entries/1
```

The culprit is the JS that makes table rows clickable. They extract the `href` from the link cell and apply it to `window.location`. Normally this works: it's a path URL (eg: `/admin/log_entries/1`) and the result preserves the current scheme+host (eg: if we were at `http://localhost:12345/admin/products`, we'll end up with `http://localhost:12345/admin_log_entries/1`).

Unfortunately, the behaviour on PhantomJS under Debian Stretch is different. In this case, the scheme+host are lost, and we end up with a `file://` URL, and therefore with `file:///admin/log_entries/1`.

As a result, links are not followed through, and therefore we don't move on to the next page, and specs fail to find the expected content.

Assigning the URI to `window.location.pathname` instead solves the problem.