### PR TITLE
Add extra example for adding controllers without a related model docs

### DIFF
--- a/docs/adding_controllers_without_related_model.md
+++ b/docs/adding_controllers_without_related_model.md
@@ -32,6 +32,20 @@ end
 ```
 
 ```ruby
+# app/controllers/admin/stats_controller.rb
+module Admin
+  class StatsController < Admin::ApplicationController
+    def index
+      @stats = {
+        customer_count: Customer.count,
+        order_count: Order.count,
+      }
+    end
+  end
+end
+```
+
+```ruby
 # config/routes.rb
 namespace :admin do
   # ...


### PR DESCRIPTION
Hey, first of all I would like to say thank you for all the work done on administrate! It's an awesome project and is being very helpful for me and my team.

About this PR, I was looking into how to setup a custom page without a related model, for example a HELP page and ended up on this doc page which explain very well how to do it. But, I ran into some problems because I didn't have an example on how the controller should look like, so I just "cloned" from a model related one and forgot to overwrite the `index` action, which took me a couple minutes to find out where the problem was. After digging into the project repository, I found the `/spec/example_app` folder and there was this controller example. I hope by adding this extra example to the docs will help other people as well :)