### PR TITLE
It should be possible to run every spec individually

### DIFF
--- a/spec/generators/assets/javascripts_generator_spec.rb
+++ b/spec/generators/assets/javascripts_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/assets/javascripts_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/assets/javascripts_generator"
 
 describe Administrate::Generators::Assets::JavascriptsGenerator, :generator do
   describe "administrate:assets:javascripts" do

--- a/spec/generators/assets/stylesheets_generator_spec.rb
+++ b/spec/generators/assets/stylesheets_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/assets/stylesheets_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/assets/stylesheets_generator"
 
 describe Administrate::Generators::Assets::StylesheetsGenerator, :generator do
   describe "administrate:assets:stylesheets" do

--- a/spec/generators/assets_generator_spec.rb
+++ b/spec/generators/assets_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/assets/assets_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/assets/assets_generator"
 
 describe Administrate::Generators::AssetsGenerator, :generator do
   describe "administrate:assets" do

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
-require "generators/administrate/install/install_generator"
-require "support/generator_spec_helpers"
 require "support/constant_helpers"
+require "support/generator_spec_helpers"
+require "generators/administrate/install/install_generator"
 
 describe Administrate::Generators::InstallGenerator, :generator do
   after { reset_routes }

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
-require "generators/administrate/routes/routes_generator"
-require "support/generator_spec_helpers"
 require "support/constant_helpers"
+require "support/generator_spec_helpers"
+require "generators/administrate/routes/routes_generator"
 
 describe Administrate::Generators::RoutesGenerator, :generator do
   before { stub_generator_dependencies }

--- a/spec/generators/views/edit_generator_spec.rb
+++ b/spec/generators/views/edit_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/edit_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/edit_generator"
 
 describe Administrate::Generators::Views::EditGenerator, :generator do
   describe "administrate:views:edit" do

--- a/spec/generators/views/field_generator_spec.rb
+++ b/spec/generators/views/field_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/views/field_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/field_generator"
 
 describe Administrate::Generators::Views::FieldGenerator, :generator do
   context "for an existing field type" do

--- a/spec/generators/views/form_generator_spec.rb
+++ b/spec/generators/views/form_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/form_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/form_generator"
 
 describe Administrate::Generators::Views::FormGenerator, :generator do
   describe "administrate:views:form" do

--- a/spec/generators/views/index_generator_spec.rb
+++ b/spec/generators/views/index_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/index_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/index_generator"
 
 describe Administrate::Generators::Views::IndexGenerator, :generator do
   describe "administrate:views:index" do

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/views/layout_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/layout_generator"
 
 describe Administrate::Generators::Views::LayoutGenerator, :generator do
   describe "administrate:views:layout" do

--- a/spec/generators/views/navigation_generator_spec.rb
+++ b/spec/generators/views/navigation_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/navigation_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/navigation_generator"
 
 describe Administrate::Generators::Views::NavigationGenerator, :generator do
   describe "administrate:views:navigation" do

--- a/spec/generators/views/new_generator_spec.rb
+++ b/spec/generators/views/new_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/new_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/new_generator"
 
 describe Administrate::Generators::Views::NewGenerator, :generator do
   describe "administrate:views:new" do

--- a/spec/generators/views/show_generator_spec.rb
+++ b/spec/generators/views/show_generator_spec.rb
@@ -1,6 +1,5 @@
-require "spec_helper"
-require "generators/administrate/views/show_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/show_generator"
 
 describe Administrate::Generators::Views::ShowGenerator, :generator do
   describe "administrate:views:show" do

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
-require "generators/administrate/views/views_generator"
 require "support/generator_spec_helpers"
+require "generators/administrate/views/views_generator"
 
 describe Administrate::Generators::ViewsGenerator, :generator do
   describe "administrate:views resource" do

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -1,3 +1,4 @@
+require "active_record"
 require "administrate/order"
 
 describe Administrate::Order do

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -1,4 +1,5 @@
 require "administrate/field/deferred"
+require "administrate/field/belongs_to"
 require "administrate/field/string"
 
 describe Administrate::Field::Deferred do

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/has_many"
 require "support/constant_helpers"
 require "support/mock_relation"

--- a/spec/lib/pages/form_spec.rb
+++ b/spec/lib/pages/form_spec.rb
@@ -1,4 +1,4 @@
-require "administrate/page/form"
+require "rails_helper"
 
 describe Administrate::Page::Form do
   describe "#page_title" do

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -1,4 +1,4 @@
-require "administrate/page/show"
+require "rails_helper"
 
 describe Administrate::Page::Show do
   describe "#page_title" do

--- a/spec/lib/pages/table_spec.rb
+++ b/spec/lib/pages/table_spec.rb
@@ -1,4 +1,0 @@
-require "administrate/page/collection"
-
-describe Administrate::Page::Collection do
-end

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "ammeter/rspec/generator/example"
 require "ammeter/rspec/generator/matchers"
 require "ammeter/init"


### PR DESCRIPTION
I noticed that some specs can't be run individually, as their dependencies are not correct. This can become rather inconvenient while debugging Administrate. This PR fixes this issue.

A way to check that specs run individually is with the following one-liner:

```
$ find spec | grep _spec.rb | while read spec; do bundle exec rspec $spec; done
```

This includes some changes that are not really necessary, but I think make the specs make more sense. I'm referring mainly to things like `spec/generators/assets/javascripts_generator_spec.rb`, where I make sure that `support/generator_spec_helpers` is required before the tested code, because I feel that the helpers should be loaded first (like `spec_helper` or `rails_helper`) are.