### PR TITLE
Update setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,6 +10,8 @@ set -e
 gem install bundler --conservative
 bundle check || bundle install
 
+bundle exec appraisal install
+
 # Set up configurable environment variables
 if [ ! -f .env ]; then
   cp .sample.env .env


### PR DESCRIPTION
1. Fork the repo
2. Follow instructions in [CONTRIBUTING.md](https://github.com/thoughtbot/administrate/blob/master/CONTRIBUTING.md#opening-a-pr)
3. Step 3 fails, because

```
$ bundle exec appraisal rspec
Could not find gem 'administrate-field-image' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
```

It looks like the previous step installs project dependencies, but does not install version specific dependencies from `./gemfiles/*` required from appraisal gem to run specs against specific rails versions.

The `gemfiles` setup is managed with `appraisal`, hence it should run its installation process before executing tests.