### PR TITLE
Tables won't always be named after models

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -117,7 +117,12 @@ module Administrate
 
     def query_table_name(attr)
       if association_search?(attr)
-        ActiveRecord::Base.connection.quote_table_name(attr.to_s.pluralize)
+        provided_class_name = attribute_types[attr].options[:class_name]
+        if provided_class_name
+          provided_class_name.constantize.table_name
+        else
+          ActiveRecord::Base.connection.quote_table_name(attr.to_s.pluralize)
+        end
       else
         ActiveRecord::Base.connection.
           quote_table_name(@scoped_resource.table_name)

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -12,9 +12,10 @@ class CustomerDashboard < Administrate::BaseDashboard
     log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
-    country: Field::BelongsTo.with_options(
+    territory: Field::BelongsTo.with_options(
       primary_key: :code,
       foreign_key: :country_code,
+      class_name: "Country",
       searchable: true,
       searchable_field: "name",
     ),
@@ -28,7 +29,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     :email,
     :email_subscriber,
     :kind,
-    :country,
+    :territory,
     :password,
   ].freeze
 

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -1,6 +1,11 @@
 class Customer < ApplicationRecord
   has_many :orders, dependent: :destroy
-  belongs_to :country, foreign_key: :country_code, primary_key: :code
+  belongs_to(
+    :territory,
+    class_name: "Country",
+    foreign_key: :country_code,
+    primary_key: :code,
+  )
   has_many :log_entries, as: :logeable
 
   validates :name, presence: true

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -28,7 +28,7 @@ customer_attributes = Array.new(100) do
   {
     name: name,
     email: Faker::Internet.safe_email(name: name),
-    country: countries.sample,
+    territory: countries.sample,
     password: Faker::Internet.password,
   }
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer do
-    country
+    association :territory, factory: :country
     sequence(:name) { |n| "Customer #{n}" }
     email { name.downcase.gsub(" ", "_") + "@example.com" }
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -87,7 +87,7 @@ feature "Search" do
 
   scenario "admin searches across associations fields", :js do
     country = create(:country, name: "Brazil", code: "BR")
-    country_match = create(:customer, country: country)
+    country_match = create(:customer, territory: country)
     mismatch = create(:customer)
 
     visit admin_customers_path


### PR DESCRIPTION
Alternative to https://github.com/thoughtbot/administrate/pull/1264.
Fixes https://github.com/thoughtbot/administrate/issues/1179.

Currently, `Administrate::Search::Query` makes the assumption that an association's table name will have the same name as the association attribute, ignoring a `:class_name` option that signals otherwise.

This change uses the `:class_name` option when given.

Changing the example app also provides a way to test this as part of the existing feature specs.