### PR TITLE
Don't convert nil to '' (empty string)

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -145,7 +145,7 @@ module Administrate
           raise "Unrecognised param data: #{data.inspect}"
         end
       else
-        data
+        data.presence
       end
     end
 


### PR DESCRIPTION
If I have a record wil `nil` values, when updating anything else in the record, it will change my `nil` values for `''`. This PR fixes that