### PR TITLE
Support for decorating resources - revised

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -10,10 +10,13 @@ module Administrate
       resources = apply_collection_includes(resources)
       resources = order.apply(resources)
       resources = resources.page(params[:_page]).per(records_per_page)
-      page = Administrate::Page::Collection.new(dashboard, order: order)
+      page = Administrate::Page::Collection.new(
+        dashboard,
+        resources,
+        order: order,
+      )
 
       render locals: {
-        resources: resources,
         search_term: search_term,
         page: page,
         show_search_bar: show_search_bar?,

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -65,8 +65,7 @@ module Administrate
       )
     end
 
-    def sanitized_order_params(page, current_field_name)
-      collection_names = page.item_includes + [current_field_name]
+    def sanitized_order_params(collection_names)
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -28,7 +28,7 @@ to display a collection of resources in an HTML table.
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+        <%= link_to(sanitized_order_params(collection_names).merge(
           collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
         <%= t(

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -10,10 +10,6 @@ to display a collection of resources in an HTML table.
   An instance of [Administrate::Page::Collection][1].
   The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
   the columns displayed in the table
-- `resources`:
-  An ActiveModel::Relation collection of resources to be displayed in the table.
-  By default, the number of resources is limited by pagination
-  or by a hard limit to prevent excessive page load times
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
 %>
@@ -53,7 +49,7 @@ to display a collection of resources in an HTML table.
   </thead>
 
   <tbody>
-    <% resources.each do |resource| %>
+    <% collection_presenter.resources.each do |resource| %>
       <tr class="js-table-row"
           <% if show_action? :show, resource %>
             <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -11,10 +11,6 @@ It renders the `_table` partial to display details about the resources.
   An instance of [Administrate::Page::Collection][1].
   Contains helper methods to help display a table,
   and knows which attributes should be displayed in the resource's table.
-- `resources`:
-  An instance of `ActiveRecord::Relation` containing the resources
-  that match the user's search criteria.
-  By default, these resources are passed to the table partial to be displayed.
 - `search_term`:
   A string containing the term the user has searched for, if any.
 - `show_search_bar`:
@@ -58,9 +54,8 @@ It renders the `_table` partial to display details about the resources.
     collection_presenter: page,
     collection_field_name: resource_name,
     collection_names: [resource_name],
-    resources: resources,
     table_title: "page-title"
   ) %>
 
-  <%= paginate resources, param_name: '_page' %>
+  <%= paginate page.resources, param_name: '_page' %>
 </section>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -57,7 +57,7 @@ It renders the `_table` partial to display details about the resources.
     "collection",
     collection_presenter: page,
     collection_field_name: resource_name,
-    page: page,
+    collection_names: [resource_name],
     resources: resources,
     table_title: "page-title"
   ) %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -57,5 +57,5 @@ It renders the `_table` partial to display details about the resources.
     table_title: "page-title"
   ) %>
 
-  <%= paginate page.resources, param_name: '_page' %>
+  <%= paginate page.resources_for_pagination, param_name: '_page' %>
 </section>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -21,16 +21,16 @@ from the associated resource class's dashboard.
 <% if field.resources.any? %>
   <% order = field.order_from_params(params.fetch(field.name, {})) %>
   <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
+  <% resources = field.resources(page_number, order) %>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection(order),
+    collection_presenter: field.associated_collection(resources, order),
     collection_field_name: field.name,
     collection_names: page.item_includes,
-    resources: field.resources(page_number, order),
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>
+    <%= paginate resources, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -30,7 +30,7 @@ from the associated resource class's dashboard.
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate associated_collection.resources, param_name: "#{field.name}[page]" %>
+    <%= paginate associated_collection.resources_for_pagination, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -25,7 +25,7 @@ from the associated resource class's dashboard.
     "collection",
     collection_presenter: field.associated_collection(order),
     collection_field_name: field.name,
-    page: page,
+    collection_names: page.item_includes,
     resources: field.resources(page_number, order),
     table_title: field.name,
   ) %>

--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -18,19 +18,19 @@ from the associated resource class's dashboard.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
 %>
 
-<% if field.resources.any? %>
+<% if field.data.any? %>
   <% order = field.order_from_params(params.fetch(field.name, {})) %>
   <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
-  <% resources = field.resources(page_number, order) %>
+  <% associated_collection = field.associated_collection(page_number, order)%>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection(resources, order),
+    collection_presenter: associated_collection,
     collection_field_name: field.name,
     collection_names: page.item_includes,
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate resources, param_name: "#{field.name}[page]" %>
+    <%= paginate associated_collection.resources, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -72,6 +72,14 @@ module Administrate
       "#{resource.class} ##{resource.id}"
     end
 
