### PR TITLE
[QoL fix] Added SCSS imports

### DIFF
--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 fieldset {
   background-color: transparent;
   border: 0;

--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 fieldset {
   background-color: transparent;

--- a/app/assets/stylesheets/administrate/base/_layout.scss
+++ b/app/assets/stylesheets/administrate/base/_layout.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 html {
   background-color: $base-background-color;

--- a/app/assets/stylesheets/administrate/base/_layout.scss
+++ b/app/assets/stylesheets/administrate/base/_layout.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 html {
   background-color: $base-background-color;
   box-sizing: border-box;

--- a/app/assets/stylesheets/administrate/base/_lists.scss
+++ b/app/assets/stylesheets/administrate/base/_lists.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 ul,
 ol {

--- a/app/assets/stylesheets/administrate/base/_lists.scss
+++ b/app/assets/stylesheets/administrate/base/_lists.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 ul,
 ol {
   list-style-type: none;

--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 table {
   border-collapse: collapse;
   font-size: 0.9em;

--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 table {
   border-collapse: collapse;

--- a/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/app/assets/stylesheets/administrate/base/_typography.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 body {
   color: $base-font-color;

--- a/app/assets/stylesheets/administrate/base/_typography.scss
+++ b/app/assets/stylesheets/administrate/base/_typography.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 body {
   color: $base-font-color;
   font-family: $base-font-family;

--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -1,5 +1,5 @@
-@import '../library/variables';
-@import '../library/data-label';
+@import "../library/variables";
+@import "../library/data-label";
 
 .attribute-label {
   @include data-label;

--- a/app/assets/stylesheets/administrate/components/_attributes.scss
+++ b/app/assets/stylesheets/administrate/components/_attributes.scss
@@ -1,3 +1,6 @@
+@import '../library/variables';
+@import '../library/data-label';
+
 .attribute-label {
   @include data-label;
   clear: left;

--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 button,
 input[type="button"],
 input[type="reset"],

--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 button,
 input[type="button"],

--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 .cell-label {
   padding-top: 0.15em;

--- a/app/assets/stylesheets/administrate/components/_cells.scss
+++ b/app/assets/stylesheets/administrate/components/_cells.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 .cell-label {
   padding-top: 0.15em;
 

--- a/app/assets/stylesheets/administrate/components/_field-unit.scss
+++ b/app/assets/stylesheets/administrate/components/_field-unit.scss
@@ -1,3 +1,6 @@
+@import '../library/variables';
+@import '../library/clearfix';
+
 .field-unit {
   @include administrate-clearfix;
   align-items: center;

--- a/app/assets/stylesheets/administrate/components/_field-unit.scss
+++ b/app/assets/stylesheets/administrate/components/_field-unit.scss
@@ -1,5 +1,5 @@
-@import '../library/variables';
-@import '../library/clearfix';
+@import "../library/variables";
+@import "../library/clearfix";
 
 .field-unit {
   @include administrate-clearfix;

--- a/app/assets/stylesheets/administrate/components/_flashes.scss
+++ b/app/assets/stylesheets/administrate/components/_flashes.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 $base-spacing: 1.5em !default;
 $flashes: (

--- a/app/assets/stylesheets/administrate/components/_flashes.scss
+++ b/app/assets/stylesheets/administrate/components/_flashes.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 $base-spacing: 1.5em !default;
 $flashes: (
   "alert": #fff6bf,

--- a/app/assets/stylesheets/administrate/components/_form-actions.scss
+++ b/app/assets/stylesheets/administrate/components/_form-actions.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 .form-actions {
   margin-left: calc(15% + 2rem);

--- a/app/assets/stylesheets/administrate/components/_form-actions.scss
+++ b/app/assets/stylesheets/administrate/components/_form-actions.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 .form-actions {
   margin-left: calc(15% + 2rem);
 }

--- a/app/assets/stylesheets/administrate/components/_main-content.scss
+++ b/app/assets/stylesheets/administrate/components/_main-content.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 .main-content {
   background-color: $white;

--- a/app/assets/stylesheets/administrate/components/_main-content.scss
+++ b/app/assets/stylesheets/administrate/components/_main-content.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 .main-content {
   background-color: $white;
   border-radius: $base-border-radius;

--- a/app/assets/stylesheets/administrate/components/_navigation.scss
+++ b/app/assets/stylesheets/administrate/components/_navigation.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 $_navigation-link-padding: 0.6em;
 
 .navigation {

--- a/app/assets/stylesheets/administrate/components/_navigation.scss
+++ b/app/assets/stylesheets/administrate/components/_navigation.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 $_navigation-link-padding: 0.6em;
 

--- a/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 .pagination {
   margin-top: $base-spacing;
   padding-left: $base-spacing;

--- a/app/assets/stylesheets/administrate/components/_pagination.scss
+++ b/app/assets/stylesheets/administrate/components/_pagination.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 .pagination {
   margin-top: $base-spacing;

--- a/app/assets/stylesheets/administrate/components/_search.scss
+++ b/app/assets/stylesheets/administrate/components/_search.scss
@@ -1,4 +1,4 @@
-@import '../library/variables';
+@import "../library/variables";
 
 $_search-icon-size: 1rem;
 

--- a/app/assets/stylesheets/administrate/components/_search.scss
+++ b/app/assets/stylesheets/administrate/components/_search.scss
@@ -1,3 +1,5 @@
+@import '../library/variables';
+
 $_search-icon-size: 1rem;
 
 .search {


### PR DESCRIPTION
When running `rails administrate:assets:stylesheets` in a Rails project (6.0.2) and updating my application.scss file, rails app throws multiple CSS errors which are caused by the lack of imports across multiple files. 

Just a minor QoL improvement.