### PR TITLE
On index pages for has_many fields, only use the size of the association

### DIFF
--- a/app/views/fields/has_many/_index.html.erb
+++ b/app/views/fields/has_many/_index.html.erb
@@ -16,4 +16,4 @@ as a count of how many objects are associated through the relationship.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
 %>
 
-<%= pluralize(field.data.size, field.attribute.to_s.humanize.downcase.singularize) %>
+<%= pluralize(field.data, field.attribute.to_s.humanize.downcase.singularize) %>

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -28,11 +28,23 @@ module Administrate
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)
         field = dashboard.attribute_type_for(attribute_name)
+        value = value.size if use_count_value?(page, field)
         field.new(attribute_name, value, page, resource: resource)
       end
 
       def get_attribute_value(resource, attribute_name)
         resource.public_send(attribute_name)
+      end
+
+      def use_count_value?(page, field)
+        return false unless page == :index
+
+        has_many_field?(field)
+      end
+
+      def has_many_field?(field)
+        field.is_a?(Administrate::Field::HasMany) ||
+          (field.is_a?(Administrate::Field::Deferred) && field.deferred_class == Administrate::Field::HasMany)
       end
 
       attr_reader :dashboard, :options

--- a/spec/administrate/page/collection_spec.rb
+++ b/spec/administrate/page/collection_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require "administrate/page/base"
+
+describe Administrate::Page::Collection do
+  describe "#attributes_for" do
+    let(:customer) { FactoryBot.create(:customer, :with_orders, order_count: 4) }
+
+    before { customer }
+
+    it "returns Integer data for a has_many field type" do
+      dashboard = CustomerDashboard.new
+      dashboard_page = Administrate::Page::Collection.new(dashboard)
+      orders_field = dashboard_page.attributes_for(customer).select { |field| field.attribute == :orders }.first
+
+      expect(orders_field.data).to be_an Integer
+    end
+
+    it "returns the correct object count for a has_many field type" do
+      dashboard = CustomerDashboard.new
+      dashboard_page = Administrate::Page::Collection.new(dashboard)
+      orders_field = dashboard_page.attributes_for(customer).select { |field| field.attribute == :orders }.first
+
+      expect(orders_field.data).to eq 4
+    end
+  end
+end

--- a/spec/administrate/page/show_spec.rb
+++ b/spec/administrate/page/show_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require "administrate/page/base"
+
+describe Administrate::Page::Show do
+  describe "#attributes" do
+    let(:customer) { FactoryBot.create(:customer, :with_orders, order_count: 4) }
+
+    before { customer }
+
+    it "returns ActiveRecord::Associations::CollectionProxy data for a has_many field type" do
+      dashboard = CustomerDashboard.new
+      dashboard_page = Administrate::Page::Show.new(dashboard, customer)
+      orders_field = dashboard_page.attributes.select { |field| field.attribute == :orders }.first
+
+      expect(orders_field.data).to be_an ActiveRecord::Associations::CollectionProxy
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses #1464 