### PR TITLE
Use the correct foreign key when sorting belongs_to associations

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -62,7 +62,7 @@ module Administrate
     end
 
     def order_by_id(relation)
-      relation.reorder("#{attribute}_id #{direction}")
+      relation.reorder("#{foreign_key(relation)} #{direction}")
     end
 
     def has_many_attribute?(relation)
@@ -75,6 +75,10 @@ module Administrate
 
     def reflect_association(relation)
       relation.klass.reflect_on_association(attribute.to_s)
+    end
+
+    def foreign_key(relation)
+      reflect_association(relation).foreign_key
     end
   end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -73,7 +73,10 @@ describe Administrate::Order do
     context "when relation has belongs_to association" do
       it "orders by id" do
         order = Administrate::Order.new(:name)
-        relation = relation_with_association(:belongs_to, foreign_key: "some_foreign_key")
+        relation = relation_with_association(
+          :belongs_to,
+          foreign_key: "some_foreign_key",
+        )
         allow(relation).to receive(:reorder).and_return(relation)
 
         ordered = order.apply(relation)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -73,12 +73,12 @@ describe Administrate::Order do
     context "when relation has belongs_to association" do
       it "orders by id" do
         order = Administrate::Order.new(:name)
-        relation = relation_with_association(:belongs_to)
+        relation = relation_with_association(:belongs_to, foreign_key: "some_foreign_key")
         allow(relation).to receive(:reorder).and_return(relation)
 
         ordered = order.apply(relation)
 
-        expect(relation).to have_received(:reorder).with("name_id asc")
+        expect(relation).to have_received(:reorder).with("some_foreign_key asc")
         expect(ordered).to eq(relation)
       end
     end
@@ -176,9 +176,15 @@ describe Administrate::Order do
     )
   end
 
-  def relation_with_association(association)
+  def relation_with_association(association, foreign_key: "#{association}_id")
     double(
-      klass: double(reflect_on_association: double(macro: association)),
+      klass: double(
+        reflect_on_association: double(
+          "#{association}_reflection",
+          macro: association,
+          foreign_key: foreign_key,
+        ),
+      ),
     )
   end
 end


### PR DESCRIPTION
`Administrate::Order` makes the assumption that a relation's foreign key will be `#{relation_name}_id`, when instead it could be anything.

This currently breaks our demo site, if you go to the [customers list](https://administrate-prototype.herokuapp.com/admin/customers) and try to order by country. This is as described by https://github.com/thoughtbot/administrate/issues/1182