### PR TITLE
Render extra columns from COLLECTION_ATTRIBUTES on index page dynamically during runtime without code deployment 

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -14,7 +14,7 @@ module Administrate
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
       col =  params[:extra_columns]&.split(",")&.map(&:to_sym) || []
-      page.attribute_names_append(col)
+      page.attribute_names_append(col) unless col.empty?
 
       render locals: {
         resources: resources,

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -13,6 +13,9 @@ module Administrate
       resources = resources.page(params[:_page]).per(records_per_page)
       page = Administrate::Page::Collection.new(dashboard, order: order)
 
+      col =  params[:extra_columns]&.split(",")&.map(&:to_sym) || []
+      page.attribute_names_append(col)
+
       render locals: {
         resources: resources,
         search_term: search_term,

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -56,8 +56,14 @@ module Administrate
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end
-      params.permit(:search, :id, :_page, :per_page,
-        association_params, :extra_columns)
+      params.permit(
+        :search,
+        :id,
+        :_page,
+        :per_page,
+        association_params,
+        :extra_columns
+      )
     end
 
     def clear_search_params

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -56,11 +56,11 @@ module Administrate
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end
-      params.permit(:search, :id, :_page, :per_page, association_params)
+      params.permit(:search, :id, :_page, :per_page, association_params, :extra_columns)
     end
 
     def clear_search_params
-      params.except(:search, :_page).permit(
+      params.except(:search, :_page).permit(:extra_columns,
         :per_page, resource_name => %i[order direction]
       )
     end

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -56,7 +56,8 @@ module Administrate
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end
-      params.permit(:search, :id, :_page, :per_page, association_params, :extra_columns)
+      params.permit(:search, :id, :_page, :per_page,
+        association_params, :extra_columns)
     end
 
     def clear_search_params

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -62,7 +62,7 @@ module Administrate
         :_page,
         :per_page,
         association_params,
-        :extra_columns
+        :extra_columns,
       )
     end
 

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -6,7 +6,14 @@ module Administrate
       def attribute_names
         dashboard.collection_attributes
       end
-
+      
+      def attribute_names_append(cols)
+        allowed_values = dashboard.attribute_types.keys
+        allowed_cols = (cols & allowed_values)
+        final_cols =  dashboard.collection_attributes | allowed_cols
+        dashboard.collection_attributes.replace final_cols
+      end
+      
       def attributes_for(resource)
         attribute_names.map do |attr_name|
           attribute_field(dashboard, resource, attr_name, :index)

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -6,14 +6,14 @@ module Administrate
       def attribute_names
         dashboard.collection_attributes
       end
-      
+
       def attribute_names_append(cols)
         allowed_values = dashboard.attribute_types.keys
         allowed_cols = (cols & allowed_values)
-        final_cols =  dashboard.collection_attributes | allowed_cols
+        final_cols = dashboard.collection_attributes | allowed_cols
         dashboard.collection_attributes.replace final_cols
       end
-      
+
       def attributes_for(resource)
         attribute_names.map do |attr_name|
           attribute_field(dashboard, resource, attr_name, :index)


### PR DESCRIPTION
Hi, I'm using this library for a project working on, and would like to be able to have extra columns show up on the index page without making code changes and deployment 

Example: http://localhost:PORT/?extra_columns=id
expected: column id will show up on the subsequent requests 

PS: this is my first time working with ruby and rails, open for feedback and comments 

Thanks. 