### PR TITLE
Add delimiter option for number fields

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -158,6 +158,13 @@ more results than expected. Default is `false`.
 
 `:suffix` - Suffixes the number with a string. Defaults to `""`.
 
+`:format` - Specify a hash which defines a formatter. This uses ActiveSupport
+and works by  by passing a hash that includes the formatter (`formatter`) and
+the options for the formatter (`formatter_options`). Defaults to the locale's
+delimiter when `formatter_options` does not include a `delimiter`. See the
+example below. Note that currently only
+`ActiveSupport::NumberHelper.number_to_delimited` is supported.
+
 For example, you might use the following to display U.S. currency:
 
 ```ruby
@@ -165,15 +172,25 @@ For example, you might use the following to display U.S. currency:
     prefix: "$",
     decimals: 2,
   )
+
+  # "$5.99"
 ```
 
-Or, to display a distance in kilometers:
+Or, to display a distance in kilometers, using a space as the delimiter:
 
 ```ruby
-  unit_price: Field::Number.with_options(
+  distance: Field::Number.with_options(
     suffix: " km",
     decimals: 2,
+    format: { 
+        formatter: :number_to_delimited,
+        formatter_options: { 
+            delimiter: ' ',
+        },
+    },
   )
+
+  # "2 000.00 km"
 ```
 
 **Field::Polymorphic**

--- a/lib/administrate/field/number.rb
+++ b/lib/administrate/field/number.rb
@@ -1,16 +1,19 @@
 require_relative "base"
+require "active_support/number_helper"
 
 module Administrate
   module Field
     class Number < Field::Base
       def to_s
-        data.nil? ? "-" : format_string % value
+        result = data.nil? ? "-" : format_string % value
+        result = format(result) if options[:format]
+        prefix + result + suffix
       end
 
       private
 
       def format_string
-        prefix + "%.#{decimals}f" + suffix
+        "%.#{decimals}f"
       end
 
       def prefix
@@ -29,6 +32,20 @@ module Administrate
 
       def value
         data * options.fetch(:multiplier, 1)
+      end
+
+      def format(result)
+        formatter = options[:format][:formatter]
+        formatter_options = options[:format][:formatter_options].to_h
+
+        case formatter
+        when :number_to_delimited
+          ActiveSupport::NumberHelper.number_to_delimited(
+            result, **formatter_options
+          )
+        else
+          result
+        end
       end
     end
   end

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -83,6 +83,65 @@ describe Administrate::Field::Number do
       end
     end
 
+    context "with `format` option" do
+      context "when `formatter: :number_to_delimited`" do
+        it "includes the delimiter for numbers greater than 999" do
+          ninety_nine = number_with_options(
+            999, format: { formatter: :number_to_delimited }
+          )
+          thousand_default = number_with_options(
+            1_000, format: { formatter: :number_to_delimited }
+          )
+          thousand_explicit_comma = number_with_options(
+            1_000, format: {
+              formatter: :number_to_delimited,
+              formatter_options: { delimiter: "," },
+            }
+          )
+          million_explicit_space = number_with_options(
+            1_000_000, format: {
+              formatter: :number_to_delimited,
+              formatter_options: { delimiter: " " },
+            }
+          )
+
+          expect(ninety_nine.to_s).to eq("999")
+          expect(thousand_default.to_s).to eq("1,000")
+          expect(thousand_explicit_comma.to_s).to eq("1,000")
+          expect(million_explicit_space.to_s).to eq("1 000 000")
+        end
+      end
+
+      context "when passed incorrect `formatter`" do
+        it "works" do
+          thousand = number_with_options(1_000, format: { formatter: :rubbish })
+
+          expect(thousand.to_s).to eq("1000")
+        end
+      end
+    end
+
+    context "with multiple options" do
+      it "correctly displays the number with all options applied" do
+        options = {
+          prefix: "$",
+          suffix: "/hour",
+          multiplier: 10,
+          decimals: 2,
+          format: {
+            formatter: :number_to_delimited,
+            formatter_options: {
+              delimiter: " ",
+              separator: ",",
+            },
+          },
+        }
+        number = number_with_options(100, **options)
+
+        expect(number.to_s).to eq("$1 000,00/hour")
+      end
+    end
+
     context "when data is nil" do
       it "returns a dash" do
         number = Administrate::Field::Number.new(:number, nil, :page)


### PR DESCRIPTION
Great gem, everyone! We're using it in a project currently and are finding it very helpful.

I realized there doesn't seem to be a delimiter option for number fields to, for example, display a number like `1000000` in the more legible format of `1,000,000`, so I whipped up this PR to add it in. Please let me know if there's anything else I can or should add. 🙇 