### PR TITLE
Update Appraisal Capybara from 3.31.0 to 3.32.1

### DIFF
--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -29,7 +29,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.31.0"
+  gem "capybara", "3.32.1"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -29,7 +29,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.31.0"
+  gem "capybara", "3.32.1"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -29,7 +29,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.31.0"
+  gem "capybara", "3.32.1"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -29,7 +29,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.31.0"
+  gem "capybara", "3.32.1"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.31.0"
+  gem "capybara", "3.32.1"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"


### PR DESCRIPTION
These are often missed by Dependabot.