### PR TITLE
Remove autoprefixer-rails as a gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       actionpack (>= 5.0)
       actionview (>= 5.0)
       activerecord (>= 5.0)
-      autoprefixer-rails (>= 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
@@ -53,8 +52,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
-    autoprefixer-rails (9.8.6.3)
-      execjs
     awesome_print (1.8.0)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
@@ -219,7 +216,7 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", ">= 5.0"
   s.add_dependency "activerecord", ">= 5.0"
 
-  s.add_dependency "autoprefixer-rails", ">= 6.0"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"


### PR DESCRIPTION
In #1749, we removed `autoprefixer-rails` from the usual `Gemfile` but it
didn't get removed from the `gemspec`.