### PR TITLE
Fix time fields default to 8pm

### DIFF
--- a/app/views/fields/time/_form.html.erb
+++ b/app/views/fields/time/_form.html.erb
@@ -18,5 +18,5 @@ By default, the input is a select field for the time attributes.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute, data: { type: 'time' } %>
+  <%= f.text_field field.attribute, data: { type: 'time' }, value: field.data.strftime("%H:%M:%S") %>
 </div>

--- a/app/views/fields/time/_form.html.erb
+++ b/app/views/fields/time/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text field that is augmented with [DateTimePicker].
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute, data: { type: 'time' }, value: field.data.strftime("%H:%M:%S") %>
+  <%= f.text_field field.attribute, data: { type: 'time' }, value: field.data&.strftime("%H:%M:%S") %>
 </div>

--- a/app/views/fields/time/_form.html.erb
+++ b/app/views/fields/time/_form.html.erb
@@ -2,7 +2,7 @@
 # Time Form Partial
 
 This partial renders an input element for time attributes.
-By default, the input is a select field for the time attributes.
+By default, the input is a text field that is augmented with [DateTimePicker].
 
 ## Local variables:
 
@@ -12,6 +12,7 @@ By default, the input is a select field for the time attributes.
   An instance of [Administrate::Field::Time][1].
   A wrapper around the tmie attributes pulled from the model.
 
+[DateTimePicker]: https://github.com/Eonasdan/bootstrap-datetimepicker
 %>
 
 <div class="field-unit__label">


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1671
Root cause explained on the issue: https://github.com/thoughtbot/administrate/issues/1671#issuecomment-641168322

For the same app as shown in that issue, the time fields now display and update as you'd expect:

![image](https://user-images.githubusercontent.com/507155/84134844-17f8d100-aa41-11ea-9252-5f94d9de8a17.png)


![image](https://user-images.githubusercontent.com/507155/84134826-1202f000-aa41-11ea-91ac-1f0070bf4893.png)

You can check that out here: https://github.com/Pezmc/AdministrateTimeBug/tree/bugfix

Tests: Given this is effectively a front-end bug, and there are no `Field::Time`'s in the example-app (and few tests against that app), I wasn't clear where to add test coverage. I could add a `spec/administrate/views/fields/time/_form_spec.rb` that asserts the value is formatted as `HH:MM:SS`, but it doesn't feel like that's asserting the right thing.