### PR TITLE
Upgrade bundler to 2.1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
       - checkout
 
       # Install bundler
-      - run: gem install bundler:1.17.3
+      - run: gem install bundler:2.1.4
 
       # Restore Cached Dependencies
       - restore_cache:
@@ -53,6 +53,7 @@ jobs:
           PGHOST: localhost
           PGUSER: administrate
           RAILS_ENV: test
+          BUNDLER_VERSION: 2.1.4
       - image: postgres:10.1-alpine
         environment:
           POSTGRES_USER: administrate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,4 +340,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This is a bit overdue, but is needed for Ruby 2.7 onwards.