### PR TITLE
Fix deprecation warning about dots in paths

### DIFF
--- a/spec/administrate/views/fields/belongs_to/_index_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_index_spec.rb
@@ -32,7 +32,7 @@ describe "fields/belongs_to/_index", type: :view do
 
   def render_belongs_to_index
     render(
-      partial: "fields/belongs_to/index.html.erb",
+      partial: "fields/belongs_to/index",
       locals: { field: belongs_to, namespace: "admin" },
     )
   end

--- a/spec/administrate/views/fields/belongs_to/_show_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_show_spec.rb
@@ -32,7 +32,7 @@ describe "fields/belongs_to/_show", type: :view do
 
   def render_belongs_to_show
     render(
-      partial: "fields/belongs_to/show.html.erb",
+      partial: "fields/belongs_to/show",
       locals: { field: belongs_to, namespace: "admin" },
     )
   end

--- a/spec/administrate/views/fields/date_time/_index_spec.rb
+++ b/spec/administrate/views/fields/date_time/_index_spec.rb
@@ -12,7 +12,7 @@ describe "fields/date_time/_index", type: :view do
     )
 
     render(
-      partial: "fields/date_time/index.html.erb",
+      partial: "fields/date_time/index",
       locals: { field: date_time, namespace: "admin" },
     )
   end

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -9,7 +9,7 @@ describe "fields/has_many/_form", type: :view do
       )
 
       render(
-        partial: "fields/has_many/form.html.erb",
+        partial: "fields/has_many/form",
         locals: { f: fake_form_builder, field: has_many },
       )
 

--- a/spec/administrate/views/fields/has_many/_index_spec.rb
+++ b/spec/administrate/views/fields/has_many/_index_spec.rb
@@ -11,7 +11,7 @@ describe "fields/has_many/_index", type: :view do
       )
 
       render(
-        partial: "fields/has_many/index.html.erb",
+        partial: "fields/has_many/index",
         locals: { field: has_many },
       )
 
@@ -29,7 +29,7 @@ describe "fields/has_many/_index", type: :view do
       )
 
       render(
-        partial: "fields/has_many/index.html.erb",
+        partial: "fields/has_many/index",
         locals: { field: has_many },
       )
 
@@ -47,7 +47,7 @@ describe "fields/has_many/_index", type: :view do
       )
 
       render(
-        partial: "fields/has_many/index.html.erb",
+        partial: "fields/has_many/index",
         locals: { field: has_many },
       )
 

--- a/spec/administrate/views/fields/has_many/_show_spec.rb
+++ b/spec/administrate/views/fields/has_many/_show_spec.rb
@@ -6,7 +6,7 @@ describe "fields/has_many/_show", type: :view do
       has_many = double(resources: [])
 
       render(
-        partial: "fields/has_many/show.html.erb",
+        partial: "fields/has_many/show",
         locals: { field: has_many },
       )
 

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -11,7 +11,7 @@ describe "fields/has_one/_form", type: :view do
     )
 
     render(
-      partial: "fields/has_one/form.html.erb",
+      partial: "fields/has_one/form",
       locals: { field: has_one, f: form_builder },
     )
 

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -10,7 +10,7 @@ describe "fields/has_one/_index", type: :view do
       )
 
       render(
-        partial: "fields/has_one/index.html.erb",
+        partial: "fields/has_one/index",
         locals: { field: has_one },
       )
 
@@ -30,7 +30,7 @@ describe "fields/has_one/_index", type: :view do
       )
 
       render(
-        partial: "fields/has_one/index.html.erb",
+        partial: "fields/has_one/index",
         locals: { field: has_one, namespace: "admin" },
       )
 

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -11,7 +11,7 @@ describe "fields/has_one/_show", type: :view do
       )
 
       render(
-        partial: "fields/has_one/show.html.erb",
+        partial: "fields/has_one/show",
         locals: { field: has_one },
       )
 
