### PR TITLE
Update instructions for controllers without models

### DIFF
--- a/docs/adding_controllers_without_related_model.md
+++ b/docs/adding_controllers_without_related_model.md
@@ -34,7 +34,7 @@ end
 ```ruby
 # app/controllers/admin/stats_controller.rb
 module Admin
-  class StatsController < Admin::ApplicationController
+  class StatsController < ActionController::Base
     def index
       @stats = {
         customer_count: Customer.count,


### PR DESCRIPTION
This should include directions to use `ActionController::Base` for the controller instead of `Admin::ApplicationController`.
If you use Admin::ApplicationController, you get ActiveRecord related issues trying to access the "resource"
![image](https://user-images.githubusercontent.com/2087677/110023739-5c6c8100-7ce2-11eb-8ed2-0e1dfb5e26c7.png)
