### PR TITLE
Render all records allowed by the authorization scope

### DIFF
--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -21,6 +21,9 @@ tr {
 tbody tr {
   &:hover {
     background-color: $base-background-color;
+  }
+
+  &[role=link] {
     cursor: pointer;
   }
 

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -68,6 +68,8 @@ to display a collection of resources in an HTML table.
                  >
                 <%= render_field attribute %>
               </a>
+            <% else %>
+              <%= render_field attribute %>
             <% end -%>
           </td>
         <% end %>

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -56,7 +56,7 @@ to display a collection of resources in an HTML table.
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           tabindex="0"
-          <% if valid_action? :show, collection_presenter.resource_name %>
+          <% if show_action? :show, resource %>
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -55,9 +55,8 @@ to display a collection of resources in an HTML table.
   <tbody>
     <% resources.each do |resource| %>
       <tr class="js-table-row"
-          tabindex="0"
           <% if show_action? :show, resource %>
-            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -63,6 +63,7 @@ to display a collection of resources in an HTML table.
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if show_action? :show, resource -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 tabindex="-1"
                  class="action-show"
                  >
                 <%= render_field attribute %>

--- a/spec/example_app/app/controllers/admin/products_controller.rb
+++ b/spec/example_app/app/controllers/admin/products_controller.rb
@@ -1,5 +1,13 @@
 module Admin
   class ProductsController < Admin::ApplicationController
+    include Administrate::Punditize
+
+    class PunditUser; end
+
+    def pundit_user
+      PunditUser.new
+    end
+
     private
 
     def find_resource(param)

--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -1,6 +1,6 @@
 class Product < ApplicationRecord
-  def self.policy_class=(p)
-    @policy_class = p
+  def self.policy_class=(policy)
+    @policy_class = policy
   end
 
   def self.policy_class

--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -1,4 +1,12 @@
 class Product < ApplicationRecord
+  def self.policy_class=(p)
+    @policy_class = p
+  end
+
+  def self.policy_class
+    @policy_class ||= ProductPolicy
+  end
+
   has_many :line_items, dependent: :destroy
   has_one :product_meta_tag, dependent: :destroy
 

--- a/spec/example_app/app/policies/product_policy.rb
+++ b/spec/example_app/app/policies/product_policy.rb
@@ -1,0 +1,35 @@
+class ProductPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    true
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    true
+  end
+end

--- a/spec/example_app/app/policies/product_policy.rb
+++ b/spec/example_app/app/policies/product_policy.rb
@@ -10,7 +10,7 @@ class ProductPolicy < ApplicationPolicy
   end
 
   def show?
-    scope.where(:id => record.id).exists?
+    scope.where(id: record.id).exists?
   end
 
   def create?

--- a/spec/example_app/spec/features/authorization_spec.rb
+++ b/spec/example_app/spec/features/authorization_spec.rb
@@ -2,11 +2,24 @@ require "rails_helper"
 
 RSpec.feature "Authorization", type: :feature do
   before do
-    class ProductPolicy::Scope
-      def resolve
-        scope.where('price < :threshold', threshold: 15)
+    class TestProductPolicy < ProductPolicy
+      class Scope < Scope
+        def resolve
+          scope.where('price < :threshold', threshold: 15)
+        end
+      end
+
+      def show?
+        false
       end
     end
+
+    @original_product_policy = Product.policy_class
+    Product.policy_class = TestProductPolicy
+  end
+
+  after do
+    Product.policy_class = @original_product_policy
   end
 
   it "renders all results yielded by the scope" do

--- a/spec/example_app/spec/features/authorization_spec.rb
+++ b/spec/example_app/spec/features/authorization_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Authorization", type: :feature do
     class TestProductPolicy < ProductPolicy
       class Scope < Scope
         def resolve
-          scope.where('price < :threshold', threshold: 15)
+          scope.where("price < :threshold", threshold: 15)
         end
       end
 
@@ -30,6 +30,6 @@ RSpec.feature "Authorization", type: :feature do
 
     expect(page).to have_content(p0.name)
     expect(page).not_to have_content(p1.name)
-    expect(page).to have_css('.js-table-row', count: 1)
+    expect(page).to have_css(".js-table-row", count: 1)
   end
 end

--- a/spec/example_app/spec/features/authorization_spec.rb
+++ b/spec/example_app/spec/features/authorization_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "Authorization", type: :feature do
+  before do
+    class ProductPolicy::Scope
+      def resolve
+        scope.where('price < :threshold', threshold: 15)
+      end
+    end
+  end
+
+  it "renders all results yielded by the scope" do
+    p0 = create(:product, name: "Shown", price: 10)
+    p1 = create(:product, name: "Hidden", price: 20)
+
+    visit admin_products_path
+
+    expect(page).to have_content(p0.name)
+    expect(page).not_to have_content(p1.name)
+    expect(page).to have_css('.js-table-row', count: 1)
+  end
+end


### PR DESCRIPTION
Working with Pundit, I was seeing this index page:

![Screenshot from 2019-12-13 22-28-37](https://user-images.githubusercontent.com/36066/70836509-3f574400-1df8-11ea-93f6-50cbe6b9ec6e.png)

That was supposed to be 4 records, but they were showing as empty rows. Instead I was expecting to see the following:

![Screenshot from 2019-12-13 22-29-10](https://user-images.githubusercontent.com/36066/70836524-4e3df680-1df8-11ea-9490-9c8cbb979a58.png)

The issue was that the Pundit scope for the model was returning those records, but the per-resource policy was returning `false` for `show?` on each one of them.

This is a bit of an edge case: if the user can't see the resources, surely the scope shouldn't be returning them. Still I can think of a use case where some users can see them listed (with limited information) but can't access the show page (with additional information). In any case, Pundit allows for this, and I think this behaviour is a bug.

The fix itself is just in `app/views/administrate/application/_collection.html.erb`. Apart from that, this PR is mostly me figuring out a way to test this in a disposable way that doesn't affect other specs.

"Mostly", because there's one more thing. While working with this, I came across the `tabindex` settings on the index page. As they stand at the moment, each row is tabbable, as well as each individual cell inside each row. I understand this is because these are links, but it strikes me as very annoying to navigate. On the example above, you need to tab 5 times per row, and you get the same link for all 5 positions. I don't think this is the way `tabindex` is supposed to be used.

The reason I made this other change is because it's related: when applying the authorization fix, I had to also make rows tabbable only if they had a link. While changing this, I noticed the other behaviour.

Can someone who knows more about accessibility than me confirm all this?