### PR TITLE
Ew replace phantomjs with selenium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,9 +29,8 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
-  gem 'selenium-webdriver'
-  # gem "poltergeist"
   gem "pundit"
+  gem 'selenium-webdriver'
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
-  gem "poltergeist"
+  gem 'selenium-webdriver'
+  # gem "poltergeist"
   gem "pundit"
   gem "shoulda-matchers"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    cliver (0.3.2)
+    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crack (0.4.3)
@@ -150,10 +150,6 @@ GEM
     parser (2.7.0.4)
       ast (~> 2.4.0)
     pg (1.2.3)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -202,6 +198,7 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -212,6 +209,9 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sentry-raven (3.0.0)
       faraday (>= 1.0)
     shoulda-matchers (4.3.0)
@@ -241,9 +241,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.0)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -271,12 +268,12 @@ DEPENDENCIES
   i18n-tasks (= 0.9.31)
   launchy
   pg
-  poltergeist
   pry-rails
   pundit
   rack-timeout
   redcarpet
   rspec-rails
+  selenium-webdriver
   sentry-raven
   shoulda-matchers
   timecop

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
----
-title: Administrate
-home: true
----
+#Administrate
 
 [![CircleCI](https://img.shields.io/circleci/project/github/thoughtbot/administrate.svg)](https://circleci.com/gh/thoughtbot/administrate/tree/master)
 [![Gem Version](https://badge.fury.io/rb/administrate.svg)](https://badge.fury.io/rb/administrate)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -16,7 +16,7 @@ class DocsController < ApplicationController
   end
 
   def show
-    if find_special_file != nil 
+    if !find_special_file.nil?
       render_page find_special_file[:file]
     else
       render_page "docs/#{params[:page]}"

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -6,7 +6,8 @@ class DocsController < ApplicationController
     },
     {
       file: 'README',
-      page: 'index'
+      page: 'index',
+      home: true
     }
   ].freeze
 
@@ -19,11 +20,11 @@ class DocsController < ApplicationController
     render_correct_page
   end
 
+  private
+
   def find_special_file
     params[:page].nil? ? retrieve_index_content : retrieve_everypage_content
   end
-
-  private
 
   def retrieve_index_content
     SPECIAL_FILES.find { |page| page[:page] == 'index' }
@@ -64,14 +65,23 @@ class DocsController < ApplicationController
 
   def parse_document(path)
     text = File.read(path)
-    DocumentParser.new(text)
+    @page_title = retrieve_index_content[:title]
+    @page_title_suffix = ""
+    DocumentParser.new(text, @page_title, @page_title_suffix)
   end
 
   class DocumentParser
-    def initialize(source_text)
+    def initialize(source_text, page_title, page_title_suffix)
       front_matter_parsed = FrontMatterParser::Parser.new(:md).call(source_text)
       @source_text = front_matter_parsed.content
-      @metadata = front_matter_parsed.front_matter
+      if front_matter_parsed.front_matter.empty?
+        p "here"
+        @metadata = {"home"=>true}
+      else
+        @metadata = front_matter_parsed.front_matter
+      end
+      p @metadata
+      @page_title_suffix = page_title_suffix
     end
 
     def body
@@ -95,7 +105,7 @@ class DocsController < ApplicationController
     end
 
     def title_suffix
-      metadata["home"] ? "" : " - Administrate"
+      metadata["home"] ? "Administrate" : " - Administrate"
     end
 
     private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -15,10 +15,6 @@ class DocsController < ApplicationController
     autolink: true,
   }.freeze
 
-  # def index
-  #   render_page "README"
-  # end
-
   def show
     render_correct_page
   end
@@ -35,14 +31,8 @@ class DocsController < ApplicationController
 
   def render_correct_page
     if !find_special_file.nil?
-      p find_special_file
       render_page find_special_file[:file]
-    # elsif params[:page] == nil
-    #     p params
-    #   render_page "README"
     else
-      p "here"
-      p params
       render_page "docs/#{params[:page]}"
     end
   end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -4,7 +4,10 @@ class DocsController < ApplicationController
     {
       file: "CONTRIBUTING",
       page: "contributing",
-    }.freeze
+    }, {
+      file: "djsfhkjdh",
+      page: "ksfhalk",
+    }
 
   ]
 
