### PR TITLE
Refactor page redirect path after 'destroy', 'create', 'update' 

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -47,7 +47,7 @@ module Administrate
 
       if resource.save
         redirect_to(
-          [namespace, resource],
+          after_resource_created_path(resource),
           notice: translate_with_resource("create.success"),
         )
       else
@@ -60,7 +60,7 @@ module Administrate
     def update
       if requested_resource.update(resource_params)
         redirect_to(
-          [namespace, requested_resource],
+          after_resource_updated_path(requested_resource),
           notice: translate_with_resource("update.success"),
         )
       else
@@ -76,10 +76,22 @@ module Administrate
       else
         flash[:error] = requested_resource.errors.full_messages.join("<br/>")
       end
-      redirect_to action: :index
+      redirect_to after_resource_destroyed_path(requested_resource)
     end
 
     private
+
+    def after_resource_destroyed_path(_requested_resource)
+      { action: :index }
+    end
+
+    def after_resource_created_path(requested_resource)
+      [namespace, requested_resource]
+    end
+
+    def after_resource_updated_path(requested_resource)
+      [namespace, requested_resource]
+    end
 
     helper_method :nav_link_state
     def nav_link_state(resource)

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -70,3 +70,21 @@ def default_sorting_direction
   :desc
 end
 ```
+
+## Customizing Redirects after actions
+
+To set custom redirects after the actions `create`, `update` and `destroy` you can override `after_resource_created_path`, `after_resource_updated_path` or `after_resource_destroyed_path` like this:
+
+```ruby
+    def after_resource_destroyed_path(_requested_resource)
+      { action: :index, controller: :some_other_resource }
+    end
+
+    def after_resource_created_path(requested_resource)
+      [namespace, requested_resource.some_other_resource]
+    end
+
+    def after_resource_updated_path(requested_resource)
+      [namespace, requested_resource.some_other_resource]
+    end
+```

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Admin::OrdersController, type: :controller do
+  controller(Admin::OrdersController) do
+    def after_resource_destroyed_path(_requested_resource)
+      { action: :index, controller: :customers }
+    end
+
+    def after_resource_created_path(requested_resource)
+      [namespace, requested_resource.customer]
+    end
+
+    def after_resource_updated_path(requested_resource)
+      [namespace, requested_resource.customer]
+    end
+  end
+
+  it "redirect to custom route after destroy" do
+    order = create(:order)
+
+    delete :destroy, id: order.to_param
+    expect(response).to redirect_to(admin_customers_path)
+  end
+
+  it "redirect to custom route after create" do
+    customer = create(:customer)
+    order_attributes = build(:order, customer: customer).attributes
+    params = order_attributes.except("id", "created_at", "updated_at", "shipped_at")
+
+    post :create, order: params
+    expect(response).to redirect_to(admin_customer_path(customer))
+  end
+
+  it "redirect to custom route after update" do
+    order = create(:order)
+    order_params = { address_line_one: order.address_line_one }
+
+    put :update, id: order.to_param, order: order_params
+    expect(response).to redirect_to(admin_customer_path(order.customer))
+  end
+end


### PR DESCRIPTION
@pablobm , please review

This is a follow-up of PR https://github.com/thoughtbot/administrate/pull/1973/

Should I squash the commits?


hound is complaining about something but I think it is not relevant, and maybe this rule should be disabled => https://github.com/rubocop/rubocop/issues/3675