### PR TITLE
Avoid triggering unpermitted params on JS link

### DIFF
--- a/app/assets/javascripts/administrate/components/table.js
+++ b/app/assets/javascripts/administrate/components/table.js
@@ -13,7 +13,7 @@ $(function() {
       var dataUrl = $(event.target).closest("tr").data("url");
       var selection = window.getSelection().toString();
       if (selection.length === 0 && dataUrl) {
-        window.location.pathname = dataUrl;
+        window.location = window.location.protocol + '//' + window.location.host + dataUrl;
       }
     }
   };

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -95,6 +95,16 @@ describe "customer index page" do
       expect_to_appear_in_order("unique name one", "unique name two")
     end
 
+    it "allows clicking through after sorting", :js do
+      customer = create(:customer)
+      create(:order, customer: customer)
+
+      visit admin_customers_path
+      click_on "Name"
+      find("[data-url]").click
+      expect(page).to have_header("Show #{customer.name}")
+    end
+
     it "allows reverse sorting" do
       create(:customer, name: "unique name one")
       create(:customer, name: "unique name two")


### PR DESCRIPTION
With https://github.com/thoughtbot/administrate/pull/1457, I introduced a bug. Reproduction:

1. Visit the index page of a model with a has_many relationship (eg: customers).
2. Click on a table header to trigger some sorting. The current URL will gain query params.
3. Click on a row to see the show page of a record. Don't click on actual data on the table (eg: customer name), but instead click on a "blank" area of the row. This is so that the JS click handler kicks in and performs the "link" behaviour, as opposed to clicking on an actual link.
4. You'll get an error `ActionController::UnpermittedParameters`.

This is triggered by the following:

1. At the index page, the URL is something like `/admin/customers`
2. When sorting the table, the current URL becomes something like `/admin/customers?customer%5Bdirection%5D=desc&customer%5Border%5D=name`
3. Clicking on the row, the JS gets us a URL like so `/admin/customers/123?customer%5Bdirection%5D=desc&customer%5Border%5D=name`
4. The partial that renders the has_many relationship in the show page can receive query params. It checks that the current ones are permitted. Turns out those aren't (they are in the index page, but not here), so it raises an exception.

I'm not sure about the spec example I have introduced. I feel that someone who finds it in the future is going to wonder where that came from. I guess they can check the git history...? Thoughts?