### PR TITLE
WIP: improve how we test controllers

### DIFF
--- a/spec/controllers/admin/log_entries_controller_spec.rb
+++ b/spec/controllers/admin/log_entries_controller_spec.rb
@@ -127,14 +127,17 @@ describe Admin::LogEntriesController, type: :controller do
         log_entry = create(:log_entry, logeable: customer)
         new_action = "cancel"
 
-        locals = capture_view_locals do
+        render_args = capture_render do
           put_update(log_entry, action: new_action, logeable: customer)
         end
 
-        page = locals[:page]
+        page = render_args.fetch(:locals).fetch(:page)
         expect(page).to be_instance_of(Administrate::Page::Form)
         expect(page.resource).to eq(log_entry)
         expect(page.resource.action).to eq(new_action)
+
+        status = render_args.fetch(:status)
+        expect(status).to eq(:unprocessable_entity)
       end
     end
   end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -12,6 +12,27 @@ module ControllerHelpers
     locals
   end
 
+  def capture_render
+    allow(@controller).to receive(:render)
+    yield
+
+    arguments = {}
+    expect(@controller).to have_received(:render).at_least(1).times do |*args|
+      args.each do |arg|
+        locals = arg.try(:fetch, :locals, nil)
+        if locals
+          arguments[:locals] = locals
+        end
+
+        status = arg.try(:fetch, :status, nil)
+        if status
+          arguments[:status] = status
+        end
+      end
+    end
+    arguments
+  end
+
   def use_new_params_syntax?
     Rails::VERSION::STRING >= "5.2"
   end


### PR DESCRIPTION
An experiment to see how the issue I described at https://github.com/thoughtbot/administrate/pull/1880#issuecomment-777665333 can be solved. I'll repeat here...

Some of our controller tests don't actually run Rails's test rendering code. Instead they capture the call to `render` with a mock, extract the value of `:locals`, and run expectations on that. As a result, nothing is actually rendered, and Rails tells us that the result was a `:no_content`.

The capture is done with `capture_view_locals`, which can be seen at https://github.com/thoughtbot/administrate/blob/e1ae45cf44a6b7fce13865175bb5e596ad448ba9/spec/support/controller_helpers.rb

To compound the problem, I don't think there is a standard way of achieving this. It's possible to test `:locals`, but only in a very limited way, by comparing exact values. See:

https://github.com/rails/rails-controller-testing/blob/4b15c86e82ee380f2a7cc009e470368f7520560a/lib/rails/controller/testing/template_assertions.rb#L104-L108

This is a first attempt at fixing the situation. It's a "if you can't beat them, join them" approach, where I extend the helper to capture more than just `:locals`.

Other options:

* Write this test differently, not relying on this helper.
* Move it to an integration test or something like that.
* Don't use locals, and instead use instance variables as it's conventional with Rails.
* Contribute to `rails-controller-testing`, and add a method that would help us here.
* Other...?