### PR TITLE
Avoid Selenium warning about old options format

### DIFF
--- a/spec/support/webdrivers.rb
+++ b/spec/support/webdrivers.rb
@@ -5,14 +5,19 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.headless!
-  options.add_argument "--window-size=1680,1050"
-
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    options: options,
+    capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(
+      "goog:chromeOptions" => {
+        "args" => [
+          "window-size=1680,1050",
+          "headless",
+          "disable-gpu",
+          "disable-dev-shm-usage",
+        ],
+      },
+    ),
   )
 end
 


### PR DESCRIPTION
After upgrading selenium-webdriver to v4.0.3 at https://github.com/thoughtbot/administrate/commit/9e462f7179f47151d1b91aab59291e6884870dab, a new warning has appeared when running the tests:

```
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
``` 

There's not much documentation as to what the options are and how they should be passed here, but this appears to work.
It's based on https://chromedriver.chromium.org/capabilities