### PR TITLE
Set `parser` version in lock-step to Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
           PGHOST: localhost
           PGUSER: administrate
           RAILS_ENV: test
+          RUBY_VERSION: 2.5.0
       - image: postgres:10.1-alpine
         environment:
           POSTGRES_USER: administrate
@@ -64,6 +65,7 @@ jobs:
           PGHOST: localhost
           PGUSER: administrate
           RAILS_ENV: test
+          RUBY_VERSION: 2.6.3
       - image: postgres:10.1-alpine
         environment:
           POSTGRES_USER: administrate

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.29"
+  gem "parser", ENV.fetch("RUBY_VERSION", Pathname(".ruby-version").read)
   gem "pry-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
-    parser (2.6.2.1)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (1.1.4)
     poltergeist (1.18.1)
@@ -268,6 +268,7 @@ DEPENDENCIES
   globalid
   i18n-tasks (= 0.9.29)
   launchy
+  parser (= 2.6.3)
   pg
   poltergeist
   pry-rails


### PR DESCRIPTION
Determine the version based on the `RUBY_VERSION` set by CI, or the
contents of `.ruby-version`.

```
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.5-compliant syntax, but you are running 2.6.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```