### PR TITLE
Adds options for quick search filter

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -4,9 +4,9 @@ module Administrate
 
     def index
       search_term = params[:search].to_s.strip
-      resources = Administrate::Search.new(scoped_resource,
+      resources = Administrate::Search.run(scoped_resource,
                                            dashboard_class,
-                                           search_term).run
+                                           search_term)
       resources = apply_collection_includes(resources)
       resources = order.apply(resources)
       resources = resources.page(params[:page]).per(records_per_page)

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -43,6 +43,8 @@ class CustomerDashboard < Administrate::Dashboard::Base
     :email,
     :orders,
   ]
+
+  FILTER_MODE = :fuzzy
 end
 ```
 
@@ -300,4 +302,62 @@ resource class).
 COLLECTION_FILTERS = {
   inactive: ->(resources) { resources.inactive }
 }
+```
+
+## Filter modes
+
+You can choose between two different modes of filtering: `fuzzy` and `strict`.
+
+### Fuzzy mode
+
+In `fuzzy` mode (default) it's produces `LIKE` normalized sql statements for each searchable field with `OR` operator. Working as simple quick text search
+
+In example:
+```ruby
+# user_dashboard.rb
+
+ATTRIBUTE_TYPES = {
+  id: Field::Number.with_options(searchable: true),
+  name: Field::String.with_options(searchable: true)
+}
+
+FILTER_MODE = :fuzzy
+```
+
+...and searching string:
+```
+BOB
+```
+
+...produces sql:
+
+```sql
+SELECT * FROM users where LOWER(CAST(id AS CHAR(256))) LIKE %bob% OR LOWER(CAST(name AS CHAR(256))) LIKE %bob%
+```
+
+### Strict mode
+
+In `strict` mode (default) it's produces equal statements with data "as is" for each searchable field with `OR` operator
+
+In example:
+```ruby
+# user_dashboard.rb
+
+ATTRIBUTE_TYPES = {
+  id: Field::Number.with_options(searchable: true),
+  name: Field::String.with_options(searchable: true)
+}
+
+FILTER_MODE = :strict
+```
+
+...and searching string:
+```
+BOB
+```
+
+...produces sql:
+
+```sql
+SELECT * FROM users where id = 'BOB' OR name = 'BOB'
 ```

--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -65,4 +65,9 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # def display_resource(<%= file_name %>)
   #   "<%= class_name %> ##{<%= file_name %>.id}"
   # end
+
+  ### FILTER_MODE
+  # a symbol representing searching strategy for quick search.
+  # Available modes: `:fuzzy` and `:strict`
+  FILTER_MODE = :fuzzy
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -455,6 +455,23 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     end
   end
 
+  describe "FILTER_MODE" do
+    it "generates fuzzy search mode by default" do
+      ActiveRecord::Schema.define { create_table :foos }
+
+      class Foo < ApplicationRecord
+        reset_column_information
+      end
+
+      run_generator ["foo"]
+      load file("app/dashboards/foo_dashboard.rb")
+
+      expect(FooDashboard::FILTER_MODE).to eq(:fuzzy)
+    ensure
+      remove_constants :Foo, :FooDashboard
+    end
+  end
+
   describe "resource controller" do
     it "has valid syntax" do
       controller = file("app/controllers/admin/customers_controller.rb")

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -23,6 +23,10 @@ class MockDashboard
   }.freeze
 end
 
+class MockDashboardWithStrictSearch < MockDashboard
+  FILTER_MODE = :strict
+end
+
 class MockDashboardWithAssociation
   ATTRIBUTE_TYPES = {
     role: Administrate::Field::BelongsTo.with_options(
@@ -116,6 +120,31 @@ describe Administrate::Search do
           "%тест test%",
           "%тест test%",
           "%тест test%",
+        ]
+        expect(scoped_object).to receive(:where).with(*expected_query)
+
+        search.run
+      ensure
+        remove_constants :User
+      end
+    end
+
+    context "with strict search mode" do
+      it "searches equality for all searchable fields" do
+        class User < ApplicationRecord; end
+        scoped_object = User.default_scoped
+        search = Administrate::Search.new(scoped_object,
+                                          MockDashboardWithStrictSearch,
+                                          "test")
+        expected_query = [
+          [
+            '"users"."id" = ?',
+            '"users"."name" = ?',
+            '"users"."email" = ?',
+          ].join(" OR "),
+          "test",
+          "test",
+          "test",
         ]
         expect(scoped_object).to receive(:where).with(*expected_query)
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -53,12 +53,12 @@ describe Administrate::Search do
       begin
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
-                                          MockDashboard,
-                                          nil)
         expect(scoped_object).to receive(:all)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboard,
