### PR TITLE
Add options for default sorting

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -78,6 +78,22 @@ module Administrate
       redirect_to action: :index
     end
 
+    def default_sorting_attribute
+      :id
+    end
+
+    def default_sorting_direction
+      :asc
+    end
+
+    def sorting_attribute
+      params.fetch(resource_name, {}).fetch(:order, default_sorting_attribute)
+    end
+    
+    def sorting_direction
+        params.fetch(resource_name, {}).fetch(:direction, default_sorting_direction)
+    end
+
     private
 
     helper_method :nav_link_state
@@ -101,10 +117,7 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(
-        params.fetch(resource_name, {}).fetch(:order, nil),
-        params.fetch(resource_name, {}).fetch(:direction, nil),
-      )
+      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
     end
 
     def dashboard

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -87,11 +87,17 @@ module Administrate
     end
 
     def sorting_attribute
-      params.fetch(resource_name, {}).fetch(:order, default_sorting_attribute)
+      params.fetch(resource_name, {}).fetch(
+        :order, 
+        default_sorting_attribute
+      )
     end
-    
+
     def sorting_direction
-        params.fetch(resource_name, {}).fetch(:direction, default_sorting_direction)
+      params.fetch(resource_name, {}).fetch(
+        :direction,
+        default_sorting_direction
+      )
     end
 
     private

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -104,14 +104,6 @@ module Administrate
       @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
     end
 
-    def default_sorting_attribute
-      :id
-    end
-
-    def default_sorting_direction
-      :asc
-    end
-
     def sorting_attribute
       params.fetch(resource_name, {}).fetch(
         :order,
@@ -119,11 +111,19 @@ module Administrate
       )
     end
 
+    def default_sorting_attribute
+      nil
+    end
+
     def sorting_direction
       params.fetch(resource_name, {}).fetch(
         :direction,
         default_sorting_direction,
       )
+    end
+
+    def default_sorting_direction
+      nil
     end
 
     def dashboard

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -97,7 +97,7 @@ module Administrate
       params.fetch(resource_name, {}).fetch(
         :direction,
         default_sorting_direction,
-       )
+      )
     end
 
     private

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -88,16 +88,16 @@ module Administrate
 
     def sorting_attribute
       params.fetch(resource_name, {}).fetch(
-        :order, 
-        default_sorting_attribute
+        :order,
+        default_sorting_attribute,
       )
     end
 
     def sorting_direction
       params.fetch(resource_name, {}).fetch(
         :direction,
-        default_sorting_direction
-      )
+        default_sorting_direction,
+       )
     end
 
     private

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -78,28 +78,6 @@ module Administrate
       redirect_to action: :index
     end
 
-    def default_sorting_attribute
-      :id
-    end
-
-    def default_sorting_direction
-      :asc
-    end
-
-    def sorting_attribute
-      params.fetch(resource_name, {}).fetch(
-        :order,
-        default_sorting_attribute,
-      )
-    end
-
-    def sorting_direction
-      params.fetch(resource_name, {}).fetch(
-        :direction,
-        default_sorting_direction,
-      )
-    end
-
     private
 
     helper_method :nav_link_state
@@ -124,6 +102,28 @@ module Administrate
 
     def order
       @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
