### PR TITLE
Add guides for Fields::Url

### DIFF
--- a/app/views/fields/url/_index.html.erb
+++ b/app/views/fields/url/_index.html.erb
@@ -1,7 +1,7 @@
 <%#
 # Url Index Partial
 
-This partial renders an email address,
+This partial renders a URL address,
 to be displayed on a resource's index page.
 
 By default, the value is rendered as an `a` element.

--- a/app/views/fields/url/_show.html.erb
+++ b/app/views/fields/url/_show.html.erb
@@ -1,7 +1,7 @@
 <%#
 # Url Show Partial
 
-This partial renders an email address,
+This partial renders a URL address,
 to be displayed on a resource's show page.
 
 By default, the value is rendered as an `a` element.

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -65,6 +65,7 @@ specify, including:
 - `Field::Select`
 - `Field::String`
 - `Field::Text`
+- `Field::Url`
 - `Field::Password`
 
 ## Customizing Fields
@@ -234,6 +235,14 @@ Defaults to `50`.
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `false`.
+
+`:truncate` - Set the number of characters to display in the index view.
+Defaults to `50`.
+
+**Field::Url**
+
+`:searchable` - Specify if the attribute should be considered when searching.
+Default is `true`.
 
 `:truncate` - Set the number of characters to display in the index view.
 Defaults to `50`.


### PR DESCRIPTION
During work on a project using administrate during the past year I
started implementing a URL field. While grepping the codebase for
another symbol I noticed the included Fields::Url field and realized I
didn't need to implement my own (mainly for the show/index templating).

This change adds documentation for the field so that it is more
discoverable to new users of administrate.