### PR TITLE
Enable Selectize for BelongsTo

### DIFF
--- a/app/assets/javascripts/administrate/components/associative.js
+++ b/app/assets/javascripts/administrate/components/associative.js
@@ -1,3 +1,4 @@
 $(function() {
+  $('.field-unit--belongs-to select').selectize({});
   $(".field-unit--has-many select").selectize({});
 });


### PR DESCRIPTION
Allow to input a model's BelongsTo relation using keyboard strokes instead of having to scroll a potentially long list of records with the mouse.

<img width="392" alt="Screenshot 2020-03-09 at 12 37 14" src="https://user-images.githubusercontent.com/4217871/76209778-fa7a5800-6202-11ea-8e84-a8a7ab046557.png">
