### PR TITLE
More natural tabbing across rows in table

### DIFF
--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -21,6 +21,9 @@ tr {
 tbody tr {
   &:hover {
     background-color: $base-background-color;
+  }
+
+  [role=link] {
     cursor: pointer;
   }
 

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -55,15 +55,15 @@ to display a collection of resources in an HTML table.
   <tbody>
     <% resources.each do |resource| %>
       <tr class="js-table-row"
-          tabindex="0"
           <% if valid_action? :show, collection_presenter.resource_name %>
-            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
             <% if show_action? :show, resource -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 tabindex="-1"
                  class="action-show"
                  >
                 <%= render_field attribute %>


### PR DESCRIPTION
(This PR is a split from https://github.com/thoughtbot/administrate/pull/1494, which was mixing two different concerns.)

When the user presses tab, the browser is expected to move to the next link. Since all cells in the table are links, the user has to press tab many times (once per column) in order to move to the next row:

![Tab stopping at each single cell](https://user-images.githubusercontent.com/36066/74949069-215c2000-53f5-11ea-9c38-bf605161ad26.gif)

Since each row works as a link, so much tabbing should not be necessary. This change makes it so that each row is tabbable, but not the cells.

There are two exceptions: action links, and data that should actually be represented as a link (eg: instances of `Field::Url` or `Field::Email`). These are not affected by this change, and are still accessible with an additional tab press for each cell. The row will be highlighted first, then each data link:

![Tab stopping at whole rows, and specific link cells](https://user-images.githubusercontent.com/36066/74950140-98de7f00-53f6-11ea-9752-521369b850e9.gif)
