### PR TITLE
Adding an error message during 'administrate' initialize when there are no models in db.

### DIFF
--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -1,3 +1,9 @@
+if defined?(Zeitwerk)
+  Zeitwerk::Loader.eager_load_all
+else
+  Rails.application.eager_load!
+end
+
 require "rails/generators/base"
 require "administrate/generator_helpers"
 require "administrate/namespace"

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,15 +18,9 @@ module Administrate
 
       def model_check
         if database_models.none?
-          puts "ERROR: Add models before installing Administrate."
-        else
-          run_routes_generator
-          create_dashboard_controller
-          run_dashboard_generators
+          raise Error, "Add models before installing Administrate."
         end
       end
-
-      private
 
       def run_routes_generator
         if dashboard_resources.none?
@@ -48,6 +42,9 @@ module Administrate
             "--namespace", namespace
         end
       end
+ 
+      private
+
 
       def namespace
         options[:namespace]

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -62,7 +62,7 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants.reject(&:abstract_class?)
+        ActiveRecord::Base.descendants.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
       end
 
       def unnamed_constants

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,7 +18,7 @@ module Administrate
 
       def model_check
         if database_models.none?
-          say_status :conflict, :red
+          say_status(:conflict, :red, "Add models before installing Administrate.")
           raise Error, "Add models before installing Administrate."
         end
       end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -17,6 +17,7 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def model_check
+        puts database_models, database_models.none?
         if database_models.none?
           raise Error, "Add models before installing Administrate."
         end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -17,11 +17,8 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def model_check
-        puts database_models, database_models.none?
-        puts models_without_tables, "w/o"
-        puts unnamed_constants, "unnamed"
         if database_models.none?
-          raise Error, "Add models before installing Administrate."
+          raise IOError, "Add models before installing Administrate."
         end
       end
 
@@ -62,17 +59,9 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
+        all_models = ActiveRecord::Base.descendants
+        all_models.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
       end
-
-      def unnamed_constants
-        ActiveRecord::Base.descendants.reject { |d| d.name == d.to_s }
-      end
-
-      def models_without_tables
-        database_models.reject(&:table_exists?)
-      end
-
     end
   end
 end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,8 +18,8 @@ module Administrate
 
       def model_check
         puts database_models, database_models.none?
-        puts models_without_tables
-        puts unnamed_constants, "w/o table + unnamed"
+        puts models_without_tables, "w/o"
+        puts unnamed_constants, "unnamed"
         if database_models.none?
           raise Error, "Add models before installing Administrate."
         end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -17,13 +17,13 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def model_check
-        puts database_models, "used"
+        puts valid_database_models, "used"
         puts ActiveRecord::Base.descendants, "base"
         puts ActiveRecord::Base.descendants.reject(&:abstract_class?), "reject abstract"
 
-        if database_models.none?
-          # say_status(:conflict, :red, "Add models before installing Administrate.")
-          raise Error, "Add models before installing Administrate."
+        if valid_database_models.none?
+          puts "ERROR: Add models before installing Administrate."
+          puts "Consider removing 'app/controllers/administrate'."
         end
       end
 
@@ -62,15 +62,11 @@ module Administrate
         Administrate::Namespace.new(namespace).resources
       end
 
-      def database_models
+      def valid_database_models
         all_models = ActiveRecord::Base.descendants
         all_models.reject(&:abstract_class?).reject(&:table_exists?)
         # .reject { |d| d.name == d.to_s }
       end
-
-      # def say_status(status, color, message) # :doc:
-      #   base.shell.say_status(status, message, color)
-      # end
     end
   end
 end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -17,7 +17,10 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def model_check
-        puts database_models
+        puts database_models, "used"
+        puts ActiveRecord::Base.descendants, "base".reject(&:abstract_class?)
+        puts ActiveRecord::Base.descendants.reject(&:abstract_class?), "reject abstract"
+
         if database_models.none?
           # say_status(:conflict, :red, "Add models before installing Administrate.")
           raise Error, "Add models before installing Administrate."

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -10,6 +10,12 @@ module Administrate
 
       class_option :namespace, type: :string, default: "admin"
 
+      def model_check
+        if database_models.none?
+          puts "WARNING: database needs models for administrate"
+        end
+      end
+
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes", "--namespace", namespace)
@@ -43,6 +49,10 @@ module Administrate
 
       def dashboard_resources
         Administrate::Namespace.new(namespace).resources
+      end
+
+      def database_models
+        ActiveRecord::Base.descendants.reject(&:abstract_class?)
       end
     end
   end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -23,7 +23,7 @@ module Administrate
 
         if valid_database_models.none?
           puts "ERROR: Add models before installing Administrate."
-          puts "Consider removing 'app/controllers/administrate'."
+          puts "Consider removing 'app/controllers/admin'."
         end
       end
 
@@ -64,8 +64,7 @@ module Administrate
 
       def valid_database_models
         all_models = ActiveRecord::Base.descendants
-        all_models.reject(&:abstract_class?).reject(&:table_exists?)
-        # .reject { |d| d.name == d.to_s }
+        all_models.reject(&:abstract_class?).reject(&:table_exists?).reject { |d| d.name == d.to_s }
       end
     end
   end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -13,8 +13,9 @@ module Administrate
       def model_check
         if database_models.none?
           puts "ERROR: Add models before installing Administrate."
