### PR TITLE
Remove unused variables in scss files

### DIFF
--- a/app/assets/stylesheets/administrate/components/_flashes.scss
+++ b/app/assets/stylesheets/administrate/components/_flashes.scss
@@ -1,11 +1,3 @@
-$base-spacing: 1.5em !default;
-$flashes: (
-  "alert": #fff6bf,
-  "error": #fbe3e4,
-  "notice": #e5edf8,
-  "success": #e6efc2,
-) !default;
-
 @each $flash-type, $color in $flashes {
   .flash-#{$flash-type} {
     background-color: $color;

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -50,10 +50,10 @@ $focus-outline-offset: 1px;
 
 // Flash Colors
 $flashes: (
-  alert: $light-yellow,
-  error: $light-red,
-  notice: $light-blue,
-  success: $light-green
+  "alert": $light-yellow,
+  "error": $light-red,
+  "notice": $light-blue,
+  "success": $light-green
 ) !default;
 
 // Border

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -47,12 +47,12 @@ $focus-outline: $focus-outline-width solid $focus-outline-color;
 $focus-outline-offset: 1px;
 
 // Flash Colors
-$flash-colors: (
-  alert: $light-yellow,
-  error: $red,
-  notice: mix($white, $blue, 50%),
-  success: $light-green
-);
+$flashes: (
+  "alert": #fff6bf,
+  "error": #fbe3e4,
+  "notice": #e5edf8,
+  "success": #e6efc2,
+) !default;
 
 // Border
 $base-border-color: $grey-1 !default;

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -22,8 +22,10 @@ $black: #000 !default;
 
 $blue: #1976d2 !default;
 $red: #d32f2f !default;
-$light-yellow: #f0cd66 !default;
-$light-green: #4ab471 !default;
+$light-yellow: #fff6bf !default;
+$light-red: #fbe3e4 !default;
+$light-green: #e6efc2 !default;
+$light-blue: #e5edf8 !default;
 
 $grey-0: #f6f7f7 !default;
 $grey-1: #dfe0e1 !default;
@@ -48,10 +50,10 @@ $focus-outline-offset: 1px;
 
 // Flash Colors
 $flashes: (
-  "alert": #fff6bf,
-  "error": #fbe3e4,
-  "notice": #e5edf8,
-  "success": #e6efc2,
+  alert: $light-yellow,
+  error: $light-red,
+  notice: $light-blue,
+  success: $light-green
 ) !default;
 
 // Border


### PR DESCRIPTION
I notice that `$flash-colors` is unused in any files, and `$base-spacing` is previously defined in [_variable.css](https://github.com/thoughtbot/administrate/blob/master/app/assets/stylesheets/administrate/library/_variables.scss#L16).
I also moved the current `$flashes` variable to the `_variables.sccs` with the rest of the variables.