### PR TITLE
Adding 'Back to app' label to internationalization

### DIFF
--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -8,7 +8,7 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
-  <%= link_to("Back to app", root_url, class: "button button--alt") if defined?(root_url) %>
+  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt") if defined?(root_url) %>
 
   <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>
     <%= link_to(

--- a/config/locales/administrate.ar.yml
+++ b/config/locales/administrate.ar.yml
@@ -23,6 +23,8 @@ ar:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: العودة إلى التطبيق
     search:
       clear: مسح البحث
       label: بحث %{resource}

--- a/config/locales/administrate.bs.yml
+++ b/config/locales/administrate.bs.yml
@@ -22,6 +22,8 @@ bs:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Natrag na aplikaciju
     search:
       clear: Izbriši pretraživanje
       label: Pretraga %{resource}

--- a/config/locales/administrate.ca.yml
+++ b/config/locales/administrate.ca.yml
@@ -23,6 +23,8 @@ ca:
     form:
       error: error
       errors: "%{pluralized_errors} han impedit que %{resource_name} es guardés amb èxit:"
+    navigation:
+      back_to_app: Torna a l'aplicació
     search:
       clear: Esborrar la cerca
       label: Cerca %{resource}

--- a/config/locales/administrate.da.yml
+++ b/config/locales/administrate.da.yml
@@ -23,6 +23,8 @@ da:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Tilbage til app
     search:
       clear: Ryd søgning
       label: Søg %{resource}

--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -23,6 +23,8 @@ de:
     form:
       error: error
       errors: "%{pluralized_errors} haben das Speichern dieses %{resource_name} verhindert:"
+    navigation:
+      back_to_app: Zurück zur App
     search:
       clear: Suche zurücksetzen
       label: "%{resource} durchsuchen"

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -23,6 +23,8 @@ en:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Back to app
     search:
       clear: Clear search
       label: Search %{resource}

--- a/config/locales/administrate.es.yml
+++ b/config/locales/administrate.es.yml
@@ -23,6 +23,8 @@ es:
     form:
       error: error
       errors: "%{pluralized_errors} no permitieron guardar este %{resource_name}:"
+    navigation:
+      back_to_app: Regresar a la aplicación
     search:
       clear: Borrar búsqueda
       label: Buscar %{resource}

--- a/config/locales/administrate.fr.yml
+++ b/config/locales/administrate.fr.yml
@@ -23,6 +23,8 @@ fr:
     form:
       error: erreur
       errors: "%{pluralized_errors} ont empêchés %{resource_name} d'être sauvergardé :"
+    navigation:
+      back_to_app: Retour à l'application
     search:
       clear: Effacer la recherche
       label: Chercher %{resource}

--- a/config/locales/administrate.id.yml
+++ b/config/locales/administrate.id.yml
@@ -23,6 +23,8 @@ id:
     form:
       error: error
       errors: "%{pluralized_errors} membuat %{resource_name} tidak bisa tersimpan:"
+    navigation:
+      back_to_app: Kembali ke aplikasi
     search:
       clear: Kosongkan pencarian
       label: Cari %{resource}

--- a/config/locales/administrate.it.yml
+++ b/config/locales/administrate.it.yml
@@ -23,6 +23,8 @@ it:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Torna all'app
     search:
       clear: Cancella ricerca
       label: Ricerca %{resource}

--- a/config/locales/administrate.ja.yml
+++ b/config/locales/administrate.ja.yml
@@ -23,6 +23,8 @@ ja:
     form:
       error: エラー
       errors: "%{pluralized_errors}のため%{resource_name}を保存できません。"
+    navigation:
+      back_to_app: アプリに戻る
     search:
       clear: 検索をクリアする
       label: サーチ %{resource}

--- a/config/locales/administrate.ko.yml
+++ b/config/locales/administrate.ko.yml
@@ -23,6 +23,8 @@ ko:
     form:
       error: 에러
       errors: "%{pluralized_errors}로 인하여 %{resource_name}을(를) 저장하는데 실패하였습니다."
+    navigation:
+      back_to_app: 앱으로 돌아 가기
     search:
       clear: 검색 초기화
       label: "%{resource} 검색"

--- a/config/locales/administrate.nl.yml
+++ b/config/locales/administrate.nl.yml
@@ -23,6 +23,8 @@ nl:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Terug naar app
     search:
       clear: Wissen
       label: Zoeken %{resource}

--- a/config/locales/administrate.pl.yml
+++ b/config/locales/administrate.pl.yml
@@ -23,6 +23,8 @@ pl:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Powrót do aplikacji
     search:
       clear: Wyczyść wyszukiwanie
       label: Szukanie %{resource}

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -24,6 +24,8 @@ pt-BR:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Voltar ao aplicativo
     search:
       clear: Limpar pesquisa
       label: Pesquisa %{resource}

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -24,6 +24,8 @@ pt:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Voltar ao aplicativo
     search:
       clear: Limpar pesquisa
       label: Pesquisa %{resource}

--- a/config/locales/administrate.ru.yml
+++ b/config/locales/administrate.ru.yml
@@ -23,6 +23,8 @@ ru:
     form:
       error: Ошибка
       errors: "При сохранении %{resource_name} произошли ошибки:"
+    navigation:
+      back_to_app: Вернуться в приложение
     search:
       clear: Очистить поиск
       label: Поиск %{resource}

--- a/config/locales/administrate.sq.yml
+++ b/config/locales/administrate.sq.yml
@@ -23,6 +23,8 @@ sq:
     form:
       error: gabim
       errors: "%{pluralized_errors} nuk e lejoj %{resource_name} të ruhet:"
+    navigation:
+      back_to_app: Kthehu tek aplikacioni
     search:
       clear: Pastro kërkimin
       label: Kërko %{resource}

--- a/config/locales/administrate.sv.yml
+++ b/config/locales/administrate.sv.yml
@@ -23,6 +23,8 @@ sv:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Tillbaka till appen
     search:
       clear: Rensa sökningen
       label: Sök %{resource}

--- a/config/locales/administrate.uk.yml
+++ b/config/locales/administrate.uk.yml
@@ -23,6 +23,8 @@ uk:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Повернутися до програми
     search:
       clear: Очистити пошук
       label: пошук %{resource}

--- a/config/locales/administrate.vi.yml
+++ b/config/locales/administrate.vi.yml
@@ -23,6 +23,8 @@ vi:
     form:
       error: error
       errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+    navigation:
+      back_to_app: Quay lại ứng dụng
     search:
       clear: Tìm kiếm rõ ràng
       label: Tìm kiếm %{resource}

--- a/config/locales/administrate.zh-CN.yml
+++ b/config/locales/administrate.zh-CN.yml
@@ -23,6 +23,8 @@ zh-CN:
     form:
       error: 错误
       errors: "%{resource_name} 保存前出现了 %{pluralized_errors} 个错误："
+    navigation:
+      back_to_app: 返回应用
     search:
       clear: 清除搜索
       label: 搜索 %{resource}

--- a/config/locales/administrate.zh-TW.yml
+++ b/config/locales/administrate.zh-TW.yml
@@ -23,6 +23,8 @@ zh-TW:
     form:
       error: 錯誤
       errors: "%{pluralized_errors} 導致此 %{resource_name} 不能被儲存："
+    navigation:
+      back_to_app: 返回应用
     search:
       clear: 清除搜尋
       label: 搜尋 %{resource}


### PR DESCRIPTION
'Back to app' label was hardcoded and now is on internationalization files

fix #1622