### PR TITLE
Pass page local when rendering fields

### DIFF
--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -32,7 +32,7 @@ All show page attributes of has_one relationship would be rendered
         ) %>
       </dt>
       <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
-        <%= render_field attribute %>
+        <%= render_field attribute, { page: page } %>
       </dd>
       </div>
     <% end -%>


### PR DESCRIPTION
Hi there!

We live dangerously and run on edge for administrate, and seems like a recent change (#1259) has caused `HasOne`'s to not render in our app with a `undefined local variable or method 'page'`

The proposed change in the PR seems to resolve the error.

Let me know if I need to change anything, or if this is too naive of a solution.

Thanks!