### PR TITLE
Automatic associations

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -79,16 +79,8 @@ which are specified through the `.with_options` class method:
 `:order` - Specifies the order of the dropdown menu, can be ordered by more
 than one column. e.g.: `"name, email DESC"`.
 
-`:primary_key` - Specifies object's primary_key. Defaults to `:id`.
-
-`:foreign_key` - Specifies the name of the foreign key directly.
-Defaults to `:#{attribute}_id`.
-
 `:scope` - Specifies a custom scope inside a callable. Useful for preloading.
 Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`
-
-`:class_name` - Specifies the name of the associated class.
-Defaults to `:#{attribute}.to_s.singularize.camelcase`.
 
 `:include_blank` - Specifies if the select element to be rendered should include
 blank option. Default is `true`.
@@ -111,6 +103,12 @@ For example:
 with this, you will be able to search through the column `name` from the
 association `belongs_to :country`, from your model.
 
+`:primary_key` (deprecated) - Specifies the association's primary_key.
+
+`:foreign_key` (deprecated) - Specifies the name of the foreign key directly.
+
+`:class_name` (deprecated) - Specifies the name of the associated class.
+
 **Field::HasMany**
 
 `:limit` - Set the number of resources to display in the show view. Default is
@@ -120,17 +118,13 @@ association `belongs_to :country`, from your model.
 
 `:direction` - What direction the sort should be in, `:asc` (default) or `:desc`.
 
-`:primary_key` - Specifies object's primary_key. Defaults to `:id`.
+`:primary_key` (deprecated) - Specifies object's primary_key.
 
-`:foreign_key` - Specifies the name of the foreign key directly. Defaults to `:#{attribute}_id`
+`:foreign_key` (deprecated) - Specifies the name of the foreign key directly.
 
-`:class_name` - Specifies the name of the associated class.
-Defaults to `:#{attribute}.to_s.singularize.camelcase`.
+`:class_name` (deprecated) - Specifies the name of the associated class.
 
 **Field::HasOne**
-
-`:class_name` - Specifies the name of the associated class.
-Defaults to `:#{attribute}.to_s.singularize.camelcase`.
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `false`.
@@ -149,6 +143,8 @@ For example:
 
 with this, you will be able to search through the column `name` from the
 association `has_many :cities`, from your model.
+
+`:class_name` (deprecated) - Specifies the name of the associated class.
 
 **Field::Number**
 

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -1,4 +1,23 @@
 require "administrate/engine"
 
 module Administrate
+  def self.warn_of_missing_resource_class
+    ActiveSupport::Deprecation.warn(
+      "Calling Field::Base.permitted_attribute without the option " +
+      ":resource_class is deprecated. If you are seeing this " +
+      "message, you are probably using a custom field type that" +
+      "does this. Please make sure to update it to a version that " +
+      "does not use a deprecated API",
+    )
+  end
+
+  def self.warn_of_deprecated_option(name)
+    ActiveSupport::Deprecation.warn(
+      "The option :#{name} is deprecated. " +
+      "Administrate should detect it automatically. " +
+      "Please file an issue at " +
+      "https://github.com/thoughtbot/administrate/issues " +
+      "if you think otherwise.",
+    )
+  end
 end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -56,7 +56,10 @@ module Administrate
 
     def permitted_attributes
       form_attributes.map do |attr|
-        attribute_types[attr].permitted_attribute(attr)
+        attribute_types[attr].permitted_attribute(
+          attr,
+          resource_class: self.class.model,
+        )
       end.uniq
     end
 

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -3,8 +3,14 @@ require_relative "associative"
 module Administrate
   module Field
     class BelongsTo < Associative
-      def self.permitted_attribute(attr, _options = nil)
-        :"#{attr}_id"
+      def self.permitted_attribute(attr, options = {})
+        resource_class = options[:resource_class]
+        if resource_class
+          foreign_key_for(resource_class, attr)
+        else
+          Administrate.warn_of_missing_resource_class
+          :"#{attr}_id"
+        end
       end
 
       def permitted_attribute

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -44,9 +44,13 @@ module Administrate
         end
       end
 
-      def permitted_attribute(attr, _options = nil)
-        options.fetch(:foreign_key,
-          deferred_class.permitted_attribute(attr, options))
+      def permitted_attribute(attr, opts = {})
+        if options.key?(:foreign_key)
+          Administrate.warn_of_deprecated_option(:foreign_key)
+          options.fetch(:foreign_key)
+        else
+          deferred_class.permitted_attribute(attr, options.merge(opts))
+        end
       end
 
       delegate :html_class, to: :deferred_class

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -7,7 +7,17 @@ module Administrate
     class HasMany < Associative
       DEFAULT_LIMIT = 5
 
-      def self.permitted_attribute(attr, _options = nil)
+      def self.permitted_attribute(attr, _options = {})
+        # This may seem arbitrary, and improvable by using reflection.
+        # Worry not: here we do exactly what Rails does. Regardless of the name
+        # of the foreign key, has_many associations use the suffix `_ids`
+        # for this.
+        #
+        # Eg: if the associated table and primary key are `countries.code`,
+        # you may expect `country_codes` as attribute here, but it will
+        # be `country_ids` instead.
+        #
+        # See https://github.com/rails/rails/blob/b30a23f53b52e59d31358f7b80385ee5c2ba3afe/activerecord/lib/active_record/associations/builder/collection_association.rb#L48
         { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 
@@ -36,7 +46,10 @@ module Administrate
       end
 
       def permitted_attribute
-        self.class.permitted_attribute(attribute)
+        self.class.permitted_attribute(
+          attribute,
+          resource_class: resource.class,
+        )
       end
 
       def resources(page = 1, order = self.order)

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -3,7 +3,7 @@ require_relative "associative"
 module Administrate
   module Field
     class Polymorphic < BelongsTo
-      def self.permitted_attribute(attr, _options = nil)
+      def self.permitted_attribute(attr, _options = {})
         { attr => %i{type value} }
       end
 

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -110,24 +110,16 @@ module Administrate
         if relationship.has_one?
           "Field::HasOne"
         elsif relationship.collection?
-          "Field::HasMany" + relationship_options_string(relationship)
+          "Field::HasMany"
         elsif relationship.polymorphic?
           "Field::Polymorphic"
         else
-          "Field::BelongsTo" + relationship_options_string(relationship)
+          "Field::BelongsTo"
         end
       end
 
       def klass
         @klass ||= Object.const_get(class_name)
-      end
-
-      def relationship_options_string(relationship)
-        if relationship.class_name != relationship.name.to_s.classify
-          options_string(class_name: relationship.class_name)
-        else
-          ""
-        end
       end
 
       def options_string(options)

--- a/spec/dashboards/order_dashboard_spec.rb
+++ b/spec/dashboards/order_dashboard_spec.rb
@@ -11,7 +11,7 @@ describe CustomerDashboard do
     it "returns the attribute_id name for belongs_to relationships" do
       dashboard = OrderDashboard.new
 
-      expect(dashboard.permitted_attributes).to include(:customer_id)
+      expect(dashboard.permitted_attributes).to include("customer_id")
     end
   end
 end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -13,9 +13,6 @@ class CustomerDashboard < Administrate::BaseDashboard
     updated_at: Field::DateTime,
     kind: Field::Select.with_options(collection: Customer::KINDS),
     territory: Field::BelongsTo.with_options(
-      primary_key: :code,
-      foreign_key: :country_code,
-      class_name: "Country",
       searchable: true,
       searchable_fields: ["name"],
       include_blank: true,

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -6,7 +6,13 @@ require "support/field_matchers"
 describe Administrate::Field::BelongsTo do
   include FieldMatchers
 
-  it { should_permit_param(:foo_id, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      :country_code,
+      on_model: Customer,
+      for_attribute: :territory,
+    )
+  end
 
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
@@ -20,31 +26,130 @@ describe Administrate::Field::BelongsTo do
     end
   end
 
-  describe "class_name option" do
-    it "determines what dashboard is used to present the association" do
-      begin
-        Foo = Class.new
-        allow(Foo).to receive(:all).and_return([])
+  describe "#associated_class" do
+    it "is automatically resolved for a conventional association" do
+      line_item = create(:line_item)
+      field = Administrate::Field::BelongsTo.new(
+        :product,
+        nil,
+        :show,
+        resource: line_item,
+      )
+      expect(field.associated_class).to eq(Product)
+    end
 
-        association = Administrate::Field::BelongsTo.with_options(
-          class_name: "Foo",
-        )
-        field = association.new(:customers, [], :show)
-        candidates = field.associated_resource_options
-
-        expect(Foo).to have_received(:all)
-        expect(candidates).to eq([])
-      ensure
-        remove_constants :Foo
-      end
+    it "is automatically resolved for a custom association" do
+      customer = create(:customer)
+      field = Administrate::Field::BelongsTo.new(
+        :territory,
+        nil,
+        :show,
+        resource: customer,
+      )
+      expect(field.associated_class).to eq(Country)
     end
   end
 
-  describe "include_blank option" do
+  describe "#display_associated_resource" do
+    it "renders the associated resource for a conventional association" do
+      product = create(:product, name: "Associated Product")
+      line_item = create(:line_item, product: product)
+      field = Administrate::Field::BelongsTo.new(
+        :product,
+        line_item.product,
+        :show,
+        resource: line_item,
+      )
+      allow_any_instance_of(ProductDashboard).to(
+        receive(:display_resource) do |_, resource|
+          "Mock #{resource.name}"
+        end,
+      )
+      expect(field.display_associated_resource).to eq("Mock Associated Product")
+    end
+
+    it "renders the associated resource for a custom association" do
+      country = create(:country, name: "Associated Country")
+      customer = create(:customer)
+      field = Administrate::Field::BelongsTo.new(
+        :territory,
+        country,
+        :show,
+        resource: customer,
+      )
+      allow_any_instance_of(CountryDashboard).to(
+        receive(:display_resource) do |_, resource|
+          "Mock #{resource.name}"
+        end,
+      )
+      expect(field.display_associated_resource).to eq("Mock Associated Country")
+    end
+  end
+
+  describe "class_name option" do
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+    end
+
+    it "determines the associated_class" do
+      line_item = create(:line_item)
+      field_class = Administrate::Field::BelongsTo.with_options(
+        class_name: "Customer",
+      )
+      field = field_class.new(
+        :product,
+        line_item.product,
+        :show,
+        resource: line_item,
+      )
+      expect(field.associated_class).to eq(Customer)
+    end
+
+    it "uses it to determine how to render the associated resource" do
+      product = create(:product, name: "Associated Product")
+      line_item = create(:line_item, product: product)
+      field_class = Administrate::Field::BelongsTo.with_options(
+        class_name: "LineItem",
+      )
+      field = field_class.new(
+        :product,
+        line_item.product,
+        :show,
+        resource: line_item,
+      )
+      expect(field.display_associated_resource).to match(
+        /^Line Item \#\d\d\d\d$/,
+      )
+    end
+
+    it "triggers a deprecation warning" do
+      line_item = create(:line_item)
+      field_class = Administrate::Field::BelongsTo.with_options(
+        class_name: "Customer",
+      )
+      field = field_class.new(
+        :product,
+        line_item.product,
+        :show,
+        resource: line_item,
+      )
+      field.associated_class
+      expect(ActiveSupport::Deprecation).to have_received(:warn).
+        with(/:class_name is deprecated/)
+    end
+  end
+
+  describe ":include_blank option" do
     context "default value as true" do
       it "determines if choices has blank option or not" do
+        customer = create(:customer, territory: nil)
         association = Administrate::Field::BelongsTo
-        field = association.new(:customers, [], :edit)
+        field = association.new(
+          :territory,
+          [],
+          :edit,
+          resource: customer,
+        )
         candidates = field.associated_resource_options
 
         expect(field.include_blank_option). to eq(true)
@@ -54,10 +159,16 @@ describe Administrate::Field::BelongsTo do
 
     context "set value as false" do
       it "determines if choices has blank option or not" do
+        customer = create(:customer, territory: nil)
         association = Administrate::Field::BelongsTo.with_options(
           include_blank: false,
         )
-        field = association.new(:customers, [], :edit)
+        field = association.new(
+          :territory,
+          [],
+          :edit,
+          resource: customer,
+        )
         candidates = field.associated_resource_options
 
         expect(field.include_blank_option). to eq(false)
@@ -67,35 +178,55 @@ describe Administrate::Field::BelongsTo do
   end
 
   describe "primary_key option" do
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      Foo = Class.new
+      FooDashboard = Class.new
+      uuid = SecureRandom.uuid
+      allow(Foo).to receive(:all).and_return([Foo])
+      allow(Foo).to receive(:uuid).and_return(uuid)
+      allow(Foo).to receive(:id).and_return(1)
+      allow_any_instance_of(FooDashboard).to(
+        receive(:display_resource).and_return(uuid),
+      )
+    end
+
+    after do
+      remove_constants :Foo, :FooDashboard
+    end
+
     it "determines what primary key is used on the relationship for the form" do
-      begin
-        Foo = Class.new
-        FooDashboard = Class.new
-        uuid = SecureRandom.uuid
-        allow(Foo).to receive(:all).and_return([Foo])
-        allow(Foo).to receive(:uuid).and_return(uuid)
-        allow(Foo).to receive(:id).and_return(1)
-        allow_any_instance_of(FooDashboard).to(
-          receive(:display_resource).and_return(uuid)
+      association =
+        Administrate::Field::BelongsTo.with_options(
+          primary_key: "uuid", class_name: "Foo",
         )
+      field = association.new(:customers, [], :show)
+      field.associated_resource_options
 
-        association =
-          Administrate::Field::BelongsTo.with_options(
-            primary_key: "uuid", class_name: "Foo"
-          )
-        field = association.new(:customers, [], :show)
-        field.associated_resource_options
+      expect(Foo).to have_received(:all)
+      expect(Foo).to have_received(:uuid)
+      expect(Foo).not_to have_received(:id)
+    end
 
-        expect(Foo).to have_received(:all)
-        expect(Foo).to have_received(:uuid)
-        expect(Foo).not_to have_received(:id)
-      ensure
-        remove_constants :Foo, :FooDashboard
-      end
+    it "triggers a deprecation warning" do
+      association =
+        Administrate::Field::BelongsTo.with_options(
+          primary_key: "uuid",
+        )
+      field = association.new(:foo, double(uuid: nil), :baz)
+      field.selected_option
+
+      expect(ActiveSupport::Deprecation).to have_received(:warn).
+        with(/:primary_key is deprecated/)
     end
   end
 
   describe "foreign_key option" do
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+    end
+
     it "determines what foreign key is used on the relationship for the form" do
       association = Administrate::Field::BelongsTo.with_options(
         foreign_key: "foo_uuid", class_name: "Foo",
@@ -104,15 +235,29 @@ describe Administrate::Field::BelongsTo do
       permitted_attribute = field.permitted_attribute
       expect(permitted_attribute).to eq("foo_uuid")
     end
+
+    it "triggers a deprecation warning" do
+      association = Administrate::Field::BelongsTo.with_options(
+        foreign_key: "foo_uuid", class_name: "Foo",
+      )
+      field = association.new(:customers, [], :show)
+
+      field.permitted_attribute
+
+      expect(ActiveSupport::Deprecation).to have_received(:warn).
+        with(/:foreign_key is deprecated/)
+    end
   end
 
-  describe "#resources" do
+  describe "#associated_resource_options" do
     context "with `order` option" do
       it "returns the resources in correct order" do
-        FactoryBot.create_list(:customer, 5)
+        order = create(:order)
+        create_list(:customer, 5)
         options = { order: "name" }
         association = Administrate::Field::BelongsTo.with_options(options)
-        field = association.new(:customers, [], :view)
+
+        field = association.new(:customer, [], :show, resource: order)
 
         correct_order = Customer.order("name").pluck(:id)
 
@@ -120,14 +265,16 @@ describe Administrate::Field::BelongsTo do
         expect(resources).to eq correct_order
       end
 
-      it "rejects order passed in `scope`" do
-        FactoryBot.create_list(:customer, 3)
+      it "ignores the order passed in `scope`" do
+        order = create(:order)
+        create_list(:customer, 3)
         options = {
           order: "name",
           scope: -> { Customer.order(name: :desc) },
         }
         association = Administrate::Field::BelongsTo.with_options(options)
-        field = association.new(:customers, [], :view)
+
+        field = association.new(:customer, [], :show, resource: order)
 
         correct_order = Customer.order("name").pluck(:id)
 
@@ -138,11 +285,15 @@ describe Administrate::Field::BelongsTo do
 
     context "with `scope` option" do
       it "returns the resources within the passed scope" do
-        1.upto(3) { |i| FactoryBot.create :customer, name: "customer-#{i}" }
+        # Building instead of creating, to avoid a dependent customer being
+        # created, leading to random failures
+        order = build(:order)
+
+        1.upto(3) { |i| create :customer, name: "customer-#{i}" }
         scope = -> { Customer.order(name: :desc).limit(2) }
 
         association = Administrate::Field::BelongsTo.with_options(scope: scope)
-        field = association.new(:customers, [], :view)
+        field = association.new(:customer, [], :show, resource: order)
         resources = field.associated_resource_options.compact.to_h.keys
 
         expect(resources).to eq ["customer-3", "customer-2"]

--- a/spec/lib/fields/boolean_spec.rb
+++ b/spec/lib/fields/boolean_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 require "administrate/field/boolean"
 require "support/field_matchers"
 
@@ -17,7 +17,13 @@ describe Administrate::Field::Boolean do
     end
   end
 
-  it { should_permit_param(:foo, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      :foo,
+      on_model: Customer,
+      for_attribute: :foo,
+    )
+  end
 
   describe "#to_s" do
     it "prints true or false" do

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -1,27 +1,67 @@
+require "rails_helper"
 require "administrate/field/deferred"
 require "administrate/field/belongs_to"
+require "administrate/field/has_many"
 require "administrate/field/string"
 
 describe Administrate::Field::Deferred do
   describe "#permitted_attribute" do
     context "when given a `foreign_key` option" do
+      before do
+        allow(ActiveSupport::Deprecation).to receive(:warn)
+      end
+
       it "returns the value given" do
-        deferred = Administrate::Field::Deferred.
-          new(Administrate::Field::BelongsTo.with_options(foreign_key: :bar))
-        expect(deferred.permitted_attribute(:foo)).to eq(:bar)
+        deferred = Administrate::Field::Deferred.new(
+          Administrate::Field::BelongsTo,
+          foreign_key: :bar,
+        )
+        expect(deferred.permitted_attribute(:foo, resource_class: LineItem)).
+          to eq(:bar)
+      end
+
+      it "triggers a deprecation warning" do
+        deferred = Administrate::Field::Deferred.new(
+          Administrate::Field::BelongsTo,
+          foreign_key: :bar,
+        )
+        deferred.permitted_attribute(:foo, resource_class: LineItem)
+        expect(ActiveSupport::Deprecation).to have_received(:warn).
+          with(/:foreign_key is deprecated/)
       end
     end
 
     context "when not given a `foreign_key` option" do
       it "delegates to the backing class" do
-        deferred = Administrate::Field::Deferred.
-          new(Administrate::Field::String)
+        deferred = Administrate::Field::Deferred.new(
+          Administrate::Field::String,
+        )
         allow(Administrate::Field::String).to receive(:permitted_attribute)
 
-        deferred.permitted_attribute(:foo)
+        deferred.permitted_attribute(:foo, resource_class: LineItem)
 
-        expect(Administrate::Field::String).
-          to have_received(:permitted_attribute).with(:foo, {})
+        expect(Administrate::Field::String).to(
+          have_received(:permitted_attribute).
+            with(:foo, resource_class: LineItem),
+        )
+      end
+    end
+
+    context "when given a `class_name` option" do
+      it "passes it on to deferred classes" do
+        field = double
+        allow(field).to receive(:permitted_attribute)
+        deferred = Administrate::Field::Deferred.new(
+          field,
+          class_name: "Foo::Bar",
+        )
+
+        deferred.permitted_attribute(:bars)
+
+        expect(field).to(
+          have_received(:permitted_attribute).
+            with(:bars, class_name: "Foo::Bar"),
+        )
       end
     end
   end
@@ -29,10 +69,14 @@ describe Administrate::Field::Deferred do
   describe "#searchable?" do
     context "when given a `searchable` option" do
       it "returns the value given" do
-        searchable_deferred = Administrate::Field::Deferred.
-          new(double(searchable?: false), searchable: true)
-        unsearchable_deferred = Administrate::Field::Deferred.
-          new(double(searchable?: true), searchable: false)
+        searchable_deferred = Administrate::Field::Deferred.new(
+          double(searchable?: false),
+          searchable: true,
+        )
+        unsearchable_deferred = Administrate::Field::Deferred.new(
+          double(searchable?: true),
+          searchable: false,
+        )
 
         expect(searchable_deferred.searchable?).to eq(true)
         expect(unsearchable_deferred.searchable?).to eq(false)
@@ -41,10 +85,12 @@ describe Administrate::Field::Deferred do
 
     context "when not given a `searchable` option" do
       it "falls back to the default of the deferred class" do
-        searchable_deferred = Administrate::Field::Deferred.
-          new(double(searchable?: true))
-        unsearchable_deferred = Administrate::Field::Deferred.
-          new(double(searchable?: false))
+        searchable_deferred = Administrate::Field::Deferred.new(
+          double(searchable?: true),
+        )
+        unsearchable_deferred = Administrate::Field::Deferred.new(
+          double(searchable?: false),
+        )
 
         expect(searchable_deferred.searchable?).to eq(true)
         expect(unsearchable_deferred.searchable?).to eq(false)

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -18,97 +18,133 @@ describe Administrate::Field::HasMany do
 
   describe "#associated_collection" do
     it "returns an index page for the dashboard of the associated attribute" do
-      begin
-        WidgetDashboard = Class.new
-        widgets = []
-        field = Administrate::Field::HasMany.new(:widgets, widgets, :show)
+      customer = build(:customer)
+      field = Administrate::Field::HasMany.new(
+        :orders,
+        Order.all,
+        :show,
+        resource: customer,
+      )
 
-        page = field.associated_collection
+      page = field.associated_collection
 
-        expect(page).to be_instance_of(Administrate::Page::Collection)
-      ensure
-        remove_constants :WidgetDashboard
-      end
+      expect(page).to be_instance_of(Administrate::Page::Collection)
     end
   end
 
   describe "class_name option" do
+    let(:dashboard_double) { double(collection_attributes: []) }
+
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      FooDashboard = Class.new
+      allow(FooDashboard).to receive(:new).and_return(dashboard_double)
+    end
+
+    after do
+      remove_constants :FooDashboard
+    end
+
     it "determines what dashboard is used to present the association" do
-      begin
-        FooDashboard = Class.new
-        dashboard_double = double(collection_attributes: [])
-        allow(FooDashboard).to receive(:new).and_return(dashboard_double)
+      association = Administrate::Field::HasMany.
+        with_options(class_name: "Foo")
+      field = association.new(:customers, [], :show)
+      collection = field.associated_collection
+      attributes = collection.attribute_names
 
-        association = Administrate::Field::HasMany.
-          with_options(class_name: "Foo")
-        field = association.new(:customers, [], :show)
-        collection = field.associated_collection
-        attributes = collection.attribute_names
+      expect(dashboard_double).to have_received(:collection_attributes)
+      expect(attributes).to eq([])
+    end
 
-        expect(dashboard_double).to have_received(:collection_attributes)
-        expect(attributes).to eq([])
-      ensure
-        remove_constants :FooDashboard
-      end
+    it "triggers a deprecation warning" do
+      association = Administrate::Field::HasMany.
+        with_options(class_name: "Foo")
+      field = association.new(:customers, [], :show)
+      field.associated_collection
+
+      expect(ActiveSupport::Deprecation).to have_received(:warn).
+        with(/:class_name is deprecated/)
     end
   end
 
   describe "primary_key option" do
+    before do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+
+      Foo = Class.new
+      FooDashboard = Class.new
+      uuid = SecureRandom.uuid
+      allow(Foo).to receive(:all).and_return([Foo])
+      allow(Foo).to receive(:uuid).and_return(uuid)
+      allow(Foo).to receive(:id).and_return(1)
+      allow_any_instance_of(FooDashboard).to(
+        receive(:display_resource).and_return(uuid),
+      )
+    end
+
+    after do
+      remove_constants :Foo, :FooDashboard
+    end
+
     it "determines what primary key is used on the relationship for the form" do
-      begin
-        Foo = Class.new
-        FooDashboard = Class.new
-        uuid = SecureRandom.uuid
-        allow(Foo).to receive(:all).and_return([Foo])
-        allow(Foo).to receive(:uuid).and_return(uuid)
-        allow(Foo).to receive(:id).and_return(1)
-        allow_any_instance_of(FooDashboard).to(
-          receive(:display_resource).and_return(uuid)
+      association =
+        Administrate::Field::HasMany.with_options(
+          primary_key: "uuid", class_name: "Foo",
         )
+      field = association.new(:customers, [], :show)
+      field.associated_resource_options
 
-        association =
-          Administrate::Field::HasMany.with_options(
-            primary_key: "uuid", class_name: "Foo"
-          )
-        field = association.new(:customers, [], :show)
-        field.associated_resource_options
+      expect(Foo).to have_received(:all)
+      expect(Foo).to have_received(:uuid)
+      expect(Foo).not_to have_received(:id)
+    end
 
-        expect(Foo).to have_received(:all)
-        expect(Foo).to have_received(:uuid)
-        expect(Foo).not_to have_received(:id)
-      ensure
-        remove_constants :Foo, :FooDashboard
-      end
+    it "triggers a deprecation warning" do
+      association =
+        Administrate::Field::HasMany.with_options(
+          primary_key: "uuid", class_name: "Foo",
+        )
+      field = association.new(:customers, [], :show)
+      field.associated_resource_options
+
+      expect(ActiveSupport::Deprecation).to have_received(:warn).
+        with(/:primary_key is deprecated/)
     end
   end
 
   describe "#more_than_limit?" do
     it "returns true if record count > limit" do
       limit = Administrate::Field::HasMany::DEFAULT_LIMIT
-      resources = MockRelation.new([:a] * (limit + 1))
+      value = MockRelation.new([:a] * (limit + 1))
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, value, :show)
 
       expect(field.more_than_limit?).to eq(true)
     end
 
     it "returns false if record count <= limit" do
       limit = Administrate::Field::HasMany::DEFAULT_LIMIT
-      resources = MockRelation.new([:a] * limit)
+      value = MockRelation.new([:a] * limit)
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, value, :show)
 
       expect(field.more_than_limit?).to eq(false)
     end
 
     context "when there are no records" do
       it "returns false" do
-        resources = nil
+        customer = build(:customer)
+        value = nil
 
-        association = Administrate::Field::HasMany
-        field = association.new(:customers, resources, :show)
+        field = Administrate::Field::HasMany.new(
+          :orders,
+          value,
+          :show,
+          resource: customer,
+        )
 
         expect(field.more_than_limit?).to eq(false)
       end
@@ -118,21 +154,30 @@ describe Administrate::Field::HasMany do
   describe "#resources" do
     it "limits the number of records shown" do
       limit = Administrate::Field::HasMany::DEFAULT_LIMIT
-      customer = FactoryBot.create(:customer, :with_orders, order_count: 10)
-      resources = customer.orders
+      customer = create(:customer, :with_orders, order_count: 10)
+      value = customer.orders
 
-      association = Administrate::Field::HasMany
-      field = association.new(:orders, resources, :show)
+      field = Administrate::Field::HasMany.new(
+        :orders,
+        value,
+        :show,
+        resource: customer,
+      )
 
       expect(field.resources.size).to eq(limit)
     end
 
     context "when there are no records" do
       it "returns an empty collection" do
-        resources = nil
+        customer = build(:customer)
+        value = nil
 
-        association = Administrate::Field::HasMany
-        field = association.new(:customers, resources, :show)
+        field = Administrate::Field::HasMany.new(
+          :orders,
+          value,
+          :show,
+          resource: customer,
+        )
 
         expect(field.resources).to eq([])
       end
@@ -140,11 +185,11 @@ describe Administrate::Field::HasMany do
 
     context "with `limit` option" do
       it "limits the number of items returned" do
-        customer = FactoryBot.create(:customer, :with_orders)
-        resources = customer.orders
+        customer = create(:customer, :with_orders)
+        value = customer.orders
 
         association = Administrate::Field::HasMany.with_options(limit: 1)
-        field = association.new(:orders, resources, :show)
+        field = association.new(:orders, value, :show, resource: customer)
 
         expect(field.resources).to be_one
       end
@@ -152,10 +197,15 @@ describe Administrate::Field::HasMany do
 
     context "with `sort_by` option" do
       it "returns the resources in correct order" do
-        customer = FactoryBot.create(:customer, :with_orders)
+        customer = create(:customer, :with_orders)
         options = { sort_by: :address_line_two }
         association = Administrate::Field::HasMany.with_options(options)
-        field = association.new(:orders, customer.orders, :show)
+        field = association.new(
+          :orders,
+          customer.orders,
+          :show,
+          resource: customer,
+        )
 
         correct_order = customer.orders.sort_by(&:address_line_two).map(&:id)
         reversed_order = customer.orders.sort do |a, b|
@@ -169,10 +219,15 @@ describe Administrate::Field::HasMany do
 
     context "with `direction` option" do
       it "returns the resources in correct order" do
-        customer = FactoryBot.create(:customer, :with_orders)
+        customer = create(:customer, :with_orders)
         options = { sort_by: :address_line_two, direction: :desc }
         association = Administrate::Field::HasMany.with_options(options)
-        field = association.new(:orders, customer.orders, :show)
+        field = association.new(
+          :orders,
+          customer.orders,
+          :show,
+          resource: customer,
+        )
 
         reversed_order = customer.orders.sort_by(&:address_line_two).map(&:id)
         correct_order = customer.orders.sort do |a, b|
@@ -188,20 +243,25 @@ describe Administrate::Field::HasMany do
   describe "#selected_options" do
     it "returns a collection of primary keys" do
       model = double("model", id: 123)
-      resources = MockRelation.new([model])
+      value = MockRelation.new([model])
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, resources, :show)
+      field = association.new(:customers, value, :show)
 
       expect(field.selected_options).to eq([123])
     end
 
     context "when there are no records" do
       it "returns an empty collection" do
-        resources = nil
+        customer = build(:customer)
+        value = nil
 
-        association = Administrate::Field::HasMany
-        field = association.new(:customers, resources, :show)
+        field = Administrate::Field::HasMany.new(
+          :orders,
+          value,
+          :show,
+          resource: customer,
+        )
 
         expect(field.selected_options).to be_nil
       end

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/number"
 require "support/field_matchers"
 
@@ -16,7 +17,13 @@ describe Administrate::Field::Number do
     end
   end
 
-  it { should_permit_param(:foo, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      :foo,
+      on_model: Customer,
+      for_attribute: :foo,
+    )
+  end
 
   describe "#to_s" do
     it "defaults to displaying no decimal points" do

--- a/spec/lib/fields/password_spec.rb
+++ b/spec/lib/fields/password_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/password"
 require "support/field_matchers"
 
@@ -15,7 +16,13 @@ describe Administrate::Field::Password do
     end
   end
 
-  it { should_permit_param(:foo, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      :foo,
+      on_model: Customer,
+      for_attribute: :foo,
+    )
+  end
 
   describe "#truncate" do
     it "renders an empty string for nil" do

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/belongs_to"
 require "administrate/field/polymorphic"
 require "support/constant_helpers"
@@ -17,7 +18,13 @@ describe Administrate::Field::Polymorphic do
     end
   end
 
-  it { should_permit_param({ foo: %i{type value} }, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      { foo: %i{type value} },
+      on_model: Customer,
+      for_attribute: :foo,
+    )
+  end
 
   describe "#display_associated_resource" do
     it "displays through the dashboard based on the polymorphic class name" do

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/string"
 require "support/field_matchers"
 
@@ -15,7 +16,13 @@ describe Administrate::Field::String do
     end
   end
 
-  it { should_permit_param(:foo, for_attribute: :foo) }
+  it do
+    should_permit_param(
+      :foo,
+      on_model: Customer,
+      for_attribute: :foo,
+    )
+  end
 
   describe "#truncate" do
     it "renders an empty string for nil" do

--- a/spec/support/field_matchers.rb
+++ b/spec/support/field_matchers.rb
@@ -1,6 +1,9 @@
 module FieldMatchers
-  def should_permit_param(expected_param, for_attribute:)
-    permitted_param = described_class.permitted_attribute(for_attribute)
+  def should_permit_param(expected_param, for_attribute:, on_model:)
+    permitted_param = described_class.permitted_attribute(
+      for_attribute,
+      resource_class: on_model,
+    )
     expect(permitted_param).to eq(expected_param)
   end
 end


### PR DESCRIPTION
Fixes #1597

### Summary

Currently, associative dashboard fields (`BelongsTo`, `HasMany`, `HasOne`) require explicit configuration options (`:class_name`, `:foreign_key`, `:primary_key`) for Administrate to find their associated models. There are details that Administrate can figure out automatically, but not everything, and not always reliably.

This PR changes these field types so that they do not need this configuration, instead detecting associations by using ActiveRecord's reflection API.

### Implementation notes

The core change of the feature specs is at `spec/example_app/app/dashboards/customer_dashboard.rb`. I started by introducing that change, then proceeded slowly to make everything work.

This implementation relies on `Field::Base.new` always receiving a `:resource_class` option. I think this is safe as it's already the case throughout the codebase. However third party gems may have incompatibilities here.

### Third party gems

I have had a look at third-party plugins listed at https://rubygems.org/gems/administrate/reverse_dependencies. From this list, only `administrate-field-nested_has_many` appear to have incompatibilities, which is not surprising as it adds a new associative field with some advanced features. Specifically you'll find that:

  * It will not work if you remove your `:class_name` options from `NestedHasMany` fields.
  * You can work around this by continuing to use the deprecated options (just for your `NestedHasMany` fields), although you'll get deprecation warnings.
  * I created a branch that will bring this plugin in sync with the changes in this PR: https://github.com/nickcharlton/administrate-field-nested_has_many/compare/master...pablobm:automatic-associations

### Deprecations

I could have removed the deprecated options completely, but I decided against it because:

* I want to minimise disruption when updating Administrate.
* I don't have 100% trust that just removing the options will work for everyone. There may be a corner case I'm missing.

Instead I'm allowing the old behaviour to exist for a bit longer, while showing abundant deprecation warnings. Hopefully this will get people to upgrade quickly and report any incompatibility.

### General review tips

The option "Hide whitespace changes" is very useful here, as I have changed a lot of indent at the specs, in order to avoid style warnings (Hound).

Also due to style warnings, I have reformatted a lot of code, adding more diff noise in the process.

So this is to say: this MR looks huge, but it's just... large, I guess.

### The future

The current code relies a lot on globals (eg: class methods) that are difficult to test and generally work with. In the future, we may want to change the interface for field types to improve the situation, but I think that would be too much for this PR.

There's still some risky string-to-class metaprogramming going on, for example a `"#{associated_class_name}Dashboard".constantize.new` in `lib/administrate/field/associative.rb` (not shown in the diff as unchanged). I have let this be for now. I think it should be reviewed in the future as part of work in the resolved to fix issues such as namespacing bugs, which are out of scope here.