+          exit
         end
-        exit
+        
       end
 
       def run_routes_generator

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,7 +18,8 @@ module Administrate
 
       def model_check
         if database_models.none?
-          raise IOError, "Add models before installing Administrate."
+          say_status :conflict, :red
+          raise Error, "Add models before installing Administrate."
         end
       end
 
@@ -61,6 +62,10 @@ module Administrate
       def database_models
         all_models = ActiveRecord::Base.descendants
         all_models.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
+      end
+
+      def say_status(status, color, message = relative_destination) # :doc:
+        base.shell.say_status(status, message, color) if config[:verbose]
       end
     end
   end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,7 +18,7 @@ module Administrate
 
       def model_check
         puts database_models, "used"
-        puts ActiveRecord::Base.descendants, "base".reject(&:abstract_class?)
+        puts ActiveRecord::Base.descendants, "base"
         puts ActiveRecord::Base.descendants.reject(&:abstract_class?), "reject abstract"
 
         if database_models.none?
@@ -65,12 +65,12 @@ module Administrate
       def database_models
         all_models = ActiveRecord::Base.descendants
         all_models.reject(&:abstract_class?).reject(&:table_exists?)
-        #.reject { |d| d.name == d.to_s }
+        # .reject { |d| d.name == d.to_s }
       end
 
-      def say_status(status, color, message) # :doc:
-        base.shell.say_status(status, message, color)
-      end
+      # def say_status(status, color, message) # :doc:
+      #   base.shell.say_status(status, message, color)
+      # end
     end
   end
 end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -12,8 +12,9 @@ module Administrate
 
       def model_check
         if database_models.none?
-          puts "ERROR: Unable to generate a dashboard without models."
+          puts "ERROR: Add models before installing Administrate."
         end
+        exit
       end
 
       def run_routes_generator

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -17,8 +17,9 @@ module Administrate
       class_option :namespace, type: :string, default: "admin"
 
       def model_check
+        puts database_models
         if database_models.none?
-          say_status(:conflict, :red, "Add models before installing Administrate.")
+          # say_status(:conflict, :red, "Add models before installing Administrate.")
           raise Error, "Add models before installing Administrate."
         end
       end
@@ -60,7 +61,8 @@ module Administrate
 
       def database_models
         all_models = ActiveRecord::Base.descendants
-        all_models.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
+        all_models.reject(&:abstract_class?).reject(&:table_exists?)
+        #.reject { |d| d.name == d.to_s }
       end
 
       def say_status(status, color, message) # :doc:

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -13,11 +13,15 @@ module Administrate
       def model_check
         if database_models.none?
           puts "ERROR: Add models before installing Administrate."
-          exit
+        else
+          run_routes_generator
+          create_dashboard_controller
+          run_dashboard_generators
         end
-        
       end
 
+      private
+      
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes", "--namespace", namespace)
@@ -38,8 +42,6 @@ module Administrate
             "--namespace", namespace
         end
       end
-
-      private
 
       def namespace
         options[:namespace]

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -21,7 +21,7 @@ module Administrate
       end
 
       private
-      
+
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes", "--namespace", namespace)

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,6 +18,8 @@ module Administrate
 
       def model_check
         puts database_models, database_models.none?
+        puts models_without_tables
+        puts unnamed_constants, "w/o table + unnamed"
         if database_models.none?
           raise Error, "Add models before installing Administrate."
         end
@@ -62,6 +64,15 @@ module Administrate
       def database_models
         ActiveRecord::Base.descendants.reject(&:abstract_class?)
       end
+
+      def unnamed_constants
+        ActiveRecord::Base.descendants.reject { |d| d.name == d.to_s }
+      end
+
+      def models_without_tables
+        database_models.reject(&:table_exists?)
+      end
+
     end
   end
 end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -12,7 +12,7 @@ module Administrate
 
       def model_check
         if database_models.none?
-          puts "WARNING: database needs models for administrate"
+          puts "ERROR: Unable to generate a dashboard without models."
         end
       end
 

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -39,8 +39,7 @@ module Administrate
 
       def model_check
         if valid_dashboard_models.none?
-          puts "** ERROR: Add models before installing Administrate. **"
-          puts "**        Consider removing 'app/controllers/admin'. **"
+          puts "WARNING: Add models before installing Administrate."
         end
       end
  

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -42,7 +42,7 @@ module Administrate
           puts "WARNING: Add models before installing Administrate."
         end
       end
- 
+
       private
 
       def namespace

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -46,7 +46,6 @@ module Administrate
  
       private
 
-
       def namespace
         options[:namespace]
       end
@@ -64,8 +63,8 @@ module Administrate
         all_models.reject(&:abstract_class?).reject { |d| d.name == d.to_s }
       end
 
-      def say_status(status, color, message = relative_destination) # :doc:
-        base.shell.say_status(status, message, color) if config[:verbose]
+      def say_status(status, color, message) # :doc:
+        base.shell.say_status(status, message, color)
       end
     end
   end


### PR DESCRIPTION
This PR fixes the behaviour observed, during the administrate install on rails apps without models, where the admin route isn't created, resulting in an application error and no warning to the user. 

The change displays a friendly error message, when this happens.