### PR TITLE
Provide a single, unified source of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,56 +46,6 @@ To accomplish these goals, Administrate follows a few guiding principles:
 [Rails Admin]: https://github.com/sferik/rails_admin
 [ActiveAdmin]: http://activeadmin.info/
 
-## Getting Started
-
-Administrate supports Rails 5.0 onwards. We support Ruby 2.4 and up.
-
-Add Administrate to your Gemfile and re-bundle:
-
-```ruby
-gem "administrate"
-```
-
-The included installer will create dashboards for each model in your
-app, complete with routes:
-
-```bash
-$ rails generate administrate:install
-```
-
-Restart your server, and visit http://localhost:3000/admin
-to see your new dashboard in action.
-
-For more detailed instructions or to make it work with Rails API-only
-applications, please go through the ['Getting Started' guide][].
-
-If your apps uses Sprockets 4, you'll need to add Administrate's assets to your `manifest.js` file. To do this, add these two lines to the file:
-
-```
-//= link administrate/application.css
-//= link administrate/application.js
-```
-
-Otherwise, your app will show you this error:
-
-```
-Asset `administrate/application.css` was not declared to be precompiled in production.
-Declare links to your assets in `app/assets/config/manifest.js`.
-```
-
-For more information on why this is necessary, see https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
-
-['Getting Started' guide]: https://administrate-demo.herokuapp.com/getting_started
-
-## Create Additional Dashboards
-
-In order to create additional dashboards, pass in the resource name to
-the dashboard generator. A dashboard and controller will be created.
-
-```bash
-$ rails generate administrate:dashboard Foo
-```
-
 ## Documentation
 
 To customize the appearance, behavior, and contents of the dashboard,
@@ -114,7 +64,7 @@ app][prerelease_docs].
 
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md).
 
-administrate was originally written by Grace Youngblood and is now maintained by
+Administrate was originally written by Grace Youngblood and is now maintained by
 Nick Charlton. Many improvements and bugfixes were contributed by the [open
 source
 community](https://github.com/thoughtbot/administrate/graphs/contributors).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -72,7 +72,9 @@ Asset `administrate/application.css` was not declared to be precompiled in produ
 Declare links to your assets in `app/assets/config/manifest.js`.
 ```
 
-For more information on why this is necessary, see https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
+For more information on why this is necessary, see [Richard Schneeman's article Self Hosted Config: Introducing the Sprockets manifest.js][sprockets_manifest]
+
+[sprockets_manifest]: https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
 
 ## Create Additional Dashboards
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,16 +3,16 @@ title: Getting Started
 ---
 
 Administrate is released as a Ruby gem, and can be installed on Rails
-applications version 4.2 or greater.
+applications version 5.0 or greater. We support Ruby 2.4 and up.
 
-Add the following to your Gemfile:
+First, add the following to your Gemfile:
 
 ```ruby
 # Gemfile
 gem "administrate"
 ```
 
-Re-bundle, then run the installer:
+Re-bundle with `bundle install`, then run the installer:
 
 ```bash
 $ rails generate administrate:install
@@ -56,6 +56,24 @@ Each `Admin::FooController` can be overwritten to specify custom behavior.
 Once you have Administrate installed,
 visit <http://localhost:3000/admin> to see your new dashboard in action.
 
+### Errors about assets?
+
+If your apps uses Sprockets 4, you'll need to add Administrate's assets to your `manifest.js` file. To do this, add these two lines to the file:
+
+```
+//= link administrate/application.css
+//= link administrate/application.js
+```
+
+Otherwise, your app will show you this error:
+
+```
+Asset `administrate/application.css` was not declared to be precompiled in production.
+Declare links to your assets in `app/assets/config/manifest.js`.
+```
+
+For more information on why this is necessary, see https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
+
 ## Create Additional Dashboards
 
 In order to create additional dashboards, pass in the resource name to
@@ -65,7 +83,7 @@ the dashboard generator. A dashboard and controller will be created.
 $ rails generate administrate:dashboard Foo
 ```
 
-Add a route for the new dashboard.
+Then add a route for the new dashboard.
 
 ```ruby
 # config/routes.rb

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,7 +58,8 @@ visit <http://localhost:3000/admin> to see your new dashboard in action.
 
 ### Errors about assets?
 
-If your apps uses Sprockets 4, you'll need to add Administrate's assets to your `manifest.js` file. To do this, add these two lines to the file:
+If your apps uses Sprockets 4, you'll need to add Administrate's assets to
+your `manifest.js` file. To do this, add these two lines to the file:
 
 ```
 //= link administrate/application.css

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -73,9 +73,8 @@ Asset `administrate/application.css` was not declared to be precompiled in produ
 Declare links to your assets in `app/assets/config/manifest.js`.
 ```
 
-For more information on why this is necessary, see [Richard Schneeman's article Self Hosted Config: Introducing the Sprockets manifest.js][sprockets_manifest]
-
-[sprockets_manifest]: https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs
+For more information on why this is necessary, see Richard Schneeman's article
+["Self Hosted Config: Introducing the Sprockets manifest.js"][https://www.schneems.com/2017/11/22/self-hosted-config-introducing-the-sprockets-manifestjs]
 
 ## Create Additional Dashboards
 


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1806

The "Getting started" section in the README is currently a duplicate of the one in the docs. They also provide different level of information, which can confuse readers who have read one but have questions solved by the other.

This MR removes this section from the README, and adds missing information to the one in the docs. This should help us maintain a single, unified, and reliable source of documentation.