### PR TITLE
css: isolate spacing properties for 'button--alt' class

### DIFF
--- a/app/assets/stylesheets/administrate/components/_buttons.scss
+++ b/app/assets/stylesheets/administrate/components/_buttons.scss
@@ -47,5 +47,8 @@ input[type="submit"],
   border: $base-border;
   border-color: $blue;
   color: $blue;
+}
+
+.button--nav {
   margin-bottom: $base-spacing;
 }

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -8,7 +8,7 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
-  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt") if defined?(root_url) %>
+  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt button--nav") if defined?(root_url) %>
 
   <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>
     <%= link_to(


### PR DESCRIPTION
When customising your own admin dashboards, it is quite expected to
use consistent graphical elements (such as buttons) in custom pages.

Exposing a `button--alt` CSS class is helpful when adding some custom
buttons, however the existing CSS class includes some spacing
properties which is specific to the navigation bar (because this class
is only used there in the Administrate engine).

This PR moves the spacing property (margin) into a dedicated
`.button--nav` class in order to give the `.button--alt` class a
reusable role.