### PR TITLE
Add format option to time field

### DIFF
--- a/app/views/fields/time/_index.html.erb
+++ b/app/views/fields/time/_index.html.erb
@@ -15,5 +15,5 @@ By default, the attribute is rendered as a text tag.
 %>
 
 <% if field.data %>
-  <%= field.data.strftime("%I:%M%p").to_s %>
+  <%= field.time %>
 <% end %>

--- a/app/views/fields/time/_show.html.erb
+++ b/app/views/fields/time/_show.html.erb
@@ -15,5 +15,5 @@ By default, the attribute is rendered as a text tag.
 %>
 
 <% if field.data %>
-  <%= field.data.strftime("%I:%M%p").to_s %>
+  <%= field.time %>
 <% end %>

--- a/lib/administrate/field/time.rb
+++ b/lib/administrate/field/time.rb
@@ -3,6 +3,17 @@ require_relative "base"
 module Administrate
   module Field
     class Time < Base
+      def time
+        return I18n.localize(data, format: format) if options[:format]
+
+        data.strftime("%I:%M%p")
+      end
+
+      private
+
+      def format
+        options[:format]
+      end
     end
   end
 end

--- a/spec/administrate/views/fields/time/_index_spec.rb
+++ b/spec/administrate/views/fields/time/_index_spec.rb
@@ -21,6 +21,7 @@ describe "fields/time/_index", type: :view do
       time = instance_double(
         "Administrate::Field::Time",
         data: customer.example_time,
+        time: "12:34PM",
       )
       render(
         partial: "fields/time/index",

--- a/spec/lib/fields/time_spec.rb
+++ b/spec/lib/fields/time_spec.rb
@@ -13,4 +13,29 @@ describe Administrate::Field::Time do
       expect(path).to eq("/fields/time/#{page}")
     end
   end
+
+  describe "#time" do
+    it "formats the time according to the passed format option" do
+      time = DateTime.new(2021, 3, 26, 16, 38)
+      formats = {
+        time: {
+          formats: { short: "%H:%M" },
+        },
+      }
+
+      options_field = Administrate::Field::Time.with_options(format: :short)
+      field = options_field.new(:time, time, :index)
+
+      with_translations(:en, formats) do
+        expect(field.time).to eq("16:38")
+      end
+    end
+
+    it "it defaults to the expected format if no format option is passed" do
+      time = DateTime.new(2021, 3, 26, 16, 38)
+      field = Administrate::Field::Time.new(:time, time, :index)
+
+      expect(field.time).to eq("04:38PM")
+    end
+  end
 end


### PR DESCRIPTION
Previously there was no way to specify format for a time field, but you can specify a format for date and datetime fields. This commit adds the ability to pass a format option to time fields.

Because I18n [uses the time locale key for for all objects with a time](https://github.com/ruby-i18n/i18n/blob/0888807ab2fe4f4c8a4b780f5654a8175df61feb/lib/i18n/backend/base.rb#L82), retain the hard-coded time field format where no format option is passed to avoid a breaking change.

Addresses #1227.