### PR TITLE
Make Field#options public, enabling access from templates

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -40,11 +40,9 @@ module Administrate
         "/fields/#{self.class.field_type}/#{page}"
       end
 
-      attr_reader :attribute, :data, :page, :resource
+      attr_reader :attribute, :data, :options, :page, :resource
 
       protected
-
-      attr_reader :options
 
       def self.field_type
         to_s.split("::").last.underscore


### PR DESCRIPTION
Over at https://github.com/thoughtbot/administrate/issues/612, a fair point was made: if field `options` were public, they could be accessed from templates. This would enable users to customize fields without having to create new field types, which I find a bit more cumbersome.

An argument against this change would be that it increases the contact surface of field types, which can be an issue later if we change the interface of fields.

An argument for this change would be that the interface of fields is unlikely to change radically at this point. If it did, probably subclasses would have to change anyway too, possibly forcing more significant changes than that of how to access the options.

I'm not 100% sure about this one. I'd like to hear more opinions, use cases, etc. So here's a PR, which hopefully will bring some feedback.