### PR TITLE
Fix deprecation warning about i18n errors

### DIFF
--- a/spec/example_app/config/environments/development.rb
+++ b/spec/example_app/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  if Rails::VERSION::MAJOR <= 6
+  if Gem::Version.new(Rails.version) <= Gem::Version.new("6.1")
     config.action_view.raise_on_missing_translations = true
   else
     config.i18n.raise_on_missing_translations = true

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  if Rails::VERSION::MAJOR <= 6
+  if Gem::Version.new(Rails.version) <= Gem::Version.new("6.1")
     config.action_view.raise_on_missing_translations = true
   else
     config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
Similar to https://github.com/thoughtbot/administrate/pull/1960, this deprecation was introduced in Rails 6.1. For example:

```
DEPRECATION WARNING: action_view.raise_on_missing_translations is
deprecated and will be removed in Rails 6.2. Set i18n.raise_on_missing_translations
instead. Note that this new setting also affects how missing translations
are handled in controllers. (called from load at ./bin/rspec:7)
```