### PR TITLE
Fix an issue where loading in routes blew up

### DIFF
--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -19,7 +19,7 @@ module Administrate
       def run_routes_generator
         if dashboard_resources.none?
           call_generator("administrate:routes", "--namespace", namespace)
-          load find_routes_file
+          Rails.application.reload_routes!
         end
       end
 


### PR DESCRIPTION
Rails has a method for reloading routes and it will reliably work —
loading in the file again throws an exception on more complex routing
structures.