### PR TITLE
Opt-out of FLoC: https://amifloced.org/

### DIFF
--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -34,5 +34,9 @@ module AdministratePrototype
     if Rails::VERSION::MAJOR >= 5
       config.active_record.time_zone_aware_types = %i(datetime time)
     end
+
+    # Opt-out of FLoC: https://amifloced.org/
+    config.action_dispatch.
+      default_headers["Permissions-Policy"] = "interest-cohort=()"
   end
 end


### PR DESCRIPTION
Instruct Chrome not to use the Administrate example site for its FLoC calculations.

FLoC is a browser-based[1] technology that Google is currently trialling. It's a means of tracking users without using third-party cookies. See: https://amifloced.org/

[1] Chrome-only at the moment