### PR TITLE
_navigation.html.erb: Hide resources without index

### DIFF
--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -15,6 +15,6 @@ as defined by the routes in the `admin/` namespace
       display_resource_name(resource),
       [namespace, resource_index_route_key(resource)],
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
-    ) %>
+    ) if valid_action? :index, resource  %>
   <% end %>
 </nav>

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :log_entries
     resources :orders
     resources :products
-    resources :product_meta_tags
+    resources :product_meta_tags, except: [:index]
     resources :payments, only: [:index, :show]
     resources :series
 

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -36,4 +36,10 @@ describe "navigation" do
       expect(page).to have_header("Users")
     end
   end
+
+  it "hides link to resources without index page" do
+    visit admin_customers_path
+    navigation = find(".navigation")
+    expect(navigation).not_to have_link("Product Meta Tags")
+  end
 end


### PR DESCRIPTION
This will hide link on the navigation bar for resources without an index page.

Add interface `actions` to Administrate::Namespace::Resource  that can be a solution to #1517.


> This is related to #1517 but not directly fix it.
