### PR TITLE
Update Portuguese translation

### DIFF
--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -23,7 +23,7 @@ pt-BR:
         none: Nenhum
     form:
       error: erro
-      errors: "%{pluralized_errors} não permitiram guardar este %{resource_name}:"
+      errors: "%{pluralized_errors} impediram %{resource_name} de ser gravado:"
     navigation:
       back_to_app: Voltar ao aplicativo
     search:

--- a/config/locales/administrate.pt-BR.yml
+++ b/config/locales/administrate.pt-BR.yml
@@ -22,8 +22,8 @@ pt-BR:
         more: "Exibindo %{count} de %{total_count}"
         none: Nenhum
     form:
-      error: error
-      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+      error: erro
+      errors: "%{pluralized_errors} não permitiram guardar este %{resource_name}:"
     navigation:
       back_to_app: Voltar ao aplicativo
     search:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -23,7 +23,7 @@ pt:
         none: Nenhum
     form:
       error: erro
-      errors: "%{pluralized_errors} não permitiram guardar este %{resource_name}:"
+      errors: "%{pluralized_errors} impediram %{resource_name} de ser gravado:"
     navigation:
       back_to_app: Voltar à aplicação
     search:

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -22,10 +22,10 @@ pt:
         more: "Mostrando %{count} de %{total_count}"
         none: Nenhum
     form:
-      error: error
-      errors: "%{pluralized_errors} prohibited this %{resource_name} from being saved:"
+      error: erro
+      errors: "%{pluralized_errors} impediu %{resource_name} de ser gravado:"
     navigation:
-      back_to_app: Voltar ao aplicativo
+      back_to_app: Voltar à aplicação
     search:
       clear: Limpar pesquisa
       label: Pesquisa %{resource}

--- a/config/locales/administrate.pt.yml
+++ b/config/locales/administrate.pt.yml
@@ -23,7 +23,7 @@ pt:
         none: Nenhum
     form:
       error: erro
-      errors: "%{pluralized_errors} impediu %{resource_name} de ser gravado:"
+      errors: "%{pluralized_errors} não permitiram guardar este %{resource_name}:"
     navigation:
       back_to_app: Voltar à aplicação
     search:


### PR DESCRIPTION
Translated the form key from English in the Portuguese and Portuguese from Brazil translation files.
 
back_to_app was using an expression used in Portuguese from Brazil that is not used in Portuguese from Portugal.