@@ -18,9 +21,11 @@ class DocsController < ApplicationController
   end
 
   def show
-    # First check if page in special files, if so
-    if (params[:page] == SPECIAL_FILES[0][:page])
-      render_page SPECIAL_FILES[0][:file]
+
+    p  SPECIAL_FILES.select { |page| page[:page] == params[:page]}
+
+    if SPECIAL_FILES.select { |page| page[:page] == params[:page]}.length > 0 
+      render_page SPECIAL_FILES.select { |page| page[:page] == params[:page]}[0][:file]
     else
       render_page "docs/#{params[:page]}"
     end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -16,11 +16,7 @@ class DocsController < ApplicationController
   end
 
   def show
-    if !find_special_file.nil?
-      render_page find_special_file[:file]
-    else
-      render_page "docs/#{params[:page]}"
-    end
+    render_correct_page
   end
 
   def find_special_file
@@ -28,6 +24,14 @@ class DocsController < ApplicationController
   end
 
   private
+
+  def render_correct_page
+    if !find_special_file.nil?
+      render_page find_special_file[:file]
+    else
+      render_page "docs/#{params[:page]}"
+    end
+  end
 
   def render_page(name)
     path = full_page_path(name)

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -25,7 +25,7 @@ class DocsController < ApplicationController
   end
 
   def check_special_file
-    SPECIAL_FILES.select { |page| page[:page] == params[:page]}
+    SPECIAL_FILES.select { |page| page[:page] == params[:page] }
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -65,8 +65,6 @@ class DocsController < ApplicationController
 
   def parse_document(path)
     text = File.read(path)
-    # @page_title = retrieve_index_content[:title]
-    # @page_title_suffix = ""
     DocumentParser.new(text)
   end
 
@@ -74,11 +72,11 @@ class DocsController < ApplicationController
     def initialize(source_text)
       front_matter_parsed = FrontMatterParser::Parser.new(:md).call(source_text)
       @source_text = front_matter_parsed.content
-      if front_matter_parsed.front_matter.empty?
-        @metadata = {"home"=>true}
-      else
-        @metadata = front_matter_parsed.front_matter
-      end
+      @metadata = if front_matter_parsed.front_matter.empty?
+          { "home"=>true }
+        else
+          front_matter_parsed.front_matter
+        end
     end
 
     def body
@@ -102,7 +100,7 @@ class DocsController < ApplicationController
     end
 
     def title_suffix
-      metadata["home"] ? "Administrate" : " - Administrate"
+      metadata["home"] ? 'Administrate' : ' - Administrate'
     end
 
     private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -65,23 +65,20 @@ class DocsController < ApplicationController
 
   def parse_document(path)
     text = File.read(path)
-    @page_title = retrieve_index_content[:title]
-    @page_title_suffix = ""
-    DocumentParser.new(text, @page_title, @page_title_suffix)
+    # @page_title = retrieve_index_content[:title]
+    # @page_title_suffix = ""
+    DocumentParser.new(text)
   end
 
   class DocumentParser
-    def initialize(source_text, page_title, page_title_suffix)
+    def initialize(source_text)
       front_matter_parsed = FrontMatterParser::Parser.new(:md).call(source_text)
       @source_text = front_matter_parsed.content
       if front_matter_parsed.front_matter.empty?
-        p "here"
         @metadata = {"home"=>true}
       else
         @metadata = front_matter_parsed.front_matter
       end
-      p @metadata
-      @page_title_suffix = page_title_suffix
     end
 
     def body

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -16,7 +16,6 @@ class DocsController < ApplicationController
   end
 
   def show
-    p find_special_file
     if find_special_file != nil 
       render_page find_special_file[:file]
     else

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -4,11 +4,7 @@ class DocsController < ApplicationController
     {
       file: "CONTRIBUTING",
       page: "contributing",
-    }, {
-      file: "djsfhkjdh",
-      page: "ksfhalk",
     }