+    end
+
+    def default_sorting_attribute
+      :id
+    end
+
+    def default_sorting_direction
+      :asc
+    end
+
+    def sorting_attribute
+      params.fetch(resource_name, {}).fetch(
+        :order,
+        default_sorting_attribute,
+      )
+    end
+
+    def sorting_direction
+      params.fetch(resource_name, {}).fetch(
+        :direction,
+        default_sorting_direction,
+      )
     end
 
     def dashboard

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -56,3 +56,17 @@ end
 ```
 
 Action is one of `new`, `edit`, `show`, `destroy`.
+
+## Customizing Default Sorting
+
+To set the default sorting on the index action you could override `default_sorting_attribute` or `default_sorting_direction` in your dashboard controller like this:
+
+```ruby
+def default_sorting_attribute
+  :age
+end
+
+def default_sorting_direction
+  :desc
+end
+```

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -58,7 +58,7 @@ describe Admin::CustomersController, type: :controller do
         end
       end
 
-      it "retreives resources in the correct order" do
+      it "retrieves resources in the correct order" do
         customers = create_list(:customer, 5)
         sorted_customer_names = customers.map(&:name).sort.reverse
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -47,12 +47,8 @@ describe Admin::CustomersController, type: :controller do
       expect(locals[:resources].map(&:id)).to eq customers.map(&:id).sort
     end
 
-    it "uses sorts using the override" do
-      @controller = Class.new(Admin::CustomersController) do
-        def self.name
-          superclass.name
-        end
-
+    context "with alternate sorting attributes" do
+      controller(Admin::CustomersController) do
         def default_sorting_attribute
           :name
         end
@@ -60,13 +56,15 @@ describe Admin::CustomersController, type: :controller do
         def default_sorting_direction
           :desc
         end
-      end.new
+      end
 
-      customers = create_list(:customer, 5)
-      sorted_customer_names = customers.map(&:name).sort.reverse
+      it "retreives resources in the correct order" do
+        customers = create_list(:customer, 5)
+        sorted_customer_names = customers.map(&:name).sort.reverse
 
-      locals = capture_view_locals { get :index }
-      expect(locals[:resources].map(&:name)).to eq sorted_customer_names
+        locals = capture_view_locals { get :index }
+        expect(locals[:resources].map(&:name)).to eq sorted_customer_names
+      end
     end
   end
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -47,15 +47,22 @@ describe Admin::CustomersController, type: :controller do
       expect(locals[:resources].map(&:id)).to eq customers.map(&:id).sort
     end
 
-    it "supports default sorting overrides" do
-      allow_any_instance_of(Admin::CustomersController).to(receive_messages(
-        default_sorting_attribute: :name,
-        default_sorting_direction: :desc,
-      ))
+    it "uses sorts using the override" do
+      @controller = Class.new(Admin::CustomersController) do
+        def self.name
+          superclass.name
+        end
 
-      customer1 = create(:customer)
-      customer2 = create(:customer)
-      customers = [customer1, customer2]
+        def default_sorting_attribute
+          :name
+        end
+
+        def default_sorting_direction
+          :desc
+        end
+      end.new
+
+      customers = create_list(:customer, 5)
       sorted_customer_names = customers.map(&:name).sort.reverse
 
       locals = capture_view_locals { get :index }

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -49,8 +49,8 @@ describe Admin::CustomersController, type: :controller do
 
     it "supports default sorting overrides" do
       allow_any_instance_of(Admin::CustomersController).to(receive_messages(
-        default_sorting_attribute: :name, 
-        default_sorting_direction: :desc
+        default_sorting_attribute: :name,
+        default_sorting_direction: :desc,
       ))
 
       customer1 = create(:customer)

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -41,20 +41,25 @@ describe Admin::CustomersController, type: :controller do
     it "sorts by id by default" do
       customer1 = create(:customer)
       customer2 = create(:customer)
+      customers = [customer1, customer2]
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources].map(&:id)).to eq [customer1, customer2].map(&:id).sort
+      expect(locals[:resources].map(&:id)).to eq customers.map(&:id).sort
     end
 
     it "supports default sorting overrides" do
-      allow_any_instance_of(Admin::CustomersController).to receive(:default_sorting_attribute).and_return(:name)
-      allow_any_instance_of(Admin::CustomersController).to receive(:default_sorting_direction).and_return(:desc)
+      allow_any_instance_of(Admin::CustomersController).to(receive_messages(
+        default_sorting_attribute: :name, 
+        default_sorting_direction: :desc
+      ))
 
       customer1 = create(:customer)
       customer2 = create(:customer)
+      customers = [customer1, customer2]
+      sorted_customer_names = customers.map(&:name).sort.reverse
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources].map(&:name)).to eq [customer1, customer2].map(&:name).sort.reverse
+      expect(locals[:resources].map(&:name)).to eq sorted_customer_names
     end
   end
 

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -37,6 +37,25 @@ describe Admin::CustomersController, type: :controller do
       locals = capture_view_locals { get :index }
       expect(locals[:show_search_bar]).to be_truthy
     end
+
+    it "sorts by id by default" do
+      customer1 = create(:customer)
+      customer2 = create(:customer)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:resources].map(&:id)).to eq [customer1, customer2].map(&:id).sort
+    end
+
+    it "supports default sorting overrides" do
+      allow_any_instance_of(Admin::CustomersController).to receive(:default_sorting_attribute).and_return(:name)
+      allow_any_instance_of(Admin::CustomersController).to receive(:default_sorting_direction).and_return(:desc)
+
+      customer1 = create(:customer)
+      customer2 = create(:customer)
+
+      locals = capture_view_locals { get :index }
+      expect(locals[:resources].map(&:name)).to eq [customer1, customer2].map(&:name).sort.reverse
+    end
   end
 
   describe "GET show" do


### PR DESCRIPTION
Provide methods to override the default ordering attribute and direction.

Reference: [#442](https://github.com/thoughtbot/administrate/issues/442#issuecomment-564940944)