@@ -40,7 +40,7 @@ describe "fields/has_one/_show", type: :view do
       )
 
       render(
-        partial: "fields/has_one/show.html.erb",
+        partial: "fields/has_one/show",
         locals: {
           field: has_one,
           namespace: "admin",
@@ -90,7 +90,7 @@ describe "fields/has_one/_show", type: :view do
       page_double = instance_double("Administrate::Page::Show")
 
       render(
-        partial: "fields/has_one/show.html.erb",
+        partial: "fields/has_one/show",
         locals: {
           field: has_one,
           namespace: "admin",

--- a/spec/administrate/views/fields/polymorphic/_form_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_form_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 
 describe "fields/polymorphic/_form", type: :view do
-
   it "displays the association name" do
     polymorphic = double(name: "parent").as_null_object
 
     render(
-      partial: "fields/polymorphic/form.html.erb",
+      partial: "fields/polymorphic/form",
       locals: { field: polymorphic, f: fake_form_builder },
     )
 

--- a/spec/administrate/views/fields/polymorphic/_index_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_index_spec.rb
@@ -6,7 +6,7 @@ describe "fields/polymorphic/_index", type: :view do
       polymorphic = double(data: nil)
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
+        partial: "fields/polymorphic/index",
         locals: { field: polymorphic },
       )
 
@@ -25,7 +25,7 @@ describe "fields/polymorphic/_index", type: :view do
       )
 
       render(
-        partial: "fields/polymorphic/index.html.erb",
+        partial: "fields/polymorphic/index",
         locals: { field: polymorphic, namespace: "admin" },
       )
 

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -12,7 +12,7 @@ describe "fields/polymorphic/_show", type: :view do
       )
 
       render(
-        partial: "fields/polymorphic/show.html.erb",
+        partial: "fields/polymorphic/show",
         locals: { field: polymorphic },
       )
 
@@ -34,7 +34,7 @@ describe "fields/polymorphic/_show", type: :view do
       allow(view).to receive(:valid_action?).and_return(true)
 
       render(
-        partial: "fields/polymorphic/show.html.erb",
+        partial: "fields/polymorphic/show",
         locals: { field: polymorphic, namespace: "admin" },
       )
 

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -12,7 +12,7 @@ describe "fields/select/_form", type: :view do
     )
 
     render(
-      partial: "fields/select/form.html.erb",
+      partial: "fields/select/form",
       locals: { field: select, f: form_builder(customer) },
     )
 

--- a/spec/administrate/views/fields/time/_index_spec.rb
+++ b/spec/administrate/views/fields/time/_index_spec.rb
@@ -6,13 +6,14 @@ describe "fields/time/_index", type: :view do
       time = double(data: nil)
 
       render(
-        partial: "fields/time/index.html.erb",
+        partial: "fields/time/index",
         locals: { field: time },
       )
 
       expect(rendered.strip).to eq("")
     end
   end
+
   context "time value is set" do
     it "renders time" do
       example_time = "12:34:00"
@@ -22,7 +23,7 @@ describe "fields/time/_index", type: :view do
         data: customer.example_time,
       )
       render(
-        partial: "fields/time/index.html.erb",
+        partial: "fields/time/index",
         locals: { field: time, namespace: "admin" },
       )
 

--- a/spec/administrate/views/fields/url/_form_spec.rb
+++ b/spec/administrate/views/fields/url/_form_spec.rb
@@ -11,7 +11,7 @@ describe "fields/url/_form", type: :view do
     )
 
     render(
-      partial: "fields/url/form.html.erb",
+      partial: "fields/url/form",
       locals: { field: url, f: form_builder(product) },
     )
 

--- a/spec/administrate/views/fields/url/_index_spec.rb
+++ b/spec/administrate/views/fields/url/_index_spec.rb
@@ -10,7 +10,7 @@ describe "fields/url/_index", type: :view do
     )
 
     render(
-      partial: "fields/url/index.html.erb",
+      partial: "fields/url/index",
       locals: { field: url, namespace: "admin" },
     )
 

--- a/spec/administrate/views/fields/url/_show_spec.rb
+++ b/spec/administrate/views/fields/url/_show_spec.rb
@@ -10,7 +10,7 @@ describe "fields/url/_show", type: :view do
     )
 
     render(
-      partial: "fields/url/show.html.erb",
+      partial: "fields/url/show",
       locals: { field: url, namespace: "admin" },
     )
 


### PR DESCRIPTION
This is a deprecation introduced in Rails 6.1. For example:

```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated:
fields/time/_index.html.erb (called from block (3 levels) in
<top (required)> at $WORDIR/spec/administrate/views/fields/time/_index_spec.rb:24)
```