### PR TITLE
Double-click to select attribute text

### DIFF
--- a/app/views/fields/string/_show.html.erb
+++ b/app/views/fields/string/_show.html.erb
@@ -4,7 +4,7 @@
 This partial renders a string attribute,
 to be displayed on a resource's show page.
 
-By default, the attribute is rendered as an unformatted string.
+By default, the attribute is rendered as text with whitespace preserved.
 
 ## Local variables:
 
@@ -15,4 +15,4 @@ By default, the attribute is rendered as an unformatted string.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/String
 %>
 
-<%= field.data %>
+<div class="preserve-whitespace"><%= field.data %></div>

--- a/app/views/fields/text/_show.html.erb
+++ b/app/views/fields/text/_show.html.erb
@@ -16,4 +16,4 @@ whitespace preserved.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Text
 %>
 
-<span class="preserve-whitespace"><%= field.data %></span>
+<div class="preserve-whitespace"><%= field.data %></div>

--- a/app/views/fields/text/_show.html.erb
+++ b/app/views/fields/text/_show.html.erb
@@ -4,8 +4,7 @@
 This partial renders a text attribute,
 to be displayed on a resource's show page.
 
-By default, the attribute is rendered as text with
-whitespace preserved.
+By default, the attribute is rendered as text with whitespace preserved.
 
 ## Local variables:
 


### PR DESCRIPTION
Each show page displays a description list of the fields.
When the field is text, it is rendered inside an inline `<span>`.

I've found it common to want to double-click this text
to copy-paste an identifier from our admin app into other systems.

Previously, double-clicking would not select the field's value.
The bug can be seen on the show page in the demo app. For example,
try selecting the city or zip code values from:

https://administrate-prototype.herokuapp.com/admin/orders/198962

Changing the markup to be a block `<div>` fixes the bug.
Alternatively, we could change the `preserve-whitespace` CSS rule
to be `display: block;`.