+    def decorate_resource(resource)
+      resource
+    end
+
+    def decorate_resource_collection(resources)
+      resources.map { |resource| decorate_resource(resource) }
+    end
+
     def collection_includes
       attribute_includes(collection_attributes)
     end

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -11,8 +11,12 @@ module Administrate
         { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 
-      def associated_collection(resources, order = self.order)
-        Administrate::Page::Collection.new(associated_dashboard, resources, order: order)
+      def associated_collection(page = 1, order = self.order)
+        Administrate::Page::Collection.new(
+          associated_dashboard,
+          resources(page, order),
+          order: order,
+        )
       end
 
       def attribute_key
@@ -39,11 +43,6 @@ module Administrate
         self.class.permitted_attribute(attribute)
       end
 
-      def resources(page = 1, order = self.order)
-        resources = order.apply(data).page(page).per(limit)
-        includes.any? ? resources.includes(*includes) : resources
-      end
-
       def more_than_limit?
         data.count(:all) > limit
       end
@@ -64,6 +63,11 @@ module Administrate
       end
 
       private
+
+      def resources(page, order)
+        resources = order.apply(data).page(page).per(limit)
+        includes.any? ? resources.includes(*includes) : resources
+      end
 
       def includes
         associated_dashboard.collection_includes

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -11,8 +11,8 @@ module Administrate
         { "#{attr.to_s.singularize}_ids".to_sym => [] }
       end
 
-      def associated_collection(order = self.order)
-        Administrate::Page::Collection.new(associated_dashboard, order: order)
+      def associated_collection(resources, order = self.order)
+        Administrate::Page::Collection.new(associated_dashboard, resources, order: order)
       end
 
       def attribute_key

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -3,6 +3,13 @@ require_relative "base"
 module Administrate
   module Page
     class Collection < Page::Base
+      def initialize(dashboard, resources, options = {})
+        super(dashboard, options)
+        @resources = resources
+      end
+
+      attr_reader :resources
+
       def attribute_names
         dashboard.collection_attributes
       end

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -8,8 +8,6 @@ module Administrate
         @resources = resources
       end
 
-      attr_reader :resources
-
       def attribute_names
         dashboard.collection_attributes
       end
@@ -32,6 +30,14 @@ module Administrate
 
       def order_params_for(attr, key: resource_name)
         { key => order.order_params_for(attr) }
+      end
+
+      def resources
+        dashboard.decorate_resource_collection(@resources)
+      end
+
+      def resources_for_pagination
+        @resources
       end
 
       private

--- a/lib/administrate/page/form.rb
+++ b/lib/administrate/page/form.rb
@@ -8,7 +8,9 @@ module Administrate
         @resource = resource
       end
 
-      attr_reader :resource
+      def resource
+        dashboard.decorate_resource(@resource)
+      end
 
       def attributes
         dashboard.form_attributes.map do |attribute|
@@ -17,7 +19,7 @@ module Administrate
       end
 
       def page_title
-        dashboard.display_resource(resource)
+        dashboard.display_resource(@resource)
       end
 
       private

--- a/lib/administrate/page/show.rb
+++ b/lib/administrate/page/show.rb
@@ -8,10 +8,12 @@ module Administrate
         @resource = resource
       end
 
-      attr_reader :resource
+      def resource
+        dashboard.decorate_resource(@resource)
+      end
 
       def page_title
-        dashboard.display_resource(resource)
+        dashboard.display_resource(@resource)
       end
 
       def attributes

--- a/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/dashboard.rb.erb
@@ -65,4 +65,11 @@ class <%= class_name %>Dashboard < Administrate::BaseDashboard
   # def display_resource(<%= file_name %>)
   #   "<%= class_name %> ##{<%= file_name %>.id}"
   # end
+
+  # Implement this method if you want to use Decorator pattern.
+  # Fields will access the returned object instead of the resource.
+  #
+  # def decorate_resource(<%= file_name %>)
+  #   <%= file_name %>
+  # end
 end

--- a/spec/administrate/views/fields/has_many/_show_spec.rb
+++ b/spec/administrate/views/fields/has_many/_show_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "fields/has_many/_show", type: :view do
   context "without any associated records" do
     it "displays 'None'" do
-      has_many = double(resources: [])
+      has_many = double(data: [])
 
       render(
         partial: "fields/has_many/show.html.erb",

--- a/spec/controllers/admin/blog/posts_controller_spec.rb
+++ b/spec/controllers/admin/blog/posts_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::Blog::PostsController, type: :controller do
       blog_post = create(:blog_post)
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources]).to eq([blog_post])
+      expect(locals[:page].resources).to eq([blog_post])
     end
 
     it "passes the search term to the view" do

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -6,7 +6,7 @@ describe Admin::CustomersController, type: :controller do
       customer = create(:customer)
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources]).to eq([customer])
+      expect(locals[:page].resources).to eq([customer])
     end
 
     it "applies any scope overrides" do
