### PR TITLE
Fix redirect after delete resource without index

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -76,7 +76,12 @@ module Administrate
       else
         flash[:error] = requested_resource.errors.full_messages.join("<br/>")
       end
-      redirect_to after_resource_destroyed_path(requested_resource)
+      after_action = after_resource_destroyed_path(requested_resource)[:action]
+      if valid_action?(after_action, resource_class)
+        redirect_to after_resource_destroyed_path(requested_resource)
+      else
+        redirect_to params[:origin_url]
+      end
     end
 
     private
@@ -104,6 +109,12 @@ module Administrate
       !!routes.detect do |controller, action|
         controller == resource.to_s.underscore.pluralize && action == name.to_s
       end
+    end
+
+    helper_method :origin_url_params
+    def origin_url_params(page)
+      is_show_page = page.instance_of?(Administrate::Page::Show)
+      { origin_url: polymorphic_path([:admin, page.resource]) } if is_show_page
     end
 
     def routes

--- a/app/views/administrate/application/_collection_item_actions.html.erb
+++ b/app/views/administrate/application/_collection_item_actions.html.erb
@@ -9,7 +9,7 @@
 <% if valid_action?(:destroy, collection_presenter.resource_name) %>
   <td><%= link_to(
     t("administrate.actions.destroy"),
-    [namespace, resource],
+    [namespace, resource, origin_url_params(page)],
     class: "text-color-red",
     method: :delete,
     data: { confirm: t("administrate.actions.confirm") }

--- a/spec/features/orders_show_spec.rb
+++ b/spec/features/orders_show_spec.rb
@@ -11,6 +11,23 @@ feature "order show page" do
     expect(page).to have_content(line_item.total_price)
   end
 
+  scenario "destroys line item", js: true do
+    line_item = create(:line_item)
+
+    visit admin_order_path(line_item.order)
+
+    accept_confirm do
+      click_on t("administrate.actions.destroy")
+    end
+
+    message_label = "administrate.controller.destroy.success"
+    expect(page).to have_flash(
+      t(message_label, resource: "Line item"),
+    )
+
+    expect(page.current_path).to eq(admin_order_path(line_item.order))
+  end
+
   scenario "links to line items", :js do
     line_item = create(:line_item)
 


### PR DESCRIPTION
fix #626

**Steps to reproduce**
- `Resourse A` has many `Resource B` 
- `Resourse B` has no index page
- go to show page of `Resourse A` and click on destroy of `Resource B` 
- resource is destroyed

**Behavior before this fix**
- **An error is raised**
![image](https://user-images.githubusercontent.com/6463001/117847934-7cdd2c80-b28b-11eb-89e3-5980c8a1d8ab.png)

**Behavior after this fix**
- **is redirected `Resourse A` show page**

