### PR TITLE
Declare doctype, language and charset

### DIFF
--- a/spec/example_app/app/views/layouts/docs.html.erb
+++ b/spec/example_app/app/views/layouts/docs.html.erb
@@ -1,5 +1,7 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8" />
   <%= stylesheet_link_tag "docs", media: "all" %>
   <link href='//fonts.googleapis.com/css?family=Lato|Source+Code+Pro|Fjalla+One' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css">


### PR DESCRIPTION
Noticed these missing on the doc pages. Surely an oversight?