-
   ]
 
   REDCARPET_CONFIG = {
@@ -21,8 +17,6 @@ class DocsController < ApplicationController
   end
 
   def show
-
-    p  SPECIAL_FILES.select { |page| page[:page] == params[:page]}
 
     if SPECIAL_FILES.select { |page| page[:page] == params[:page]}.length > 0 
       render_page SPECIAL_FILES.select { |page| page[:page] == params[:page]}[0][:file]

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -20,7 +20,15 @@ class DocsController < ApplicationController
   end
 
   def find_special_file
-    params[:page].nil? ? SPECIAL_FILES.find { |page| page[:page] == 'index' } : SPECIAL_FILES.find { |page| page[:page] == params[:page] }
+    params[:page].nil? ? retrieve_index_content : retrieve_everypage_content
+  end
+
+  def retrieve_index_content
+    SPECIAL_FILES.find { |page| page[:page] == 'index' }
+  end
+
+  def retrieve_everypage_content
+    SPECIAL_FILES.find { |page| page[:page] == params[:page] }
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -3,6 +3,10 @@ class DocsController < ApplicationController
     {
       file: 'CONTRIBUTING',
       page: 'contributing'
+    },
+    {
+      file: "README",
+      page: "index"
     }
   ].freeze
 
@@ -20,16 +24,22 @@ class DocsController < ApplicationController
   end
 
   def find_special_file
-    SPECIAL_FILES.select { |page| page[:page] == params[:page] }.first
+    if params[:page] == nil
+      SPECIAL_FILES.select { |page| page[:page] == "index" }.first
+    else
+      SPECIAL_FILES.select { |page| page[:page] == params[:page] }.first
+    end
   end
 
   private
 
   def render_correct_page
     if !find_special_file.nil?
+      p find_special_file
       render_page find_special_file[:file]
-    elsif params[:page] == nil
-      render_page "README"
+    # elsif params[:page] == nil
+    #     p params
+    #   render_page "README"
     else
       p "here"
       p params

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -1,4 +1,15 @@
 class DocsController < ApplicationController
+
+  SPECIAL_FILES = [
+    {
+      file: "CONTRIBUTING.md",
+      name: "Contributing",
+      path: "Contributing",
+      page: "CONTRIBUTING",
+    }.freeze
+
+  ]
+
   REDCARPET_CONFIG = {
     fenced_code_blocks: true,
     autolink: true,
@@ -9,7 +20,12 @@ class DocsController < ApplicationController
   end
 
   def show
-    render_page "docs/#{params[:page]}"
+    # First check if page in special files, if so
+    if (params[:page] == "contributing")
+      render_page "CONTRIBUTING"
+    else
+      render_page "docs/#{params[:page]}"
+    end
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -73,10 +73,10 @@ class DocsController < ApplicationController
       front_matter_parsed = FrontMatterParser::Parser.new(:md).call(source_text)
       @source_text = front_matter_parsed.content
       @metadata = if front_matter_parsed.front_matter.empty?
-          { "home"=>true }
-        else
-          front_matter_parsed.front_matter
-        end
+                    { "home"=>true }
+                  else
+                    front_matter_parsed.front_matter
+                  end
     end
 
     def body

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -21,16 +21,16 @@ class DocsController < ApplicationController
 
   def find_special_file
     if params[:page] == nil
-      SPECIAL_FILES.select { |page| page[:page] == "index" }.first
+      SPECIAL_FILES.find { |page| page[:page] == "index" }
     else
-      SPECIAL_FILES.select { |page| page[:page] == params[:page] }.first
+      SPECIAL_FILES.find { |page| page[:page] == params[:page] }
     end
   end
 
   private
 
   def render_correct_page
-    if !find_special_file.nil?
+    if find_special_file
       render_page find_special_file[:file]
     else
       render_page "docs/#{params[:page]}"

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -4,9 +4,6 @@ class DocsController < ApplicationController
       file: 'CONTRIBUTING',
       page: 'contributing'
     }
-    {
-
-    }
   ].freeze
 
   REDCARPET_CONFIG = {
@@ -19,8 +16,8 @@ class DocsController < ApplicationController
   end
 
   def show
-    if check_special_file.length > 0 
-      render_page check_special_file[0][:file]
+    if find_special_file.length > 0 
+      render_page find_special_file[0][:file]
     else
       render_page "docs/#{params[:page]}"
     end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -5,8 +5,8 @@ class DocsController < ApplicationController
       page: 'contributing'
     },
     {
-      file: "README",
-      page: "index"
+      file: 'README',
+      page: 'index'
     }
   ].freeze
 
