### PR TITLE
Script to list recent changes to templates

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+if ARGV.count != 1
+  script = $0
+  puts "Usage:"
+  puts "  #{script} <git reference>"
+  puts
+  puts "Example:"
+  puts "  #{script} v0.15.0"
+  exit 1
+end
+
+gitref = ARGV.first
+
+files = `git diff --name-only #{gitref} | grep html.erb`
+
+if files.empty?
+  puts "No template changes since #{gitref}"
+else
+  puts "The following templates have changed since #{gitref}:"
+  puts
+  puts(files.split.map { |line| "  #{line}" })
+  puts
+  puts "If your application overrides any of them, make sure to review your"
+  puts "custom templates to ensure that they remain compatible."
+end

--- a/bin/changelog
+++ b/bin/changelog
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
 
+def silent_run(cmd)
+  pid = spawn(cmd, out: "/dev/null", err: "/dev/null")
+  Process.wait(pid)
+  $?.success?
+end
+
 if ARGV.count != 1
   script = $0
   puts "Usage:"
@@ -11,6 +17,11 @@ if ARGV.count != 1
 end
 
 gitref = ARGV.first
+
+unless silent_run("git cat-file -t #{gitref}")
+  puts "The given git reference `#{gitref}` does not exist in this repository."
+  exit 1
+end
 
 files = `git diff --name-only #{gitref} | grep html.erb`
 


### PR DESCRIPTION
A first stab at a script to help with writing changelogs. Currently, it lists which template files have changed since the version given as an argument (actually a Git tag):

```
$ ./bin/changelog v0.15.0
The following templates have changed since v0.15.0:

  app/views/administrate/application/_navigation.html.erb
  app/views/fields/url/_index.html.erb
  app/views/fields/url/_show.html.erb

If your application overrides any of them, make sure to review your
custom templates to ensure that they remain compatible.
```

This was inspired by https://github.com/thoughtbot/administrate/issues/1957, where a user observed that it would be worth mentioning these template updates in the changelog, as it's something that people need to look out for when upgrading Administrate.

Perhaps in the future we can add other capabilities to this script.