### PR TITLE
Adds ability to set the first sort direction on a dashboard.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
-  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "0.9.31"
   gem "pry-rails"
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
@@ -268,6 +271,7 @@ DEPENDENCIES
   i18n-tasks (= 0.9.31)
   launchy
   pg
+  pry-byebug
   pry-rails
   pundit
   rack-timeout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,9 +153,6 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
@@ -271,7 +268,6 @@ DEPENDENCIES
   i18n-tasks (= 0.9.31)
   launchy
   pg
-  pry-byebug
   pry-rails
   pundit
   rack-timeout

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -101,11 +101,13 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction, first_sort_direction)
+      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction,
+        first_sort_direction)
     end
 
     def first_sort_direction
-      sorting_params.fetch(:first_sort_direction) { default_first_sort_direction }
+      sorting_params.fetch(:first_sort_direction) {
+        default_first_sort_direction }
     end
 
     def default_first_sort_direction

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -101,7 +101,15 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
+      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction, first_sort_direction)
+    end
+
+    def first_sort_direction
+      sorting_params.fetch(:first_sort_direction) { default_first_sort_direction }
+    end
+
+    def default_first_sort_direction
+      nil
     end
 
     def sorting_attribute

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -56,12 +56,13 @@ module Administrate
         Administrate::Order.new(
           params.fetch(:order, sort_by),
           params.fetch(:direction, direction),
-          params.fetch(:first_sort_direction, first_sort_direction)
+          params.fetch(:first_sort_direction, first_sort_direction),
         )
       end
 
       def order
-        @order ||= Administrate::Order.new(sort_by, direction, first_sort_direction)
+        @order ||= Administrate::Order.new(sort_by, direction,
+          first_sort_direction)
       end
 
       private

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -56,11 +56,12 @@ module Administrate
         Administrate::Order.new(
           params.fetch(:order, sort_by),
           params.fetch(:direction, direction),
+          params.fetch(:first_sort_direction, first_sort_direction)
         )
       end
 
       def order
-        @order ||= Administrate::Order.new(sort_by, direction)
+        @order ||= Administrate::Order.new(sort_by, direction, first_sort_direction)
       end
 
       private
@@ -84,6 +85,10 @@ module Administrate
 
       def sort_by
         options[:sort_by]
+      end
+
+      def first_sort_direction
+        options[:first_sort_direction]
       end
 
       def direction

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -3,7 +3,7 @@ module Administrate
     def initialize(attribute = nil, direction = nil, first_sort_direction = nil)
       @attribute = attribute
       @direction = sanitize_direction(direction)
-      @first_sort_direction = first_sort_direction
+      @first_sort_direction = sanitize_direction(first_sort_direction)
     end
 
     def apply(relation)

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,8 +1,9 @@
 module Administrate
   class Order
-    def initialize(attribute = nil, direction = nil)
+    def initialize(attribute = nil, direction = nil, first_sort_direction = nil)
       @attribute = attribute
       @direction = sanitize_direction(direction)
+      @first_sort_direction = first_sort_direction
     end
 
     def apply(relation)
@@ -42,7 +43,7 @@ module Administrate
       if ordered_by?(attr)
         opposite_direction
       else
-        :asc
+        @first_sort_direction ||= :asc
       end
     end
 

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -161,19 +161,19 @@ describe Administrate::Order do
         params = order.order_params_for(:order)
         expect(params[:direction]).to eq(:desc)
       end
-      
+
       it "sorts by asc if specified" do
         order = Administrate::Order.new(:email, nil, :asc)
         params = order.order_params_for(:order)
         expect(params[:direction]).to eq(:asc)
       end
-      
+
       it "sorts by asc if not specified" do
         order = Administrate::Order.new(:email)
         params = order.order_params_for(:order)
         expect(params[:direction]).to eq(:asc)
       end
-      
+
       it "sorts by asc if invalid input" do
         order = Administrate::Order.new(:email, nil, :foobar)
         params = order.order_params_for(:order)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -173,6 +173,12 @@ describe Administrate::Order do
         params = order.order_params_for(:order)
         expect(params[:direction]).to eq(:asc)
       end
+      
+      it "sorts by asc if invalid input" do
+        order = Administrate::Order.new(:email, nil, :foobar)
+        params = order.order_params_for(:order)
+        expect(params[:direction]).to eq(:asc)
+      end
     end
 
     context "when the data is already ordered by the given attribute" do

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -155,6 +155,26 @@ describe Administrate::Order do
       end
     end
 
+    context "when given a first sort direction" do
+      it "sorts by desc if specified" do
+        order = Administrate::Order.new(:email, nil, :desc)
+        params = order.order_params_for(:order)
+        expect(params[:direction]).to eq(:desc)
+      end
+      
+      it "sorts by asc if specified" do
+        order = Administrate::Order.new(:email, nil, :asc)
+        params = order.order_params_for(:order)
+        expect(params[:direction]).to eq(:asc)
+      end
+      
+      it "sorts by asc if not specified" do
+        order = Administrate::Order.new(:email)
+        params = order.order_params_for(:order)
+        expect(params[:direction]).to eq(:asc)
+      end
+    end
+
     context "when the data is already ordered by the given attribute" do
       it "returns the attribute" do
         order = Administrate::Order.new(:name)


### PR DESCRIPTION
I wanted this functionality in a project I'm working on, so decided to submit a little PR to be considered.

Basically, in my project we want the first sort order when sorting a dashboard's column to be `:desc` instead of the default (`:asc`).

This PR allows you to override the `default_first_sort_direction` in an `application_controller` to be `:desc`.

I'm relatively inexperienced with Ruby, so if there is a better way to do some of the things this does, I would love to hear ways to improve it!