### PR TITLE
Select field selected value

### DIFF
--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -26,7 +26,7 @@ to be displayed on a resource's edit form page.
         field.selectable_options,
         :last,
         :first,
-        field.data.presence,
+        field.data,
       )
     ) %>
   <% else %>
@@ -36,7 +36,7 @@ to be displayed on a resource's edit form page.
         field.selectable_options,
         :to_s,
         :to_s,
-        field.data.presence,
+        field.data,
       )
     ) %>
   <% end %>

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+require "administrate/field/select"
+
+describe "fields/select/_form", type: :view do
+  it "displays the selected option" do
+    customer = build(:customer)
+    select = instance_double(
+      "Administrate::Field::Select",
+      attribute: :email_subscriber,
+      data: false,
+      selectable_options: [true, false, nil],
+    )
+
+    render(
+      partial: "fields/select/form.html.erb",
+      locals: { field: select, f: form_builder(customer) },
+    )
+
+    expect(rendered).to have_css(
+      %{select[name="customer[email_subscriber]"]
+        option[value="false"][selected="selected"]},
+    )
+  end
+
+  def form_builder(object)
+    ActionView::Helpers::FormBuilder.new(
+      object.model_name.singular,
+      object,
+      build_template,
+      {},
+    )
+  end
+
+  def build_template
+    Object.new.tap do |template|
+      template.extend ActionView::Helpers::FormHelper
+      template.extend ActionView::Helpers::FormOptionsHelper
+    end
+  end
+end


### PR DESCRIPTION
When using the select field for a boolean attribute that can be either `true`, `false` or `nil`, the current behavior causes `false` and `nil` to be treated the same. If the attribute is set to `false`, the edit dashboard shows the selected value as being the `nil` option instead of `false` as expected.