### PR TITLE
Restore destroy functionality

### DIFF
--- a/app/assets/javascripts/administrate/application.js
+++ b/app/assets/javascripts/administrate/application.js
@@ -1,4 +1,5 @@
 //= require jquery
+//= require jquery_ujs
 //= require selectize
 //= require moment
 //= require datetime_picker

--- a/spec/example_app/app/assets/javascripts/application.js
+++ b/spec/example_app/app/assets/javascripts/application.js
@@ -11,4 +11,5 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -48,7 +48,7 @@ feature "log entries index page" do
     expect(current_path).to eq(new_admin_log_entry_path)
   end
 
-  scenario "user deletes record" do
+  scenario "user deletes record", js: true do
     create(:log_entry)
 
     visit admin_log_entries_path

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -45,7 +45,7 @@ feature "order index page" do
     expect(current_path).to eq(new_admin_order_path)
   end
 
-  scenario "user deletes record" do
+  scenario "user deletes record", js: true do
     create(:order)
 
     visit admin_orders_path
@@ -56,7 +56,7 @@ feature "order index page" do
     )
   end
 
-  scenario "cannot delete because associated payment" do
+  scenario "cannot delete because associated payment", js: true do
     create(:payment, order: create(:order))
 
     visit admin_orders_path

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,4 +37,8 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, options)
 end
 
+Capybara.register_driver :rack_test do |app|
+  Capybara::RackTest::Driver.new(app, respect_data_method: false)
+end
+
 Capybara.server = :webrick


### PR DESCRIPTION
In #1618, we removed the explicit include of `jquery_ujs` as it should
no longer be necessary. Alas, this broke the ability to destroy items.

This wasn't caught by the tests because Capybara tries to be clever with
these links, sending the `DELETE` directly instead of clicking on the link. We
disable this here and switch the specs to use the JS driver so that
we're actually testing the functionality (it can't pass without).

Adding the include of `jquery_ujs` solves this for now, unblocking us
from having a release for lots of other features and allows us to
revisit this problem again (in a way that we'll catch it this time!).

Fixes #1643.