### PR TITLE
Don't read attribute from associative field collection

### DIFF
--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -32,7 +32,9 @@ module Administrate
       end
 
       def get_attribute_value(resource, attribute_name)
-        resource.public_send(attribute_name)
+        unless resource.is_a? ActiveRecord::Associations::CollectionProxy
+          resource.public_send(attribute_name)
+        end
       end
 
       attr_reader :dashboard, :options


### PR DESCRIPTION
Proposal to fix #1570:

- [x] makes `administrate-field-nested_has_many` tests green again
- [x] fixes the `NestedHasMany` regressions observed in my app
