### PR TITLE
Avoid confusion with class methods and protected/private modifiers

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -20,16 +20,16 @@ module Administrate
         to_s.split("::").last.underscore
       end
 
+      def self.permitted_attribute(attr, _options = nil)
+        attr
+      end
+
       def initialize(attribute, data, page, options = {})
         @attribute = attribute
         @data = data
         @page = page
         @resource = options.delete(:resource)
         @options = options
-      end
-
-      def self.permitted_attribute(attr, _options = nil)
-        attr
       end
 
       def html_class

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -16,6 +16,10 @@ module Administrate
         false
       end
 
+      def self.field_type
+        to_s.split("::").last.underscore
+      end
+
       def initialize(attribute, data, page, options = {})
         @attribute = attribute
         @data = data
@@ -41,12 +45,6 @@ module Administrate
       end
 
       attr_reader :attribute, :data, :options, :page, :resource
-
-      protected
-
-      def self.field_type
-        to_s.split("::").last.underscore
-      end
     end
   end
 end

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -3,13 +3,6 @@ require_relative "associative"
 module Administrate
   module Field
     class HasOne < Associative
-      def nested_form
-        @nested_form ||= Administrate::Page::Form.new(
-          resolver.dashboard_class.new,
-          data || resolver.resource_class.new,
-        )
-      end
-
       def self.permitted_attribute(attr, options = nil)
         associated_class_name =
           if options
@@ -22,6 +15,13 @@ module Administrate
             dashboard_class.new.permitted_attributes + [:id]
 
         { "#{attr}_attributes": related_dashboard_attributes }
+      end
+
+      def nested_form
+        @nested_form ||= Administrate::Page::Form.new(
+          resolver.dashboard_class.new,
+          data || resolver.resource_class.new,
+        )
       end
 
       private

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -3,16 +3,16 @@ require_relative "associative"
 module Administrate
   module Field
     class Polymorphic < BelongsTo
+      def self.permitted_attribute(attr, _options = nil)
+        { attr => %i{type value} }
+      end
+
       def associated_resource_grouped_options
         classes.map do |klass|
           [klass.to_s, candidate_resources_for(klass).map do |resource|
             [display_candidate_resource(resource), resource.to_global_id]
           end]
         end
-      end
-
-      def self.permitted_attribute(attr, _options = nil)
-        { attr => %i{type value} }
       end
 
       def permitted_attribute

--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -5,14 +5,14 @@ module Administrate
   class ViewGenerator < Rails::Generators::Base
     include Administrate::GeneratorHelpers
 
-    private
-
     def self.template_source_path
       File.expand_path(
         "../../../app/views/administrate/application",
         __FILE__,
       )
     end
+
+    private
 
     def copy_resource_template(template_name)
       template_file = "#{template_name}.html.erb"


### PR DESCRIPTION
Working on something else, I saw the following:

```ruby
protected

# ...

def self.field_type
  to_s.split("::").last.underscore
end
```

This code can lead to misunderstanding, as the `protected` modifier doesn't apply to class methods like `self.field_type`.

On this PR, I move two such class methods behind the modifier, near the top of the class, to avoid this confusion.

I also move three other class methods to the top of the class, as I feel class methods should go together in general, in order to clarify interfaces and avoid future instances of this anti-pattern.