### PR TITLE
Order by belongs_to field

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -102,7 +102,9 @@ module Administrate
 
     def order
       @order ||= Administrate::Order.new(
-        sorting_attribute, sorting_direction, belongs_to_sorting_attribute
+        sorting_attribute,
+        sorting_direction,
+        association_attribute: belongs_to_sorting_attribute,
       )
     end
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -101,11 +101,17 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
+      @order ||= Administrate::Order.new(
+        sorting_attribute, sorting_direction, belongs_to_sorting_attribute
+      )
     end
 
     def sorting_attribute
       sorting_params.fetch(:order) { default_sorting_attribute }
+    end
+
+    def belongs_to_sorting_attribute
+      nil
     end
 
     def default_sorting_attribute

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -70,3 +70,16 @@ def default_sorting_direction
   :desc
 end
 ```
+
+## Customizing belongs_to Sorting Field
+
+To set which field to use when sorting by a `belongs_to` association, you could override
+`belongs_to_sorting_field` in your dashboard controller like this:
+
+```ruby
+def belongs_to_sorting_field
+  :name
+end
+```
+
+If the field doesn't exist, the collection will be sorted by the associations `id`.

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,6 +1,10 @@
 module Administrate
   class Order
-    def initialize(attribute = nil, direction = nil, association_attribute = nil)
+    def initialize(
+      attribute = nil,
+      direction = nil,
+      association_attribute = nil
+    )
       @attribute = attribute
       @direction = sanitize_direction(direction)
       @association_attribute = association_attribute

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -3,7 +3,7 @@ module Administrate
     def initialize(
       attribute = nil,
       direction = nil,
-      association_attribute = nil
+      association_attribute: nil
     )
       @attribute = attribute
       @direction = sanitize_direction(direction)
@@ -77,9 +77,11 @@ module Administrate
     end
 
     def order_by_association_attribute(relation)
+      table_name = plural_name(relation)
+
       relation.
         includes(attribute.to_sym).
-        reorder("#{attribute.pluralize}.#{association_attribute} #{direction}")
+        reorder("#{table_name}.#{association_attribute} #{direction}")
     end
 
     def order_by_attribute(relation)
@@ -107,6 +109,10 @@ module Administrate
 
     def foreign_key(relation)
       reflect_association(relation).foreign_key
+    end
+
+    def plural_name(relation)
+      reflect_association(relation).plural_name
     end
   end
 end

--- a/spec/example_app/app/controllers/admin/orders_controller.rb
+++ b/spec/example_app/app/controllers/admin/orders_controller.rb
@@ -1,4 +1,7 @@
 module Admin
   class OrdersController < Admin::ApplicationController
+    def belongs_to_sorting_attribute
+      :name
+    end
   end
 end

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -68,4 +68,18 @@ feature "order index page" do
       "Cannot delete record because dependent payments exist", type: :error
     )
   end
+
+  scenario "user sorts by belongs_to field" do
+    create(:order, customer: create(:customer, name: "Alpha"))
+    create(:order, customer: create(:customer, name: "Charlie"))
+    create(:order, customer: create(:customer, name: "Bravo"))
+
+    visit admin_orders_path
+
+    click_on "Customer"
+    expect(page).to have_content(/Alpha.*Bravo.*Charlie/)
+
+    click_on "Customer"
+    expect(page).to have_content(/Charlie.*Bravo.*Alpha/)
+  end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -100,11 +100,16 @@ describe Administrate::Order do
       end
 
       it "orders_by_association_attribute" do
-        order = Administrate::Order.new("product", :asc, :name)
+        order = Administrate::Order.new(
+          "product",
+          :asc,
+          association_attribute: :name,
+        )
         relation = relation_with_association(
           :belongs_to,
           true,
           foreign_key: "some_foreign_key",
+          plural_name: "products",
         )
         allow(relation).to receive(:includes).and_return(relation)
         allow(relation).to receive(:reorder).and_return(relation)
@@ -212,7 +217,8 @@ describe Administrate::Order do
   def relation_with_association(
     association,
     has_attribute = false,
-    foreign_key: "#{association}_id"
+    foreign_key: "#{association}_id",
+    plural_name: "names"
   )
     double(
       klass: double(
@@ -221,6 +227,7 @@ describe Administrate::Order do
           macro: association,
           foreign_key: foreign_key,
           klass: double(has_attribute?: has_attribute),
+          plural_name: plural_name,
         ),
       ),
     )

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -100,7 +100,7 @@ describe Administrate::Order do
       end
 
       it "orders_by_association_attribute" do
-        order = Administrate::Order.new('product', :asc, :name)
+        order = Administrate::Order.new("product", :asc, :name)
         relation = relation_with_association(
           :belongs_to,
           true,
@@ -220,7 +220,7 @@ describe Administrate::Order do
           "#{association}_reflection",
           macro: association,
           foreign_key: foreign_key,
-          klass: double(has_attribute?: has_attribute)
+          klass: double(has_attribute?: has_attribute),
         ),
       ),
     )

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -98,6 +98,22 @@ describe Administrate::Order do
         expect(relation).to have_received(:reorder).with("some_foreign_key asc")
         expect(ordered).to eq(relation)
       end
+
+      it "orders_by_association_attribute" do
+        order = Administrate::Order.new('product', :asc, :name)
+        relation = relation_with_association(
+          :belongs_to,
+          true,
+          foreign_key: "some_foreign_key",
+        )
+        allow(relation).to receive(:includes).and_return(relation)
+        allow(relation).to receive(:reorder).and_return(relation)
+
+        ordered = order.apply(relation)
+
+        expect(relation).to have_received(:reorder).with("products.name asc")
+        expect(ordered).to eq(relation)
+      end
     end
   end
 
@@ -195,8 +211,8 @@ describe Administrate::Order do
 
   def relation_with_association(
     association,
-    foreign_key: "#{association}_id",
-    klass: nil
+    has_attribute = false,
+    foreign_key: "#{association}_id"
   )
     double(
       klass: double(
@@ -204,7 +220,7 @@ describe Administrate::Order do
           "#{association}_reflection",
           macro: association,
           foreign_key: foreign_key,
-          klass: klass,
+          klass: double(has_attribute?: has_attribute)
         ),
       ),
     )

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -90,6 +90,7 @@ describe Administrate::Order do
         relation = relation_with_association(
           :belongs_to,
           foreign_key: "some_foreign_key",
+          klass: double(has_attribute?: false),
         )
         allow(relation).to receive(:reorder).and_return(relation)
 
@@ -107,7 +108,7 @@ describe Administrate::Order do
         )
         relation = relation_with_association(
           :belongs_to,
-          true,
+          klass: double(has_attribute?: true),
           foreign_key: "some_foreign_key",
           plural_name: "products",
         )
@@ -216,9 +217,9 @@ describe Administrate::Order do
 
   def relation_with_association(
     association,
-    has_attribute = false,
     foreign_key: "#{association}_id",
-    plural_name: "names"
+    klass: nil,
+    plural_name: nil
   )
     double(
       klass: double(
@@ -226,7 +227,7 @@ describe Administrate::Order do
           "#{association}_reflection",
           macro: association,
           foreign_key: foreign_key,
-          klass: double(has_attribute?: has_attribute),
+          klass: klass,
           plural_name: plural_name,
         ),
       ),


### PR DESCRIPTION
#### What does this PR do?

- Updates `Order` to be able to sort by `belongs_to` field
  - Updates `initialize` to take in `association_attribute`
  - Adds `order_by_association_attribute`
  - Adds `order_by_attribute`
  - Updates `order_by_association` to use `order_by_attribute` for `belongs_to` associations
  - Adds `association_has_attribute?`
- Adds `belongs_to_sorting_field` to `ApplicationController` to be overridden by users to select which field to sort by
- Adds `belongs_to_sorting_attribute` to `OrdersController` for testing
- Updates/adds tests to specs 
- Adds `Customizing belongs_to Sorting Field` section in `/docs/customizing_controller_actions.md`
  
#### How should this be manually tested?

- Start local server
- Visit `/admin/orders`
- Click on 'Customer'

#### Any background context you want to provide?

My team currently uses `administrate` in our application and we noticed when trying to sort by a `belongs_to` association, by default it sorts by the association's `id`. We found a workaround by sub-classing `Administrate::Order` in our `controller` to be able to sort by an association's field. Our implementation was very specific to our data model but I thought this feature could be useful for future or current devs so I decided to create a more dynamic version. 

#### Screenshots (if appropriate)

**Before:**
```ruby
class OrdersController < Admin::ApplicationController
end
```
![before-admin-sorting](https://user-images.githubusercontent.com/44950896/96774554-63ce6600-13a3-11eb-9812-665a0d335e6b.gif)

**After:**
```ruby
class OrdersController < Admin::ApplicationController
  def belongs_to_sorting_attribute
    :name
  end
end
```
![after-admin-sorting](https://user-images.githubusercontent.com/44950896/96774584-6cbf3780-13a3-11eb-84b9-7a86d4625ee9.gif)


#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO
