### PR TITLE
Add YARD for inline documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pkg
 /.idea
 .byebug_history
 gemfiles/.bundle/
+.yardoc
+/doc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,13 @@
+-
+CHANGELOG.md
+docs/getting_started.md
+docs/rails_api.md
+docs/customizing_dashboards.md
+docs/customizing_page_views.md
+docs/customizing_attribute_partials.md
+docs/adding_controllers_without_related_model.md
+docs/adding_custom_field_types.md
+docs/authentication.md
+docs/authorization.md
+CODE_OF_CONDUCT.md
+LICENSE.md

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.25)
     zeitwerk (2.3.1)
 
 PLATFORMS
@@ -281,6 +282,7 @@ DEPENDENCIES
   unicorn
   webmock
   xpath (= 3.2.0)
+  yard
 
 BUNDLED WITH
    1.17.3

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
   gem "rspec-rails"
 end
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
   gem "rspec-rails"
 end
 

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
   gem "rspec-rails"
 end
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
   gem "rspec-rails"
 end
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem "yard"
   gem "rspec-rails", "~> 4.0.0.beta2"
 end
 


### PR DESCRIPTION
* Ignores the `doc/` directory so we don't commit the generated docs,
* Includes the existing docs as files, plus the CHANGELOG, CoC, and
  LICENSE.

Fixes: #1605.