### PR TITLE
Use singular resource name for error explanation

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -21,7 +21,7 @@ and renders all form fields for a resource's editable attributes.
         <%= t(
           "administrate.form.errors",
           pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
-          resource_name: display_resource_name(page.resource_name)
+          resource_name: display_resource_name(page.resource_name).singularize
         ) %>
       </h2>
 

--- a/spec/features/form_errors_spec.rb
+++ b/spec/features/form_errors_spec.rb
@@ -7,6 +7,7 @@ feature "form errors" do
     click_on "Create Customer"
 
     expect(page).to have_content "Name can't be blank"
+    expect(page).to have_content "prohibited this Customer from being saved"
   end
 
   scenario "error messages for editing resource" do


### PR DESCRIPTION
Just a little thing I noticed.

Was:
<img width="653" alt="Screen Shot 2020-05-14 at 11 40 06 AM" src="https://user-images.githubusercontent.com/1410181/81956403-4073e380-95d9-11ea-9624-1a17870440e5.png">

Now:
<img width="656" alt="Screen Shot 2020-05-14 at 11 43 17 AM" src="https://user-images.githubusercontent.com/1410181/81956419-45d12e00-95d9-11ea-8787-89ab3ee9336e.png">

<hr>

Not sure if this is too much of a bandaid approach here. Was imagining potentially passing in the `count` option to `display_resource_name` from the error partial view code, but if you haven't defined a translation, then the `default` string that's constructed is what ends up being returned. Given that the default comes from `default_resource_name` (which pluralizes the model name), the count is often ignored for the plural version.

Thoughts on if this is good enough or if a larger refactor around how `display_resource_name` is used is called for?