### PR TITLE
Bring Appraisal gemfiles up to date

### DIFF
--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "0.9.33"
+  gem "i18n-tasks", "0.9.34"
   gem "pry-rails"
   gem "yard"
   gem "rspec-rails"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "0.9.33"
+  gem "i18n-tasks", "0.9.34"
   gem "pry-rails"
   gem "yard"
   gem "rspec-rails"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -22,7 +22,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "0.9.33"
+  gem "i18n-tasks", "0.9.34"
   gem "pry-rails"
   gem "yard"
   gem "rspec-rails"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "0.9.33"
+  gem "i18n-tasks", "0.9.34"
   gem "pry-rails"
   gem "yard"
 end

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "0.9.33"
+  gem "i18n-tasks", "0.9.34"
   gem "pry-rails"
   gem "yard"
 end


### PR DESCRIPTION
I get these gemfile updates when I run `./bin/appraisal`. I don't know what the mechanism is, but I figured that this is what ultimately runs on CI, so we should keep the files up to date in the repo.