### PR TITLE
`protected` visibility is discouraged

### DIFF
--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -11,7 +11,7 @@ module Administrate
         associated_class_name.constantize
       end
 
-      protected
+      private
 
       def associated_dashboard
         "#{associated_class_name}Dashboard".constantize.new

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -23,7 +23,7 @@ module Administrate
         data ? data.to_global_id : nil
       end
 
-      protected
+      private
 
       def associated_dashboard(klass = data.class)
         "#{klass.name}Dashboard".constantize.new

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -23,7 +23,7 @@ module Administrate
         dashboard.try(:item_includes) || []
       end
 
-      protected
+      private
 
       def attribute_field(dashboard, resource, attribute_name, page)
         value = get_attribute_value(resource, attribute_name)

--- a/lib/administrate/page/form.rb
+++ b/lib/administrate/page/form.rb
@@ -20,7 +20,7 @@ module Administrate
         dashboard.display_resource(resource)
       end
 
-      protected
+      private
 
       attr_reader :dashboard
     end


### PR DESCRIPTION
Coming from other languages, it's tempting to use `protected` in Ruby. However this keyword has different nuanced in Ruby and is generally discouraged.

In Ruby, typical legitimate uses of `protected` include support methods for comparators and operators. None of the methods marked as `protected` here fall into this category, so I think they should be marked `private` instead.