### PR TITLE
Remove autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "administrate-field-image"
-gem "autoprefixer-rails"
 gem "faker"
 gem "front_matter_parser"
 gem "globalid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,6 @@ DEPENDENCIES
   administrate-field-image
   ammeter
   appraisal
-  autoprefixer-rails
   awesome_print
   bundler-audit
   byebug

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "autoprefixer-rails"
 gem "faker"
 gem "front_matter_parser"
 gem "globalid"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "autoprefixer-rails"
 gem "faker"
 gem "front_matter_parser"
 gem "globalid"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "autoprefixer-rails"
 gem "faker"
 gem "front_matter_parser"
 gem "globalid"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "administrate-field-image"
-gem "autoprefixer-rails"
 gem "faker"
 gem "front_matter_parser"
 gem "globalid"

--- a/spec/example_app/browserslist
+++ b/spec/example_app/browserslist
@@ -1,4 +1,0 @@
-Last 2 versions
-Explorer >= 9
-iOS >= 7.1
-Android >= 4.4


### PR DESCRIPTION
Removed auto-prefixer gem as it has been deprecated. Tested on latest versions of Chrome, Firefox and IE with no adverse impact noted.