### PR TITLE
Fix typo in code comment

### DIFF
--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -55,7 +55,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # in the search field:
   #
   #   COLLECTION_FILTERS = {
-  #     open: ->(resources) { where(open: true) }
+  #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 


### PR DESCRIPTION
The example code in the `COLLECTION_FILTERS` generated code comment
had a small bug, was missing a reference to the `resources` parameter.