### PR TITLE
Use left joins instead of inner join when searching

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -109,7 +109,7 @@ module Administrate
 
     def search_results(resources)
       resources.
-        joins(tables_to_join).
+        left_joins(tables_to_join).
         where(query_template, *query_values)
     end
 

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -152,14 +152,16 @@ describe Administrate::Search do
       it "joins with the correct association table to query" do
         allow(scoped_object).to receive(:where)
 
-        expect(scoped_object).to receive(:joins).with(%i(role author address)).
+        expect(scoped_object).to receive(:left_joins).
+          with(%i(role author address)).
           and_return(scoped_object)
 
         search.run
       end
 
       it "builds the 'where' clause using the joined tables" do
-        allow(scoped_object).to receive(:joins).with(%i(role author address)).
+        allow(scoped_object).to receive(:left_joins).
+          with(%i(role author address)).
           and_return(scoped_object)
 
         expect(scoped_object).to receive(:where).with(*expected_query)


### PR DESCRIPTION
When searching an association with `belongs_to :foobar, optional: true`, the current implementation uses `INNER JOIN` which will filter out resources where the association does not exist.

By default when searching associations, it should `LEFT OUTER JOIN` the association.