### PR TITLE
Add a basic GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,54 @@
+---
+name: CI
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', 3.1, 3.2]
+    env:
+      PGHOST: localhost
+      PGUSER: administrate
+      PGPASSWORD: administrate
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: administrate_test
+          POSTGRES_PASSWORD: administrate
+        ports:
+           - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Install Appraisal dependencies
+        run: bundle exec appraisal install
+      - name: Setup the environment
+        run: cp .sample.env .env
+      - run: cp spec/example_app/config/database.yml.sample spec/example_app/config/database.yml
+      - name: Setup the database
+        run: bundle exec rake db:setup
+      - name: Run tests
+        run: bundle exec rspec
+      - name: Appraise Rails 6.0
+        run: bundle exec appraisal rails60 rspec
+        if: ${{ matrix.ruby <= '3.0' }}
+      - name: Appraise Rails 6.1
+        run: bundle exec appraisal rails61 rspec
+      - name: Appraisal Rails 7.0
+        run: bundle exec appraisal rails70 rspec


### PR DESCRIPTION
This is the closest absolute conversation from the original CircleCI 2.0
version as possible. Main differences:

* Actions' Postgres container requires a password or otherwise doesn't
  start (see SO answer),
* Ports are explicitly exported,
* Actions has a stronger, built-in approach to service health,
* Using the "global" environment variables stops us having to repeat the
  Postgres config multiple times,

https://docs.github.com/en/actions/guides/building-and-testing-ruby
https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
https://docs.github.com/en/actions/reference/environment-variables#about-environment-variables
https://docs.github.com/en/actions/guides/creating-redis-service-containers#running-jobs-directly-on-the-runner-machine
https://stackoverflow.com/a/60618750/83386
https://www.postgresql.org/docs/9.5/libpq-envars.html