@@ -14,7 +14,7 @@ describe Admin::CustomersController, type: :controller do
       visible_customer = create(:customer, hidden: false)
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources]).to contain_exactly visible_customer
+      expect(locals[:page].resources).to contain_exactly visible_customer
     end
 
     it "passes the search term to the view" do
@@ -44,7 +44,7 @@ describe Admin::CustomersController, type: :controller do
       customers = [customer1, customer2]
 
       locals = capture_view_locals { get :index }
-      expect(locals[:resources].map(&:id)).to eq customers.map(&:id).sort
+      expect(locals[:page].resources.map(&:id)).to eq customers.map(&:id).sort
     end
 
     context "with alternate sorting attributes" do
@@ -63,7 +63,7 @@ describe Admin::CustomersController, type: :controller do
         sorted_customer_names = customers.map(&:name).sort.reverse
 
         locals = capture_view_locals { get :index }
-        expect(locals[:resources].map(&:name)).to eq sorted_customer_names
+        expect(locals[:page].resources.map(&:name)).to eq sorted_customer_names
       end
     end
   end

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -26,7 +26,7 @@ describe Admin::OrdersController, type: :controller do
     describe "GET index" do
       it "shows only the records in the admin scope" do
         locals = capture_view_locals { get :index }
-        expect(locals[:resources].count).to eq(9) # only my orders
+        expect(locals[:page].resources.count).to eq(9) # only my orders
       end
     end
 

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -10,6 +10,7 @@ class OrderDashboard < Administrate::BaseDashboard
     address_city: Field::String,
     address_state: Field::String,
     address_zip: Field::String,
+    address: Field::String.with_options(searchable: false),
     customer: Field::BelongsTo,
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
@@ -22,12 +23,13 @@ class OrderDashboard < Administrate::BaseDashboard
     :total_price,
     :created_at,
     :updated_at,
+    :address,
   ]
 
   COLLECTION_ATTRIBUTES = [
     :id,
     :customer,
-    :address_state,
+    :address,
     :total_price,
     :line_items,
     :shipped_at,
@@ -35,4 +37,8 @@ class OrderDashboard < Administrate::BaseDashboard
 
   FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+
+  def decorate_resource(resource)
+    OrderDecorator.new(resource)
+  end
 end

--- a/spec/example_app/app/decorators/order_decorator.rb
+++ b/spec/example_app/app/decorators/order_decorator.rb
@@ -1,0 +1,60 @@
+class OrderDecorator < SimpleDelegator
+  STATES = { "AL" => "Alabama",
+             "AK" => "Alaska",
+             "AZ" => "Arizona",
+             "AR" => "Arkansas",
+             "CA" => "California",
+             "CO" => "Colorado",
+             "CT" => "Connecticut",
+             "DE" => "Delaware",
+             "FL" => "Florida",
+             "GA" => "Georgia",
+             "HI" => "Hawaii",
+             "ID" => "Idaho",
+             "IL" => "Illinois",
+             "IN" => "Indiana",
+             "IA" => "Iowa",
+             "KS" => "Kansas",
+             "KY" => "Kentucky",
+             "LA" => "Louisiana",
+             "ME" => "Maine",
+             "MD" => "Maryland",
+             "MA" => "Massachusetts",
+             "MI" => "Michigan",
+             "MN" => "Minnesota",
+             "MS" => "Mississippi",
+             "MO" => "Missouri",
+             "MT" => "Montana",
+             "NE" => "Nebraska",
+             "NV" => "Nevada",
+             "NH" => "New Hampshire",
+             "NJ" => "New Jersey",
+             "NM" => "New Mexico",
+             "NY" => "New York",
+             "NC" => "North Carolina",
+             "ND" => "North Dakota",
+             "OH" => "Ohio",
+             "OK" => "Oklahoma",
+             "OR" => "Oregon",
+             "PA" => "Pennsylvania",
+             "RI" => "Rhode Island",
+             "SC" => "South Carolina",
+             "SD" => "South Dakota",
+             "TN" => "Tennessee",
+             "TX" => "Texas",
+             "UT" => "Utah",
+             "VT" => "Vermont",
+             "VA" => "Virginia",
+             "WA" => "Washington",
+             "WV" => "West Virginia",
+             "WI" => "Wisconsin",
+             "WY" => "Wyoming" }.freeze
+
+  def address_state
+    STATES[super] || super
+  end
+
+  def address
+    [address_city, address_state].join(", ")
+  end
+end

--- a/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
+++ b/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
@@ -3,19 +3,19 @@ Just a copy of the HasMany _show partial, here to test that
 things won't break if the app adds new types of association fields
 %>
 
-<% if field.resources.any? %>
+<% if field.data.any? %>
   <% order = field.order_from_params(params.fetch(field.name, {})) %>
   <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
-  <% resources = field.resources(page_number, order) %>
+  <% associated_collection = field.associated_collection(page_number, order)%>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection(resources, order),
+    collection_presenter: associated_collection,
     collection_field_name: field.name,
     collection_names: page.item_includes,
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate resources, param_name: "#{field.name}[page]" %>
+    <%= paginate associated_collection.resources, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
+++ b/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
@@ -10,7 +10,7 @@ things won't break if the app adds new types of association fields
     "collection",
     collection_presenter: field.associated_collection(order),
     collection_field_name: field.name,
-    page: page,
+    collection_names: page.item_includes,
     resources: field.resources(page_number, order),
     table_title: field.name,
   ) %>

