### PR TITLE
EXPERIMENT - disable Appraisal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,7 @@ default_job: &default_job
   working_directory: ~/administrate
   steps:
     - shared_steps
-    # Run the tests against multiple versions of Rails
-    - run: bundle exec appraisal install
-    - run: bundle exec appraisal rake
+    - run: bundle exec rake
 
 jobs:
   ruby-25:

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem "sentry-raven"
 gem "unicorn"
 
 group :development, :test do
-  gem "appraisal"
   gem "awesome_print"
   gem "bundler-audit", require: false
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,10 +47,6 @@ GEM
       activesupport (>= 3.0)
       railties (>= 3.0)
       rspec-rails (>= 2.2)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.0)
     awesome_print (1.8.0)
     builder (3.2.4)
@@ -250,7 +246,6 @@ DEPENDENCIES
   administrate!
   administrate-field-image
   ammeter
-  appraisal
   awesome_print
   bundler-audit
   byebug


### PR DESCRIPTION
Related issue: https://github.com/thoughtbot/administrate/issues/1774

This is a quick-and-dirty experiment to see if Appraisal is the reason
that CI builds don't seem to be caching bundled gems.

The intention is not to remove Appraisal - just to get some information to debug the builds.
An attempt has been made to cache Appraisal's dependencies here: https://github.com/thoughtbot/administrate/pull/1549