### PR TITLE
Improve how documentation pages are rendered

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
----
-title: Contributing Guide
----
+# Contributing Guide
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
----
-title: Administrate
-home: true
----
+# Administrate
 
 [![CircleCI](https://img.shields.io/circleci/project/github/thoughtbot/administrate.svg)](https://circleci.com/gh/thoughtbot/administrate/tree/master)
 [![Gem Version](https://badge.fury.io/rb/administrate.svg)](https://badge.fury.io/rb/administrate)

--- a/spec/example_app/app/models/doc_page.rb
+++ b/spec/example_app/app/models/doc_page.rb
@@ -1,0 +1,71 @@
+class DocPage
+  class << self
+    def find(page)
+      full_path = Rails.root + "../../#{page}.md"
+
+      if File.exist?(full_path)
+        text = File.read(full_path)
+        new(text)
+      end
+    end
+  end
+
+  def initialize(text)
+    @text = text
+  end
+
+  def title
+    document.title
+  end
+
+  def body
+    document.body
+  end
+
+  private
+
+  attr_reader :text
+
+  def document
+    @document ||= DocumentParser.new(text)
+  end
+
+  class DocumentParser
+    def initialize(source_text)
+      parsed_document = FrontMatterParser::Parser.new(:md).call(source_text)
+      @source_text = parsed_document.content
+      @metadata = parsed_document.front_matter
+    end
+
+    def body
+      @body ||=
+        begin
+          renderer = Redcarpet::Render::HTML
+          markdown = Redcarpet::Markdown.new(renderer, redcarpet_config)
+
+          source_text_with_heading = <<~MARKDOWN
+            # #{title}
+
+            #{source_text}
+          MARKDOWN
+
+          markdown.render(source_text_with_heading)
+        end
+    end
+
+    def title
+      metadata["title"]
+    end
+
+    private
+
+    attr_reader :source_text, :metadata
+
+    def redcarpet_config
+      {
+        fenced_code_blocks: true,
+        autolink: true,
+      }
+    end
+  end
+end

--- a/spec/example_app/app/views/layouts/docs.html.erb
+++ b/spec/example_app/app/views/layouts/docs.html.erb
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title><%= @page_title %><%= @page_title_suffix %></title>
+  <title><%= @page_title %></title>
   <%= stylesheet_link_tag "docs", media: "all" %>
   <link href='//fonts.googleapis.com/css?family=Lato|Source+Code+Pro|Fjalla+One' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css">

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -7,6 +7,31 @@ describe "documentation navigation" do
     expect(page).to have_http_status(:not_found)
   end
 
+  it "shows the README" do
+    visit(root_path)
+
+    expect(page).to have_css("div.main h1", text: "Administrate")
+    expect(page).to have_content(
+      "A framework for creating flexible, powerful admin dashboards in Rails",
+    )
+  end
+
+  it "shows the Contributing Guides" do
+    visit("/contributing")
+
+    expect(page).to have_css("div.main h1", text: "Contributing Guide")
+    expect(page).to have_content(
+      "We welcome pull requests from everyone.",
+    )
+  end
+
+  it "shows other docs pages" do
+    visit("/getting_started")
+
+    expect(page).to have_css("div.main h1", text: "Getting Started")
+    expect(page).to have_content("Administrate is released as a Ruby gem")
+  end
+
   it "links to each documentation page" do
     visit root_path
     links = internal_documentation_links
@@ -19,7 +44,7 @@ describe "documentation navigation" do
     end
   end
 
-  it "links to the Github repo" do
+  it "links to the GitHub repo" do
     visit root_path
 
     expect(github_link[:href]).

--- a/spec/models/doc_page_spec.rb
+++ b/spec/models/doc_page_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe DocPage do
+  describe ".find" do
+    it "is nil if the page doesn't exist" do
+      page = DocPage.find("not_a_page")
+
+      expect(page).to be_nil
+    end
+
+    it "renders pages without metadata" do
+      page = DocPage.find("README")
+
+      expect(page).to have_attributes(
+        title: nil,
+        body: a_string_matching(
+          /A framework for creating flexible, powerful admin dashboards/,
+        ),
+      )
+    end
+
+    it "renders pages with metadata" do
+      page = DocPage.find("docs/getting_started")
+
+      expect(page).to have_attributes(
+        title: "Getting Started",
+        body: a_string_starting_with(
+          "<h1>Getting Started</h1>\n\n<p>Administrate is " \
+          "released as a Ruby gem",
+        ),
+      )
+    end
+  end
+end


### PR DESCRIPTION
Taking @EWright212's work from #1705, as I don't seem to be able to push to that branch.

---

* Extracts an object to encapsulate rendering a given page (which also
   allows us to explicitly test it),
* Allows us to render pages without the YAML frontmatter, which was
   making a mess of the README and Contributing Guide,