### PR TITLE
Better error message if key is not specified in ATTRIBUTE_TYPES

### DIFF
--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -91,7 +91,7 @@ module Administrate
 
     def attribute_includes(attributes)
       attributes.map do |key|
-        field = self.class::ATTRIBUTE_TYPES.fetch(key)
+        field = attribute_type_for(key)
 
         key if field.associative?
       end.compact

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -91,7 +91,7 @@ module Administrate
 
     def attribute_includes(attributes)
       attributes.map do |key|
-        field = self.class::ATTRIBUTE_TYPES[key]
+        field = self.class::ATTRIBUTE_TYPES.fetch(key)
 
         key if field.associative?
       end.compact


### PR DESCRIPTION
I was getting:

```
NoMethodError: undefined method `associative?' for nil:NilClass
```

After the change:

```
KeyError: key not found: :created_at
```