@@ -20,8 +20,8 @@ class DocsController < ApplicationController
   end
 
   def find_special_file
-    if params[:page] == nil
-      SPECIAL_FILES.find { |page| page[:page] == "index" }
+    if params[:page].nil?
+      SPECIAL_FILES.find { |page| page[:page] == 'index' }
     else
       SPECIAL_FILES.find { |page| page[:page] == params[:page] }
     end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -23,6 +23,8 @@ class DocsController < ApplicationController
     params[:page].nil? ? retrieve_index_content : retrieve_everypage_content
   end
 
+  private
+
   def retrieve_index_content
     SPECIAL_FILES.find { |page| page[:page] == 'index' }
   end
@@ -30,8 +32,6 @@ class DocsController < ApplicationController
   def retrieve_everypage_content
     SPECIAL_FILES.find { |page| page[:page] == params[:page] }
   end
-
-  private
 
   def render_correct_page
     if find_special_file

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -1,11 +1,10 @@
 class DocsController < ApplicationController
-
   SPECIAL_FILES = [
     {
       file: 'CONTRIBUTING',
       page: 'contributing'
     }
-  ]
+  ].freeze
 
   REDCARPET_CONFIG = {
     fenced_code_blocks: true,

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -2,8 +2,8 @@ class DocsController < ApplicationController
 
   SPECIAL_FILES = [
     {
-      file: "CONTRIBUTING",
-      page: "contributing",
+      file: 'CONTRIBUTING',
+      page: 'contributing'
     }
   ]
 

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -17,12 +17,15 @@ class DocsController < ApplicationController
   end
 
   def show
-
-    if SPECIAL_FILES.select { |page| page[:page] == params[:page]}.length > 0 
-      render_page SPECIAL_FILES.select { |page| page[:page] == params[:page]}[0][:file]
+    if check_special_file.length > 0 
+      render_page check_special_file[0][:file]
     else
       render_page "docs/#{params[:page]}"
     end
+  end
+
+  def check_special_file
+    SPECIAL_FILES.select { |page| page[:page] == params[:page]}
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -73,7 +73,7 @@ class DocsController < ApplicationController
       front_matter_parsed = FrontMatterParser::Parser.new(:md).call(source_text)
       @source_text = front_matter_parsed.content
       @metadata = if front_matter_parsed.front_matter.empty?
-                    { "home"=>true }
+                    { 'home' => true }
                   else
                     front_matter_parsed.front_matter
                   end
@@ -100,7 +100,7 @@ class DocsController < ApplicationController
     end
 
     def title_suffix
-      metadata["home"] ? 'Administrate' : ' - Administrate'
+      metadata['home'] ? 'Administrate' : ' - Administrate'
     end
 
     private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -16,15 +16,16 @@ class DocsController < ApplicationController
   end
 
   def show
-    if find_special_file.length > 0 
-      render_page find_special_file[0][:file]
+    p find_special_file
+    if find_special_file != nil 
+      render_page find_special_file[:file]
     else
       render_page "docs/#{params[:page]}"
     end
   end
 
   def find_special_file
-    SPECIAL_FILES.select { |page| page[:page] == params[:page] }
+    SPECIAL_FILES.select { |page| page[:page] == params[:page] }.first
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -2,10 +2,8 @@ class DocsController < ApplicationController
 
   SPECIAL_FILES = [
     {
-      file: "CONTRIBUTING.md",
-      name: "Contributing",
-      path: "Contributing",
-      page: "CONTRIBUTING",
+      file: "CONTRIBUTING",
+      page: "contributing",
     }.freeze
 
   ]
@@ -21,8 +19,8 @@ class DocsController < ApplicationController
 
   def show
     # First check if page in special files, if so
-    if (params[:page] == "contributing")
-      render_page "CONTRIBUTING"
+    if (params[:page] == SPECIAL_FILES[0][:page])
+      render_page SPECIAL_FILES[0][:file]
     else
       render_page "docs/#{params[:page]}"
     end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -20,11 +20,7 @@ class DocsController < ApplicationController
   end
 
   def find_special_file
-    if params[:page].nil?
-      SPECIAL_FILES.find { |page| page[:page] == 'index' }
-    else
-      SPECIAL_FILES.find { |page| page[:page] == params[:page] }
-    end
+    params[:page].nil? ? SPECIAL_FILES.find { |page| page[:page] == 'index' } : SPECIAL_FILES.find { |page| page[:page] == params[:page] }
   end
 
   private

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -4,6 +4,9 @@ class DocsController < ApplicationController
       file: 'CONTRIBUTING',
       page: 'contributing'
     }
