### PR TITLE
Fix deprecation warning (`template` vs `view` in rspec-rails)

### DIFF
--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -53,7 +53,7 @@ describe "fields/has_one/_show", type: :view do
     end
 
     it "renders nested attribute relationships" do
-      template.extend Administrate::ApplicationHelper
+      view.extend Administrate::ApplicationHelper
 
       product = create(:product)
       page = create(:page, product: product)


### PR DESCRIPTION
We are getting the following warning when running this example:

```
template is deprecated. Use view instead. Called from
PATH/spec/administrate/views/fields/has_one/_show_spec.rb:56:in `block
(3 levels) in <top (required)>'.

If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.
```