### PR TITLE
Don't show unpersisted `has_one` associations

### DIFF
--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -15,7 +15,7 @@ By default, the relationship is rendered as a link to the associated object.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
 %>
 
-<% if field.data %>
+<% if field.linkable? %>
   <%= link_to(
     field.display_associated_resource,
     [namespace, field.data],

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -15,7 +15,7 @@ All show page attributes of has_one relationship would be rendered
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasOne
 %>
 
-<% if field.data %>
+<% if field.linkable? %>
   <fieldset class="attribute--nested">
     <legend>
       <%= link_to(

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -31,6 +31,10 @@ module Administrate
         )
       end
 
+      def linkable?
+        data.try(:persisted?)
+      end
+
       private
 
       def resolver

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 describe "fields/has_one/_index", type: :view do
   context "without an associated record" do
     it "displays nothing" do
-      has_one = double(data: nil)
+      has_one = Administrate::Field::HasOne.new(
+        :product_meta_tag,
+        build(:product_meta_tag),
+        :index,
+      )
 
       render(
         partial: "fields/has_one/index.html.erb",
@@ -21,6 +25,7 @@ describe "fields/has_one/_index", type: :view do
       has_one = instance_double(
         "Administrate::Field::HasOne",
         data: product,
+        linkable?: true,
         display_associated_resource: product.name,
       )
 

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -4,10 +4,10 @@ require "administrate/field/has_one"
 describe "fields/has_one/_show", type: :view do
   context "without an associated record" do
     it "displays nothing" do
-      has_one = instance_double(
-        "Administrate::Field::HasOne",
-        display_associated_resource: "",
-        data: nil,
+      has_one = Administrate::Field::HasOne.new(
+        :product_meta_tag,
+        build(:product_meta_tag),
+        :show,
       )
 
       render(
@@ -27,6 +27,7 @@ describe "fields/has_one/_show", type: :view do
         "Administrate::Field::HasOne",
         display_associated_resource: product.name,
         data: product,
+        linkable?: true,
         nested_show: nested_show,
       )
 

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -63,4 +63,45 @@ describe Administrate::Field::HasOne do
       expect(path).to eq("/fields/has_one/#{page}")
     end
   end
+
+  describe "#linkable?" do
+    context "when data is persisted" do
+      it "shows it" do
+        product_meta_tag = create(:product_meta_tag)
+        field = described_class.new(
+          :product_meta_tag,
+          product_meta_tag,
+          :show,
+        )
+
+        expect(field).to be_linkable
+      end
+    end
+
+    context "when data isn't persisted" do
+      it "doesn't shows it" do
+        product_meta_tag = build(:product_meta_tag)
+        field = described_class.new(
+          :product_meta_tag,
+          product_meta_tag,
+          :show,
+        )
+
+        expect(field).to_not be_linkable
+      end
+    end
+
+    context "when data doesn't respond to `persisted?`" do
+      it "doesn't show it" do
+        product_meta_tag = double(:product_meta_tag)
+        field = described_class.new(
+          :product_meta_tag,
+          product_meta_tag,
+          :show,
+        )
+
+        expect(field.linkable?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -100,7 +100,7 @@ describe Administrate::Field::HasOne do
           :show,
         )
 
-        expect(field.linkable?).to be_falsey
+        expect(field).not_to be_linkable
       end
     end
   end


### PR DESCRIPTION
Showing unpersisted `has_one` associations can be misleading and break the application is some cases.

Let's consider the following example:

```
class Product < ApplicationRecord
  has_one :product_meta_tag

  def product_meta_tag
    super || build_product_meta_tag
  end
end
```

That opens for a scenario where a `product.product_meta_tag` will return a non-persisted instance of a ProductMetaTag. In the `_show` partial we're just checking if `field.data` (i.e., ProductMetaTag instance) exists to display it, and a non-persisted instance would be displayed. The link displayed in the partial (`link_to( field.display_associated_resource, [namespace, field.data]`) would be pointing to the index page of product meta tags, what is not desired. Also, in the absence of an index route, the page would break.

The solution: just check if data is persisted to display it or not.