### PR TITLE
Change the way polymorphic fields display links

### DIFF
--- a/app/views/fields/polymorphic/_show.html.erb
+++ b/app/views/fields/polymorphic/_show.html.erb
@@ -17,7 +17,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.attribute) %>
+  <% if valid_action?(:show, field.data.class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],


### PR DESCRIPTION
In one of my recent projects using administrate I made a change in the `_show` of the polymorphic field. It attended my needs, and I think it's the way to go. 

Contextualizing: The `valid_action?` implementation receives as second argument the resource class name (constantize), and so will look for the correspondent controller and check if the action exists. In the polymorphic field, we're using this to display the attribute as a link or just plain text.

The problem: In the `_show` partial we check for the field attribute, that will return just the attribute name, and polymorphic fields constantly have attribute names that don't correspond whit any controller name. Here is an example: I can have an Address model that have a polymorphic association that receives the name of `owner`, and the owner can be a Shop and User model. We have the `ShopsController` and `UsersController`, but not an `OwnersController`. As result, we'll be showing the owner as plain text only.

The solution: Just inform the field data class instead of the attribute name. Doing so, using the example described above, we'll be checking for the ShopsController and UsersController instead of the OwnersController, properly showing the owner as a link.