### PR TITLE
Remove jquery ujs

### DIFF
--- a/app/assets/javascripts/administrate/application.js
+++ b/app/assets/javascripts/administrate/application.js
@@ -1,5 +1,4 @@
 //= require jquery
-//= require jquery_ujs
 //= require selectize
 //= require moment
 //= require datetime_picker

--- a/spec/example_app/app/assets/javascripts/application.js
+++ b/spec/example_app/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
 //= require_tree .


### PR DESCRIPTION
`rails-ujs` has been moved into the rails project and using both `jquery-ujs` together with `rails-ujs` causes issues when attempting to programatically submit events (eg calling `Rails.fire`):

<img width="696" alt="Screen Shot 2020-04-22 at 6 02 12 PM" src="https://user-images.githubusercontent.com/656637/80038319-6b2fb800-84c3-11ea-840a-4aefec5349bf.png">

