### PR TITLE
Add min-width to main-content

### DIFF
--- a/app/assets/stylesheets/administrate/components/_main-content.scss
+++ b/app/assets/stylesheets/administrate/components/_main-content.scss
@@ -5,6 +5,7 @@
               0 2px 2px rgba($black, 0.2);
   flex: 1 1 100%;
   padding-bottom: 10vh;
+  min-width: 800px;
 }
 
 .main-content__header,


### PR DESCRIPTION
Destroy button fits on the page when Layout is Responsive.

fix #1699 