### PR TITLE
Fix display resource name plural singular & localisation

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -38,10 +38,10 @@ module Administrate
       "#{resource_name.to_s.singularize}_dashboard".classify.constantize
     end
 
-    def display_resource_name(resource_name)
+    def display_resource_name(resource_name, plural:)
       dashboard_from_resource(resource_name).resource_name(
-        count: PLURAL_MANY_COUNT,
-        default: default_resource_name(resource_name),
+        count: plural ? PLURAL_MANY_COUNT : 1,
+        default: default_resource_name(resource_name, plural),
       )
     end
 
@@ -76,8 +76,12 @@ module Administrate
 
     private
 
-    def default_resource_name(resource_name)
-      resource_name.to_s.pluralize.gsub("/", "_").titleize
+    def default_resource_name(resource_name, plural)
+      base = resource_name.to_s
+      if plural
+        base = base.pluralize
+      end
+      base.gsub("/", "_").titleize
     end
   end
 end

--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -21,7 +21,7 @@ and renders all form fields for a resource's editable attributes.
         <%= t(
           "administrate.form.errors",
           pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
-          resource_name: display_resource_name(page.resource_name)
+          resource_name: display_resource_name(page.resource_name, plural: false)
         ) %>
       </h2>
 

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -12,7 +12,7 @@ as defined by the routes in the `admin/` namespace
 
   <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>
     <%= link_to(
-      display_resource_name(resource),
+      display_resource_name(resource, plural: true),
       resource_index_route(resource),
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
     ) if valid_action? :index, resource  %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -24,7 +24,7 @@ It renders the `_table` partial to display details about the resources.
 %>
 
 <% content_for(:title) do %>
-  <%= display_resource_name(page.resource_name) %>
+  <%= display_resource_name(page.resource_name, plural: true) %>
 <% end %>
 
 <header class="main-content__header" role="banner">
@@ -36,7 +36,7 @@ It renders the `_table` partial to display details about the resources.
     <%= render(
       "search",
       search_term: search_term,
-      resource_name: display_resource_name(page.resource_name)
+      resource_name: display_resource_name(page.resource_name, plural: true)
     ) %>
   <% end %>
 

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -44,7 +44,7 @@ It renders the `_table` partial to display details about the resources.
     <%= link_to(
       t(
         "administrate.actions.new_resource",
-        name: page.resource_name.titleize.downcase
+        name: display_resource_name(page.resource_name, plural: false).downcase
       ),
       [:new, namespace, page.resource_path],
       class: "button",

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -18,7 +18,7 @@ to do the heavy lifting.
 <% content_for(:title) do %>
   <%= t(
     "administrate.actions.new_resource",
-    name: display_resource_name(page.resource_name).titleize
+    name: display_resource_name(page.resource_name, plural: false).titleize
   ) %>
 <% end %>
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -43,8 +43,19 @@ describe "customer index page" do
   end
 
   it "links to the new page" do
-    visit admin_customers_path
-    click_on("New customer")
+    translations = {
+      activerecord: {
+        models: {
+          customer: "Basic Customer",
+        },
+      },
+    }
+
+    with_translations(:en, translations) do
+      visit admin_customers_path
+
+      click_on("New basic customer")
+    end
 
     expect(current_path).to eq(new_admin_customer_path)
   end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -2,33 +2,39 @@ require "rails_helper"
 
 RSpec.describe Administrate::ApplicationHelper do
   describe "#display_resource_name" do
-    it "defaults to the plural of the model name" do
-      displayed = display_resource_name(:customer)
+    it "handles singular arguments" do
+      displayed = display_resource_name(:customer, plural: true)
 
       expect(displayed).to eq("Customers")
     end
 
     it "handles string arguments" do
-      displayed = display_resource_name("customer")
+      displayed = display_resource_name("customer", plural: true)
 
       expect(displayed).to eq("Customers")
     end
 
     it "handles plural arguments" do
-      displayed = display_resource_name(:customers)
+      displayed = display_resource_name(:customers, plural: true)
 
       expect(displayed).to eq("Customers")
     end
 
     it "handles namespaced resources" do
-      displayed = display_resource_name("blog/posts")
+      displayed = display_resource_name("blog/posts", plural: true)
 
       expect(displayed).to eq("Blog Posts")
     end
 
+    it "handles singular output" do
+      displayed = display_resource_name(:customer, plural: false)
+
+      expect(displayed).to eq("Customer")
+    end
+
     context "when translations are defined" do
-      it "uses the plural of the defined translation" do
-        translations = {
+      let(:translations) do
+        {
           activerecord: {
             models: {
               customer: {
@@ -38,24 +44,36 @@ RSpec.describe Administrate::ApplicationHelper do
             },
           },
         }
+      end
 
+      around do |example|
         with_translations(:en, translations) do
-          displayed = display_resource_name(:customer)
-
-          expect(displayed).to eq("Users")
+          example.run
         end
+      end
+
+      it "uses the plural of the defined translation" do
+        displayed = display_resource_name(:customer, plural: true)
+
+        expect(displayed).to eq("Users")
+      end
+
+      it "uses the singular of the defined translation" do
+        displayed = display_resource_name(:customer, plural: false)
+
+        expect(displayed).to eq("User")
       end
     end
 
     context "using custom dashboards" do
       it "pluralizes the resource name" do
-        displayed = display_resource_name("stat")
+        displayed = display_resource_name("stat", plural: true)
 
         expect(displayed).to eq("Stats")
       end
 
       it "handles plural arguments" do
-        displayed = display_resource_name(:stats)
+        displayed = display_resource_name(:stats, plural: true)
 
         expect(displayed).to eq("Stats")
       end


### PR DESCRIPTION
Fixes two bugs:
- In a couple places plural gets used when it should be singular
- New page link model name can't be translated

Fixes #1072