### PR TITLE
Attempt to fix random CI failures

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,5 +1,17 @@
 RSpec.configure do |config|
   config.before(:suite) do
+    if config.use_transactional_fixtures?
+      raise(<<-MSG)
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the app-under-test that the browser driver connects to
+        uses a different database connection to the database connection used by
+        the spec. The app's database connection would not be able to access
+        uncommitted transaction data setup over the spec's database connection.
+      MSG
+    end
     DatabaseCleaner.clean_with(:truncation)
   end
 
@@ -7,15 +19,24 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, :js => true) do
-    DatabaseCleaner.strategy = :truncation
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    unless driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
   end
 
   config.before(:each) do
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
We get frequent random CI failures with errors on feature specs, like
the following:

```
Failures:

  1) Search admin searches with an unknown filter
     Failure/Error: DatabaseCleaner.clean

     ActiveRecord::StatementInvalid:
       PG::TRDeadlockDetected: ERROR:  deadlock detected
       DETAIL:  Process 12270 waits for AccessExclusiveLock on relation 16412 of database 16386; blocked by process 12192.
       Process 12192 waits for AccessShareLock on relation 16400 of database 16386; blocked by process 12270.
       HINT:  See server log for query details.
       : TRUNCATE TABLE "public"."blog_posts", "public"."series", "public"."countries", "public"."log_entries", "public"."payments", "public"."product_meta_tags", "public"."customers", "public"."products", "public"."orders", "public"."line_items" RESTART IDENTITY CASCADE;
     # ./spec/support/database_cleaner.rb:19:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # PG::TRDeadlockDetected:
     #   ERROR:  deadlock detected
     #   DETAIL:  Process 12270 waits for AccessExclusiveLock on relation 16412 of database 16386; blocked by process 12192.
     #   Process 12192 waits for AccessShareLock on relation 16400 of database 16386; blocked by process 12270.
     #   HINT:  See server log for query details.
     #   ./spec/support/database_cleaner.rb:19:in `block (2 levels) in <top (required)>'

Finished in 29.41 seconds (files took 3.65 seconds to load)
418 examples, 1 failure
```

This may or may not be related to `DatabaseCleaner`. As an attempt to
fix it, I'm trying this configuration, copied straight from their
documentation at https://github.com/DatabaseCleaner/database_cleaner/blob/v1.7.0/README.markdown