### PR TITLE
Namespace option view generators 

### DIFF
--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -1,9 +1,11 @@
 require "rails/generators/base"
 require "administrate/generator_helpers"
+require "administrate/namespace"
 
 module Administrate
   class ViewGenerator < Rails::Generators::Base
     include Administrate::GeneratorHelpers
+    class_option :namespace, type: :string, default: "admin"
 
     def self.template_source_path
       File.expand_path(
@@ -14,12 +16,16 @@ module Administrate
 
     private
 
+    def namespace
+      options[:namespace]
+    end
+
     def copy_resource_template(template_name)
       template_file = "#{template_name}.html.erb"
 
       copy_file(
         template_file,
-        "app/views/admin/#{resource_path}/#{template_file}",
+        "app/views/#{namespace}/#{resource_path}/#{template_file}",
       )
     end
 

--- a/lib/generators/administrate/views/views_generator.rb
+++ b/lib/generators/administrate/views/views_generator.rb
@@ -4,10 +4,11 @@ module Administrate
   module Generators
     class ViewsGenerator < Administrate::ViewGenerator
       def copy_templates
-        call_generator("administrate:views:index", resource_path, "--namespace", namespace)
-        call_generator("administrate:views:show", resource_path, "--namespace", namespace)
-        call_generator("administrate:views:new", resource_path, "--namespace", namespace)
-        call_generator("administrate:views:edit", resource_path, "--namespace", namespace)
+        view = "administrate:views:"
+        call_generator("#{view}index", resource_path, "--namespace", namespace)
+        call_generator("#{view}show", resource_path, "--namespace", namespace)
+        call_generator("#{view}new", resource_path, "--namespace", namespace)
+        call_generator("#{view}edit", resource_path, "--namespace", namespace)
       end
     end
   end

--- a/lib/generators/administrate/views/views_generator.rb
+++ b/lib/generators/administrate/views/views_generator.rb
@@ -4,10 +4,10 @@ module Administrate
   module Generators
     class ViewsGenerator < Administrate::ViewGenerator
       def copy_templates
-        call_generator("administrate:views:index", resource_path)
-        call_generator("administrate:views:show", resource_path)
-        call_generator("administrate:views:new", resource_path)
-        call_generator("administrate:views:edit", resource_path)
+        call_generator("administrate:views:index", resource_path, "--namespace", namespace)
+        call_generator("administrate:views:show", resource_path, "--namespace", namespace)
+        call_generator("administrate:views:new", resource_path, "--namespace", namespace)
+        call_generator("administrate:views:edit", resource_path, "--namespace", namespace)
       end
     end
   end

--- a/spec/generators/views/edit_generator_spec.rb
+++ b/spec/generators/views/edit_generator_spec.rb
@@ -42,21 +42,21 @@ describe Administrate::Generators::Views::EditGenerator, :generator do
     end
   end
 
-  describe "administrate:views:edit resource --namespace <namespace>" do
-    it "copies the edit template into the `<namespace>/resource` namespace" do
+  describe "administrate:views:edit resource --namespace=<namespace>" do
+    it "copies the edit template into the `namespace/resource` namespace" do
       expected_contents = contents_for_application_template("edit")
 
-      run_generator ["LineItem", "--namespace", "test"]
-      contents = File.read(file("app/views/test/line_items/edit.html.erb"))
+      run_generator ["LineItem", "--namespace", "console"]
+      contents = File.read(file("app/views/console/line_items/edit.html.erb"))
 
       expect(contents).to eq(expected_contents)
     end
 
-    it "copies the form partial into the `admin/resource` namespace" do
+    it "copies the form partial into the `namespace/resource` namespace" do
       expected_contents = contents_for_application_template("_form")
 
-      run_generator ["users", "--namespace", "test2"]
-      contents = File.read(file("app/views/test2/users/_form.html.erb"))
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/_form.html.erb"))
 
       expect(contents).to eq(expected_contents)
     end

--- a/spec/generators/views/edit_generator_spec.rb
+++ b/spec/generators/views/edit_generator_spec.rb
@@ -41,4 +41,24 @@ describe Administrate::Generators::Views::EditGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
   end
+
+  describe "administrate:views:edit resource --namespace <namespace>" do
+    it "copies the edit template into the `<namespace>/resource` namespace" do
+      expected_contents = contents_for_application_template("edit")
+
+      run_generator ["LineItem", "--namespace", "test"]
+      contents = File.read(file("app/views/test/line_items/edit.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator ["users", "--namespace", "test2"]
+      contents = File.read(file("app/views/test2/users/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
 end

--- a/spec/generators/views/index_generator_spec.rb
+++ b/spec/generators/views/index_generator_spec.rb
@@ -42,4 +42,24 @@ describe Administrate::Generators::Views::IndexGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
   end
+
+  describe "administrate:views:index resource --namespace=<namespace>" do
+    it "copies the index view into the `namespace/resource` namespace" do
+      expected_contents = contents_for_application_template("index")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/index.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the collection partial into the `namespace/resource` namespace" do
+      expected_contents = contents_for_application_template("_collection")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/_collection.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
 end

--- a/spec/generators/views/new_generator_spec.rb
+++ b/spec/generators/views/new_generator_spec.rb
@@ -41,4 +41,24 @@ describe Administrate::Generators::Views::NewGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
   end
+
+  describe "administrate:views:new resource --namespace=<namespace>" do
+    it "copies the new template into the `namspace/resource` namespace" do
+      expected_contents = contents_for_application_template("new")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/new.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the form partial into the `namespace/resource` namespace" do
+      expected_contents = contents_for_application_template("_form")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/_form.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
 end

--- a/spec/generators/views/show_generator_spec.rb
+++ b/spec/generators/views/show_generator_spec.rb
@@ -23,4 +23,15 @@ describe Administrate::Generators::Views::ShowGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
   end
+
+  describe "administrate:views:show resource --namespace=<namespace>" do
+    it "copies the show view into the `namespace/resource` namespace" do
+      expected_contents = contents_for_application_template("show")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/show.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+  end
 end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -12,7 +12,8 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       %w[index show new edit].each do |generator|
         expect(Rails::Generators).
-          to invoke_generator("administrate:views:#{generator}", [resource])
+          to invoke_generator("administrate:views:#{generator}",
+          [resource, , "--namespace", "admin"])
       end
     end
 
@@ -24,7 +25,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       expect(Rails::Generators).to invoke_generator(
         "administrate:views:index",
-        [resource],
+        [resource, , "--namespace", "admin"],
         behavior: :revoke,
       )
     end
@@ -41,8 +42,24 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         %w[index show new edit].each do |generator|
           expect(Rails::Generators). to invoke_generator(
             "administrate:views:#{generator}",
-            [application_resource_path],
+            [application_resource_path, "--namespace", "admin"],
           )
+        end
+      end
+    end
+
+    context "when run with a namespace specified" do
+      it "runs all sub-generators with a namespace" do
+        allow(Rails::Generators).to receive(:invoke)
+        resource = "users"
+        namespace = "console"
+  
+        run_generator [resource]
+  
+        %w[index show new edit].each do |generator|
+          expect(Rails::Generators).
+            to invoke_generator("administrate:views:#{generator}",
+            [resource, "--namespace", namespace])
         end
       end
     end

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -15,7 +15,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
           to invoke_generator(
             "administrate:views:#{generator}",
             [resource, "--namespace", "admin"],
-            )
+          )
       end
     end
 

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -13,7 +13,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
       %w[index show new edit].each do |generator|
         expect(Rails::Generators).
           to invoke_generator("administrate:views:#{generator}",
-          [resource, , "--namespace", "admin"])
+          [resource, "--namespace", "admin"])
       end
     end
 
@@ -25,7 +25,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       expect(Rails::Generators).to invoke_generator(
         "administrate:views:index",
-        [resource, , "--namespace", "admin"],
+        [resource, "--namespace", "admin"],
         behavior: :revoke,
       )
     end
@@ -54,7 +54,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         resource = "users"
         namespace = "console"
   
-        run_generator [resource]
+        run_generator [resource, "--namespace", namespace]
   
         %w[index show new edit].each do |generator|
           expect(Rails::Generators).

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -12,8 +12,10 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       %w[index show new edit].each do |generator|
         expect(Rails::Generators).
-          to invoke_generator("administrate:views:#{generator}",
-          [resource, "--namespace", "admin"])
+          to invoke_generator(
+            "administrate:views:#{generator}",
+            [resource, "--namespace", "admin"],
+            )
       end
     end
 
@@ -53,13 +55,15 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         allow(Rails::Generators).to receive(:invoke)
         resource = "users"
         namespace = "console"
-  
+
         run_generator [resource, "--namespace", namespace]
-  
+
         %w[index show new edit].each do |generator|
           expect(Rails::Generators).
-            to invoke_generator("administrate:views:#{generator}",
-            [resource, "--namespace", namespace])
+            to invoke_generator(
+              "administrate:views:#{generator}",
+              [resource, "--namespace", namespace],
+            )
         end
       end
     end


### PR DESCRIPTION
Resolves issue [1632](https://github.com/thoughtbot/administrate/issues/1632) 

- Makes `rails generate administrate:views:index Modelname --namespace=<Namespace>` possible. Output is
```
      create  app/views/<namespace>/modelnames/index.html.erb
      create  app/views/<namespace>/modelnames/_collection.html.erb
```