### PR TITLE
Revert ujs removal

### DIFF
--- a/app/assets/javascripts/administrate/application.js
+++ b/app/assets/javascripts/administrate/application.js
@@ -1,4 +1,5 @@
 //= require jquery
+//= require jquery_ujs
 //= require selectize
 //= require moment
 //= require datetime_picker

--- a/spec/example_app/app/assets/javascripts/application.js
+++ b/spec/example_app/app/assets/javascripts/application.js
@@ -11,4 +11,5 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery_ujs
 //= require_tree .

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -48,7 +48,7 @@ feature "log entries index page" do
     expect(current_path).to eq(new_admin_log_entry_path)
   end
 
-  scenario "user deletes record" do
+  scenario "user deletes record", :js do
     create(:log_entry)
 
     visit admin_log_entries_path

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -45,7 +45,7 @@ feature "order index page" do
     expect(current_path).to eq(new_admin_order_path)
   end
 
-  scenario "user deletes record" do
+  scenario "user deletes record", :js do
     create(:order)
 
     visit admin_orders_path
@@ -56,7 +56,7 @@ feature "order index page" do
     )
   end
 
-  scenario "cannot delete because associated payment" do
+  scenario "cannot delete because associated payment", :js do
     create(:payment, order: create(:order))
 
     visit admin_orders_path

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,4 +37,8 @@ Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, options)
 end
 
+Capybara.register_driver :rack_test do |app|
+  Capybara::RackTest::Driver.new(app, respect_data_method: false)
+end
+
 Capybara.server = :webrick


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1643

When https://github.com/thoughtbot/administrate/pull/1618 was merged, some JS broke. One important piece of functionality that stopped working was "destroy" links.

We were using the JS-driven destroy links that are common in Rails. These work on links with the attribute `data-method="delete"`, and show a `confirm()` box with text extracted from the attribute `data-confirm`.

You might be wondering why the specs didn't break... Well, it turns out that Capybara tries to be clever about these special attributes, even when using Rack::Test. As a result, tests passed even though the JS to drive the functionality wasn't working. To avoid this happening again, I have told Capybara to `respect_data_method: false`.

We'll still have to look into the issue that #1618 was intended to help with: how to integrate with both Webpacker and the asset pipeline. For now, this is a pressing problem, and this solution will make do.

The specs demonstrating the issue are taken from https://github.com/thoughtbot/administrate/pull/1688. Note one difference though: I'm passing the `:js` option as now Rack::Test won't try pretend that JS is available.