### PR TITLE
Correct text of misleading specs

### DIFF
--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe Administrate::ApplicationHelper do
       expect(requireness(release_year)).to eq("optional")
     end
 
-    it "returns 'optional' if field is required if condition is met" do
+    it "is 'optional' for fields required only conditionally (with :unless)" do
       description = page.attributes.detect { |i| i.attribute == :description }
       expect(requireness(description)).to eq("optional")
     end
 
-    it "returns 'optional' if field is required unless condition is met" do
+    it "is 'optional' for fields required only conditionally (with :if)" do
       price = page.attributes.detect { |i| i.attribute == :price }
       expect(requireness(price)).to eq("optional")
     end


### PR DESCRIPTION
I was reading through these specs, and I think the descriptions are incorrect, as the condition is never actually checked. It looks like it was introduced by mistake at https://github.com/thoughtbot/administrate/pull/1808