+    {
+
+    }
   ].freeze
 
   REDCARPET_CONFIG = {
@@ -23,7 +26,7 @@ class DocsController < ApplicationController
     end
   end
 
-  def check_special_file
+  def find_special_file
     SPECIAL_FILES.select { |page| page[:page] == params[:page] }
   end
 

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -11,9 +11,9 @@ class DocsController < ApplicationController
     autolink: true,
   }.freeze
 
-  def index
-    render_page "README"
-  end
+  # def index
+  #   render_page "README"
+  # end
 
   def show
     render_correct_page
@@ -28,7 +28,11 @@ class DocsController < ApplicationController
   def render_correct_page
     if !find_special_file.nil?
       render_page find_special_file[:file]
+    elsif params[:page] == nil
+      render_page "README"
     else
+      p "here"
+      p params
       render_page "docs/#{params[:page]}"
     end
   end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   end
 
   get "/:page", to: "docs#show"
-  root to: "docs#index"
+  root to: "docs#show"
 end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   end
 
   get "/:page", to: "docs#show"
-  root to: "docs#show"
+  root to: 'docs#show'
 end

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -37,5 +37,4 @@ describe "documentation navigation" do
       map { |anchor| anchor[:href] }.
       select { |href| URI.parse(href).relative? }
   end
-
 end

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -37,4 +37,5 @@ describe "documentation navigation" do
       map { |anchor| anchor[:href] }.
       select { |href| URI.parse(href).relative? }
   end
+
 end

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -52,7 +52,10 @@ feature "log entries index page" do
     create(:log_entry)
 
     visit admin_log_entries_path
-    click_on t("administrate.actions.destroy")
+    
+    accept_confirm do
+      click_on t("administrate.actions.destroy")
+    end
 
     expect(page).to have_flash(
       t("administrate.controller.destroy.success", resource: "LogEntry"),

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -49,7 +49,10 @@ feature "order index page" do
     create(:order)
 
     visit admin_orders_path
-    click_on t("administrate.actions.destroy")
+    
+    accept_confirm do
+      click_on t("administrate.actions.destroy")
+    end
 
     expect(page).to have_flash(
       t("administrate.controller.destroy.success", resource: "Order")

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -63,7 +63,10 @@ feature "order index page" do
     create(:payment, order: create(:order))
 
     visit admin_orders_path
-    click_on t("administrate.actions.destroy")
+    
+    accept_confirm do
+      click_on t("administrate.actions.destroy")
+    end
 
     expect(page).to have_flash(
       "Cannot delete record because dependent payments exist", type: :error

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require File.expand_path("../../spec/example_app/config/environment", __FILE__)
 
 require "rspec/rails"
 require "shoulda/matchers"
-require "capybara/poltergeist"
+require "selenium/webdriver"
 
 Dir[Rails.root.join("../../spec/support/**/*.rb")].each { |file| require file }
 
@@ -31,14 +31,23 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :poltergeist
-Capybara.register_driver :poltergeist do |app|
-  options = { phantomjs_options: ["--load-images=no"] }
-  Capybara::Poltergeist::Driver.new(app, options)
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 
-Capybara.register_driver :rack_test do |app|
-  Capybara::RackTest::Driver.new(app, respect_data_method: false)
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      args: %w[headless enable-features=NetworkService,NetworkServiceInProcess]
+    }
+  )
+
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    desired_capabilities: capabilities
 end
+
+Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.server = :webrick

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require "webmock/rspec"
+require 'capybara/rspec'
+require "selenium/webdriver"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
Remove gem phantomjs as it has been discontinued. Replaced with selenium and web drivers. 

Small fixes to three tests due to selenium's handling of pop ups:

Capybara was used to directly to accept a confirmation box. This was done by wrapping the code that caused the confirmation box to appear in the accept_confirm function.

`accept_confirm do
  click_link 'Destroy'
end`