### PR TITLE
Only call html_safe on flash message that responds to it

### DIFF
--- a/app/views/administrate/application/_flashes.html.erb
+++ b/app/views/administrate/application/_flashes.html.erb
@@ -14,6 +14,7 @@ This partial renders flash messages on every page.
 <% if flash.any? %>
   <div class="flashes">
     <% flash.each do |key, value| -%>
+      <% next unless value.respond_to?(:html_safe) %>
       <div class="flash flash-<%= key %>"><%= value.html_safe %></div>
     <% end -%>
   </div>

--- a/spec/example_app/app/views/application/_flashes.html.erb
+++ b/spec/example_app/app/views/application/_flashes.html.erb
@@ -1,7 +1,7 @@
 <% if flash.any? %>
   <div id="flash">
     <% flash.each do |key, value| -%>
-      <div class="flash-<%= key %>"><%= value %></div>
+      <div class="flash-<%= key %>"><%= value.html_safe %></div>
     <% end -%>
   </div>
 <% end %>


### PR DESCRIPTION
This one line change is already covered by existing feature specs.

Resolves: https://github.com/thoughtbot/administrate/issues/2009