### PR TITLE
Allow for label/value setting in Field::Select collection

### DIFF
--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -19,13 +19,25 @@ to be displayed on a resource's edit form page.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.select(
-    field.attribute,
-    options_from_collection_for_select(
-      field.selectable_options,
-      :to_s,
-      :to_s,
-      field.data.presence,
-    )
-  ) %>
+  <% if field.selectable_options.first&.is_a?(Array) %>
+    <%= f.select(
+      field.attribute,
+      options_from_collection_for_select(
+        field.selectable_options,
+        :last,
+        :first,
+        field.data.presence,
+      )
+    ) %>
+  <% else %>
+    <%= f.select(
+      field.attribute,
+      options_from_collection_for_select(
+        field.selectable_options,
+        :to_s,
+        :to_s,
+        field.data.presence,
+      )
+    ) %>
+  <% end %>
 </div>

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -37,13 +37,13 @@ describe "product form has_one relationship" do
 
   it "respects setting of label/value in Field::Select" do
     old_release_year = ProductDashboard::ATTRIBUTE_TYPES[:release_year]
-
-    ProductDashboard::ATTRIBUTE_TYPES[:release_year] = Administrate::Field::Select.with_options(
+    new_release_year = Administrate::Field::Select.with_options(
       collection: [
         ["Last Year", 2019],
-        ["This Year", 2020]
+        ["This Year", 2020],
       ],
     )
+    ProductDashboard::ATTRIBUTE_TYPES[:release_year] = new_release_year
 
     visit new_admin_product_path
     expect(page).to have_select("Release year", with_options: ["This Year"])

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -35,6 +35,24 @@ describe "product form has_one relationship" do
     end
   end
 
+  it "respects setting of label/value in Field::Select" do
+    old_release_year = ProductDashboard::ATTRIBUTE_TYPES[:release_year]
+
+    ProductDashboard::ATTRIBUTE_TYPES[:release_year] = Administrate::Field::Select.with_options(
+      collection: [
+        ["Last Year", 2019],
+        ["This Year", 2020]
+      ],
+    )
+
+    visit new_admin_product_path
+    expect(page).to have_select("Release year", with_options: ["This Year"])
+    expect(page.find("option", match: :first).text).to eq("Last Year")
+    expect(page.find("option", match: :first).value).to eq("2019")
+
+    ProductDashboard::ATTRIBUTE_TYPES[:release_year] = old_release_year
+  end
+
   it "edits product and meta tag data correctly" do
     product = create(:product)
 


### PR DESCRIPTION
This mimics the default behavior in Rails `select` helpers, where you can supply an array of length-2-arrays, and each collection item is understood as `[label, value]`.