### PR TITLE
Dashboard indentation

### DIFF
--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -19,8 +19,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-<%=
-  attributes.first(COLLECTION_ATTRIBUTE_LIMIT).map do |attr|
+<%=  attributes.first(COLLECTION_ATTRIBUTE_LIMIT).map do |attr|
     "  #{attr}"
   end.join("\n")
 %>
@@ -29,8 +28,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-<%=
-  attributes.map do |attr|
+<%=  attributes.map do |attr|
     "  #{attr}"
   end.join("\n")
 %>
@@ -40,8 +38,7 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-<%=
-  form_attributes.map do |attr|
+<%=  form_attributes.map do |attr|
     "  #{attr}"
   end.join("\n")
 %>


### PR DESCRIPTION
I edited the dashboard generator template folder so the indentation for COLLECTION_ATTRIBUTES, SHOW_PAGE_ATTRIBUTES and FORM_ATTRIBUTES is now 4 spaces for items in the arrays instead of 2. MH