--- a/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
+++ b/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
@@ -15,7 +15,7 @@ things won't break if the app adds new types of association fields
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate associated_collection.resources, param_name: "#{field.name}[page]" %>
+    <%= paginate associated_collection.resources_for_pagination, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
+++ b/spec/example_app/app/views/fields/has_many_variant/_show.html.erb
@@ -6,16 +6,16 @@ things won't break if the app adds new types of association fields
 <% if field.resources.any? %>
   <% order = field.order_from_params(params.fetch(field.name, {})) %>
   <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
+  <% resources = field.resources(page_number, order) %>
   <%= render(
     "collection",
-    collection_presenter: field.associated_collection(order),
+    collection_presenter: field.associated_collection(resources, order),
     collection_field_name: field.name,
     collection_names: page.item_includes,
-    resources: field.resources(page_number, order),
     table_title: field.name,
   ) %>
   <% if field.more_than_limit? %>
-    <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>
+    <%= paginate resources, param_name: "#{field.name}[page]" %>
   <% end %>
 
 <% else %>

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 feature "order index page" do
   scenario "user views order attributes" do
-    order = create(:order)
+    order = create(:order, address_state: "AL", address_city: "Montgomery")
 
     visit admin_orders_path
 
     expect(page).to have_header("Orders")
     expect(page).to have_content(order.id)
+    expect(page).to have_content("Montgomery, Alabama")
   end
 
   scenario "user clicks through to customer show page" do

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -2,13 +2,15 @@ require "rails_helper"
 
 feature "order show page" do
   scenario "displays line item information" do
-    line_item = create(:line_item)
+    order = create(:order, address_state: "AL", address_city: "Montgomery")
+    line_item = create(:line_item, order: order)
 
     visit admin_order_path(line_item.order)
 
     expect(page).to have_content(line_item.unit_price)
     expect(page).to have_content(line_item.quantity)
     expect(page).to have_content(line_item.total_price)
+    expect(page).to have_content("Montgomery, Alabama")
   end
 
   scenario "links to line items", :js do

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -19,13 +19,21 @@ describe Administrate::Field::HasMany do
   describe "#associated_collection" do
     it "returns an index page for the dashboard of the associated attribute" do
       begin
-        WidgetDashboard = Class.new
+        WidgetDashboard = Class.new do
+          def collection_attributes
+            %i[coolness shininess]
+          end
+        end
+
         widgets = []
         field = Administrate::Field::HasMany.new(:widgets, widgets, :show)
+        order = instance_double(Administrate::Order)
+        allow(order).to receive(:ordered_by?).with(:coolness).and_return(true)
 
-        page = field.associated_collection
+        page = field.associated_collection(order)
 
