### PR TITLE
Add searchable option to Field::DateTime

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -209,6 +209,9 @@ objects to display as.
 `:timezone` - Specify which timezone `Date` and `DateTime` objects are based
 in.
 
+`:searchable` - Specify if the attribute should be considered when searching.
+Default is `false`.
+
 **Field::Date**
 
 `:format` - Specify what format, using `strftime` you would like `Date`


### PR DESCRIPTION
Since `Field::DateTime` inherites `Field::Base`, `Field::DateTime` could be searchable if set `searchable` option to true.
I was wondering this is true or not because this document  does not describe it. I think it would be useful for this document.

I checked this behavior with
- Ruby 2.6.2
- administrate 0.11.0