### PR TITLE
Added scope support for polymorphic association field

### DIFF
--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -9,7 +9,9 @@ module Administrate
 
       def associated_resource_grouped_options
         classes.map do |klass|
-          [klass.to_s, candidate_resources_for(klass).map do |resource|
+          scope = klass.is_a?(Hash) ? klass[:scope] : :all
+          klass = klass.is_a?(Hash) ? klass[:klass] : klass
+          [klass.to_s, candidate_resources_for(klass, scope).map do |resource|
             [display_candidate_resource(resource), resource.to_global_id]
           end]
         end
@@ -39,8 +41,8 @@ module Administrate
         @_order ||= options.delete(:order)
       end
 
-      def candidate_resources_for(klass)
-        order ? klass.order(order) : klass.all
+      def candidate_resources_for(klass, scope = :all)
+        klass.send(scope).order(order)
       end
 
       def display_candidate_resource(resource)

--- a/spec/example_app/app/dashboards/log_entry_dashboard.rb
+++ b/spec/example_app/app/dashboards/log_entry_dashboard.rb
@@ -6,7 +6,12 @@ class LogEntryDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     action: Field::String,
-    logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order]),
+    logeable: Field::Polymorphic.with_options(
+      classes: [
+        { klass: Customer, scope: :cn },
+        ::Order,
+      ],
+    ),
   }.freeze
 
   COLLECTION_ATTRIBUTES = [:id] + ATTRIBUTES

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -11,6 +11,8 @@ class Customer < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true
 
+  scope :cn, -> { where(country_code: "CN") }
+
   KINDS = [
     :standard,
     :vip,

--- a/spec/features/log_entries_form_spec.rb
+++ b/spec/features/log_entries_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "log entry form" do
   it "displays a select box for the logeable" do
-    customer = create(:customer)
+    customer = create(:customer, country_code: "CN")
 
     visit new_admin_log_entry_path
     fill_in "Action", with: "create"
@@ -16,7 +16,7 @@ describe "log entry form" do
   end
 
   it "shows the selected logeable value" do
-    customer = create(:customer)
+    customer = create(:customer, country_code: "CN")
     log_entry = create(:log_entry, logeable: customer)
 
     visit edit_admin_log_entry_path(log_entry)


### PR DESCRIPTION
At the moment associated models in a polymorphic association cannot be scoped, by default ```:all``` is called in  `candidate_resources_for(klass)`. This can produce pretty long lists in the select field.

- Added option to pass a scope to associated models in `Polymorphic::Field`
- Updated the example app to show an example with `Customer`
- Was not sure how to writte a test for that, open to suggestions.

First time contributing to open source here, open to any feedback on how to make better contributions 😃 .