### PR TITLE
Cache Bundle across Gemfiles in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ commands:
 
       # Bundle install dependencies
       - run: bundle install --path vendor/bundle
+      - run: BUNDLE_GEMFILE=gemfiles/rails42.gemfile bundle install --path vendor/bundle
+      - run: BUNDLE_GEMFILE=gemfiles/rails50.gemfile bundle install --path vendor/bundle
+      - run: BUNDLE_GEMFILE=gemfiles/rails51.gemfile bundle install --path vendor/bundle
+      - run: BUNDLE_GEMFILE=gemfiles/rails52.gemfile bundle install --path vendor/bundle
+      - run: BUNDLE_GEMFILE=gemfiles/rails60.gemfile bundle install --path vendor/bundle
 
       # Cache Dependencies
       - save_cache:
@@ -38,7 +43,6 @@ default_job: &default_job
   steps:
     - shared_steps
     # Run the tests against multiple versions of Rails
-    - run: bundle exec appraisal install
     - run: bundle exec appraisal rake
 
 jobs:


### PR DESCRIPTION
The `appraisal install` command does not (yet?) accept flags in the same
way that `bundle install` does.

Prior to this commit, `bundle install --path vendor/bundle` is invoked
between restoring from and saving to the cache. In theory, this
relies on prior installation work.

Unfortunately, since the test suite is run through Appraisals, these
caches are unused.

This commit replaces the `appraisal` install with the underlying
behavior, called explicitly by setting `BUNDLE_GEMFILE` directly for
each supported Rails version.