-        expect(page).to be_instance_of(Administrate::Page::Collection)
+        expect(page.attribute_names).to eq(%i[coolness shininess])
+        expect(page.ordered_by?(:coolness)).to eq true
       ensure
         remove_constants :WidgetDashboard
       end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -30,7 +30,7 @@ describe Administrate::Field::HasMany do
         order = instance_double(Administrate::Order)
         allow(order).to receive(:ordered_by?).with(:coolness).and_return(true)
 
-        page = field.associated_collection(order)
+        page = field.associated_collection(widgets, order)
 
         expect(page.attribute_names).to eq(%i[coolness shininess])
         expect(page.ordered_by?(:coolness)).to eq true
@@ -50,7 +50,7 @@ describe Administrate::Field::HasMany do
         association = Administrate::Field::HasMany.
           with_options(class_name: "Foo")
         field = association.new(:customers, [], :show)
-        collection = field.associated_collection
+        collection = field.associated_collection(double)
         attributes = collection.attribute_names
 
         expect(dashboard_double).to have_received(:collection_attributes)

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -19,4 +19,17 @@ describe Administrate::Page::Show do
       expect(page.attributes.first.resource.name).to eq("Worf")
     end
   end
+
+  describe "#resource" do
+    context "when dashboard of associated resource has decorator method" do
+      it "returns decorated resource" do
+        order = FactoryBot.create(:order,
+                                  address_city: "San Francisco",
+                                  address_state: "CA")
+        page = described_class.new(OrderDashboard.new, order)
+
+        expect(page.resource.address).to eq("San Francisco, California")
+      end
+    end
+  end
 end

--- a/spec/lib/pages/table_spec.rb
+++ b/spec/lib/pages/table_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe Administrate::Page::Collection do
+  describe "#resources" do
+    context "when dashboard of associated resource has decorator method" do
+      it "returns decorated resources" do
+        order = FactoryBot.create(:order,
+                                  address_city: "San Francisco",
+                                  address_state: "CA")
+        page = described_class.new(OrderDashboard.new, [order])
+
+        expect(page.resources.first.address).to eq("San Francisco, California")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently it's possible to modify how different types of field  are presented (with [attribute partials](https://administrate-prototype.herokuapp.com/customizing_attribute_partials)), and to modify the title used when displaying a resource (with [`display_resource`](https://administrate-prototype.herokuapp.com/customizing_dashboards)), BUT there's no straightforward way to modify how an individual field is displayed, beyond creating a [custom field type](https://administrate-prototype.herokuapp.com/adding_custom_field_types) for each field (which feels like a bit of a hack).

One use case for this is when a resource has a field which stores some kind of numeric code, and it's desirable to display a text description of the code instead of the code itself. 

This PR is an attempt to resurrect https://github.com/thoughtbot/administrate/pull/843 (big credit to @pustomytnyk). It started with a rebase of that PR, but has been heavily modified - in particular the refactorings required to move responsibility for resources into the `Collection` page have been separated out into their own commits.

The overall change is kind of complicated and touches a lot of files, but **please see the individual commit messages** for a description of the what's and why's of each step.

There are a number of bits of remaining awkwardness and awkward naming which I'd love to get some input on.

TODO: 

- [ ] Document internal API changes
- [ ] Check the first page of reverse dependencies for any breaking changes:
  - [ ] administrate-field-password
  - [ ] administrate-field-active_storage
  - [ ] administrate-field-enum
  - [ ] administrate-field-nested_has_many
  - [ ] administrate-field-belongs_to_search
  - [ ] administrate-field-image
  - [ ] administrate-field-carrierwave
  - [ ] administrate-field-paperclip
  - [ ] administrate-field-date_picker
  - [ ] administrate_exportable
  - [ ] administrate-field-ckeditor
  - [ ] administrate-field-jsonb
  - [ ] administrate-field-money
  - [ ] administrate-field-country
  - [ ] administrate-field-lat_lng
  - [ ] administrate-field-json
  - [ ] administrate-field-simple_markdown
  - [ ] administrate-field-boolean_to_yes_no
  - [ ] administrate-base_controller
  - [ ] administrate-field-select
  - [ ] administrate-field-boolean_emoji
  - [ ] administrate-field-lazy_belongs_to
  - [ ] administrate-field-jsontable
  - [ ] administrate-field-hidden
  - [ ] administrate-field-time
  - [ ] administrate-field-refile
  - [ ] administrate-field-froala
  - [ ] administrate-field-state_machine
  - [ ] administrate-field-collection_select
  - [ ] administrate-field-globalize-string