+                            nil
+        )
       ensure
         remove_constants :User
       end
@@ -68,12 +68,11 @@ describe Administrate::Search do
       begin
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
-                                          MockDashboard,
-                                          "   ")
         expect(scoped_object).to receive(:all)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboard,
+                            "   ")
       ensure
         remove_constants :User
       end
@@ -83,9 +82,6 @@ describe Administrate::Search do
       begin
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
-                                          MockDashboard,
-                                          "test")
         expected_query = [
           [
             'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
@@ -98,7 +94,9 @@ describe Administrate::Search do
         ]
         expect(scoped_object).to receive(:where).with(*expected_query)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboard,
+                            "test")
       ensure
         remove_constants :User
       end
@@ -108,9 +106,6 @@ describe Administrate::Search do
       begin
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
-                                          MockDashboard,
-                                          "Тест Test")
         expected_query = [
           [
             'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
@@ -123,7 +118,9 @@ describe Administrate::Search do
         ]
         expect(scoped_object).to receive(:where).with(*expected_query)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboard,
+                            "Тест Test")
       ensure
         remove_constants :User
       end
@@ -133,7 +130,7 @@ describe Administrate::Search do
       it "searches equality for all searchable fields" do
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
+        search = described_class.new(scoped_object,
                                           MockDashboardWithStrictSearch,
                                           "test")
         expected_query = [
@@ -148,7 +145,9 @@ describe Administrate::Search do
         ]
         expect(scoped_object).to receive(:where).with(*expected_query)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboardWithStrictSearch,
+                            "test")
       ensure
         remove_constants :User
       end
@@ -157,8 +156,8 @@ describe Administrate::Search do
     context "when searching through associations" do
       let(:scoped_object) { double(:scoped_object) }
 
-      let(:search) do
-        Administrate::Search.new(
+      subject(:search_run) do
+        described_class.run(
           scoped_object,
           MockDashboardWithAssociation,
           "Тест Test",
@@ -184,7 +183,7 @@ describe Administrate::Search do
         expect(scoped_object).to receive(:joins).with(%i(role author address)).
           and_return(scoped_object)
 
-        search.run
+        search_run
       end
 
       it "builds the 'where' clause using the joined tables" do
@@ -193,7 +192,7 @@ describe Administrate::Search do
 
         expect(scoped_object).to receive(:where).with(*expected_query)
 
-        search.run
+        search_run
       end
     end
 
@@ -203,16 +202,15 @@ describe Administrate::Search do
           scope :vip, -> { where(kind: :vip) }
         end
         scoped_object = User.default_scoped
-        search = Administrate::Search.new(scoped_object,
-                                          MockDashboard,
-                                          "vip:")
         expect(scoped_object).to \
           receive(:where).
           with(kind: :vip).
           and_return(scoped_object)
         expect(scoped_object).to receive(:where).and_return(scoped_object)
 
-        search.run
+        described_class.run(scoped_object,
+                            MockDashboard,
+                            "vip:")
       ensure
         remove_constants :User
       end

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -57,8 +57,7 @@ describe Administrate::Search do
 
         described_class.run(scoped_object,
                             MockDashboard,
-                            nil
-        )
+                            nil)
       ensure
         remove_constants :User
       end
@@ -130,9 +129,6 @@ describe Administrate::Search do
       it "searches equality for all searchable fields" do
         class User < ApplicationRecord; end
         scoped_object = User.default_scoped
-        search = described_class.new(scoped_object,
-                                          MockDashboardWithStrictSearch,
-                                          "test")
         expected_query = [
           [
             '"users"."id" = ?',


### PR DESCRIPTION
Extend quick search feature with `strict` strategy that gives possibility
to search entities for strictly equality to search pattern.
For backward compatibility default strategy is `fuzzy` that works as before this changes.