### PR TITLE
More readable warnings

### DIFF
--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -20,15 +20,15 @@ module Administrate
       end
 
       def warn_about_invalid_models
-        namespaced_models.each do |invalid_model|
-          puts "WARNING: Unable to generate a dashboard for #{invalid_model}."
-          puts "         Administrate does not yet support namespaced models."
-        end
-
-        models_without_tables.each do |invalid_model|
-          puts "WARNING: Unable to generate a dashboard for #{invalid_model}."
-          puts "         It is not connected to a database table."
-          puts "         Make sure your database migrations are up to date."
+        invalid_dashboard_models.each do |model|
+          puts "WARNING: Unable to generate a dashboard for #{model}."
+          if namespaced_models.include?(model)
+            puts "       - Administrate does not yet support namespaced models."
+          end
+          if models_without_tables.include?(model)
+            puts "       - It is not connected to a database table."
+            puts "         Make sure your database migrations are up to date."
+          end
         end
 
         unnamed_constants.each do |invalid_model|
@@ -49,15 +49,15 @@ module Administrate
       end
 
       def valid_dashboard_models
-        database_models - invalid_database_models
+        database_models - invalid_dashboard_models
       end
 
       def database_models
         ActiveRecord::Base.descendants.reject(&:abstract_class?)
       end
 
-      def invalid_database_models
-        models_without_tables + namespaced_models + unnamed_constants
+      def invalid_dashboard_models
+        (models_without_tables + namespaced_models + unnamed_constants).uniq
       end
 
       def models_without_tables

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -46,7 +46,7 @@ describe Administrate::Generators::RoutesGenerator, :generator do
 
       expect(output).to include <<-MSG.strip_heredoc
         WARNING: Unable to generate a dashboard for Blog::Post.
-                 Administrate does not yet support namespaced models.
+               - Administrate does not yet support namespaced models.
       MSG
     end
 
@@ -96,6 +96,22 @@ describe Administrate::Generators::RoutesGenerator, :generator do
         expect(output).not_to include("WARNING: Unable to generate a "\
           "dashboard for AbstractModel")
       end
+    end
+
+    it "groups together warnings related to the same model" do
+      class TestModelNamespace
+        class ModelWithoutDBTable < ApplicationRecord; end
+      end
+
+      model_name = TestModelNamespace::ModelWithoutDBTable.to_s
+      output = run_generator
+
+      warning = "WARNING: Unable to generate a dashboard " \
+        "for #{model_name}."
+      occurrences = output.scan(warning).count
+      expect(occurrences).to eq(1)
+    ensure
+      remove_constants :TestModelNamespace
     end
   end
 


### PR DESCRIPTION
During normal operation, the routes generator can print a few warnings. When there's more than one reason to trigger a warning for a given resource, these are printed out separately, often with other warnings intereleaved.

For example, these are 8 warning about 4 different resources:

```
WARNING: Unable to generate a dashboard for ActionText::RichText.
         Administrate does not yet support namespaced models.
WARNING: Unable to generate a dashboard for ActionMailbox::InboundEmail.
         Administrate does not yet support namespaced models.
WARNING: Unable to generate a dashboard for ActiveStorage::Blob.
         Administrate does not yet support namespaced models.
WARNING: Unable to generate a dashboard for ActiveStorage::Attachment.
         Administrate does not yet support namespaced models.
WARNING: Unable to generate a dashboard for ActionText::RichText.
         It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActionMailbox::InboundEmail.
         It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActiveStorage::Blob.
         It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActiveStorage::Attachment.
         It is not connected to a database table.
         Make sure your database migrations are up to date.
```

This is a bit difficult to read and can be confusing. Instead, I propose that we group together the warnings related to each given resource, like so:

```
WARNING: Unable to generate a dashboard for ActionText::RichText.
       - Administrate does not yet support namespaced models.
       - It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActionMailbox::InboundEmail.
       - Administrate does not yet support namespaced models.
       - It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActiveStorage::Blob.
       - Administrate does not yet support namespaced models.
       - It is not connected to a database table.
         Make sure your database migrations are up to date.
WARNING: Unable to generate a dashboard for ActiveStorage::Attachment.
       - Administrate does not yet support namespaced models.
       - It is not connected to a database table.
         Make sure your database migrations are up to date.
```

This PR implements this behaviour.
