### PR TITLE
Prevent dangerous query method on #order_by_id

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -62,7 +62,7 @@ module Administrate
       relation.
         left_joins(attribute.to_sym).
         group(:id).
-        reorder("COUNT(#{attribute}.id) #{direction}")
+        reorder(Arel.sql("COUNT(#{attribute}.id) #{direction}"))
     end
 
     def order_by_id(relation)

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -68,6 +68,20 @@ describe "customer index page" do
       expect(page).to have_table_header(custom_label)
     end
   end
+
+  it "sorts by count on a has_many association" do
+    create_list(:order, 2, customer: create(:customer, name: "Ade"))
+    create_list(:order, 3, customer: create(:customer, name: "Ben"))
+    create_list(:order, 1, customer: create(:customer, name: "Cam"))
+
+    visit admin_customers_path
+
+    click_on "Orders"
+    expect(page).to have_content(/Cam.*1 order.*Ade.*2 orders.*Ben.*3 orders/)
+
+    click_on "Orders"
+    expect(page).to have_content(/Ben.*3 orders.*Ade.*2 orders.*Cam.*1 order/)
+  end
 end
 
 describe "search input" do


### PR DESCRIPTION
#### What does this PR do?

- Adds `Arel.sql()` to `#order_by_id` in `/lib/order.rb` to prevent deprecation warning for dangerous query method.
- Adds test for sorting by `has_many` association 

#### Where should the reviewer start?

`/lib/order.rb`

#### How should this be manually tested?

- Temporarily remove `Arel.sql()` from `#order_by_id` 
- Run `bundle exec appraisal rails52 rspec spec/features/index_page_spec.rb` 

#### What are the relevant tickets?

#1758 

#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO