### PR TITLE
Use correct values when sorting by has_many associations

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -59,10 +59,12 @@ module Administrate
     end
 
     def order_by_count(relation)
+      klass = reflect_association(relation).klass
+      query = "COUNT(#{klass.table_name}.#{klass.primary_key}) #{direction}"
       relation.
         left_joins(attribute.to_sym).
         group(:id).
-        reorder(Arel.sql("COUNT(#{attribute}.id) #{direction}"))
+        reorder(Arel.sql(query))
     end
 
     def order_by_id(relation)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -67,7 +67,10 @@ describe Administrate::Order do
     context "when relation has_many association" do
       it "orders the column by count" do
         order = Administrate::Order.new(:name)
-        relation = relation_with_association(:has_many)
+        relation = relation_with_association(
+          :has_many,
+          klass: double(table_name: "users", primary_key: "uid"),
+        )
         allow(relation).to receive(:reorder).and_return(relation)
         allow(relation).to receive(:left_joins).and_return(relation)
         allow(relation).to receive(:group).and_return(relation)
@@ -76,7 +79,7 @@ describe Administrate::Order do
 
         expect(relation).to have_received(:left_joins).with(:name)
         expect(relation).to have_received(:group).with(:id)
-        expect(relation).to have_received(:reorder).with("COUNT(name.id) asc")
+        expect(relation).to have_received(:reorder).with("COUNT(users.uid) asc")
         expect(ordered).to eq(relation)
       end
     end
@@ -190,13 +193,18 @@ describe Administrate::Order do
     )
   end
 
-  def relation_with_association(association, foreign_key: "#{association}_id")
+  def relation_with_association(
+    association,
+    foreign_key: "#{association}_id",
+    klass: nil
+  )
     double(
       klass: double(
         reflect_on_association: double(
           "#{association}_reflection",
           macro: association,
           foreign_key: foreign_key,
+          klass: klass,
         ),
       ),
     )


### PR DESCRIPTION
When sorting by has_many associations, Administrate assumes that the table and column names are `#{attribute}.id`.
An error will occur if the user defines a different association than the table name or uses a primary key other than :id.

For example, the following code causes an error.

```ruby
# db/migrate/20201016000000_create_users.rb
create_table :users, primary_key: "uid" do |t|
  t.references :company

  t.timestamps
end

# app/models/company.rb
class Company < ApplicationRecord
  has_many :employee, class_name: "User"
end

Administrate::Order.new("employee", "asc").apply(Company.all).take
#  Company Load (0.5ms)  SELECT "companies".* FROM "companies" LEFT OUTER JOIN "users" ON "users"."company_id" = "companies"."id" GROUP BY "companies"."id" ORDER BY COUNT(employee.id) asc LIMIT ?  [["LIMIT", 1]]
# Traceback (most recent call last):
#        1: from (irb):1
# ActiveRecord::StatementInvalid (SQLite3::SQLException: no such column: employee.id)
```

This commit fixes `Administrate::Order` to use the correct table and column names.