### PR TITLE
Refactor search_attributes to be defined in BaseDashboard

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -6,7 +6,7 @@ module Administrate
       authorize_resource(resource_class)
       search_term = params[:search].to_s.strip
       resources = Administrate::Search.new(scoped_resource,
-                                           dashboard_class,
+                                           dashboard,
                                            search_term).run
       resources = apply_collection_includes(resources)
       resources = order.apply(resources)

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -79,6 +79,12 @@ module Administrate
       self.class::COLLECTION_ATTRIBUTES
     end
 
+    def search_attributes
+      attribute_types.keys.select do |attribute|
+        attribute_types[attribute].searchable?
+      end
+    end
+
     def display_resource(resource)
       "#{resource.class} ##{resource.id}"
     end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -48,8 +48,8 @@ module Administrate
       end
     end
 
-    def initialize(scoped_resource, dashboard_class, term)
-      @dashboard_class = dashboard_class
+    def initialize(scoped_resource, dashboard, term)
+      @dashboard = dashboard
       @scoped_resource = scoped_resource
       @query = Query.new(term, valid_filters.keys)
     end
@@ -108,9 +108,7 @@ module Administrate
     end
 
     def search_attributes
-      attribute_types.keys.select do |attribute|
-        attribute_types[attribute].searchable?
-      end
+      @dashboard.search_attributes
     end
 
     def search_results(resources)
@@ -120,15 +118,15 @@ module Administrate
     end
 
     def valid_filters
-      if @dashboard_class.const_defined?(:COLLECTION_FILTERS)
-        @dashboard_class.const_get(:COLLECTION_FILTERS).stringify_keys
+      if @dashboard.class.const_defined?(:COLLECTION_FILTERS)
+        @dashboard.class.const_get(:COLLECTION_FILTERS).stringify_keys
       else
         {}
       end
     end
 
     def attribute_types
-      @dashboard_class::ATTRIBUTE_TYPES
+      @dashboard.class.const_get(:ATTRIBUTE_TYPES)
     end
 
     def query_table_name(attr)

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -8,6 +8,7 @@ require "administrate/field/has_many"
 require "administrate/field/has_one"
 require "administrate/field/number"
 require "administrate/field/string"
+require "administrate/base_dashboard"
 require "administrate/search"
 
 describe Administrate::Search do
@@ -33,7 +34,7 @@ describe Administrate::Search do
           has_one :address
         end
 
-        class UserDashboard
+        class UserDashboard < Administrate::BaseDashboard
           ATTRIBUTE_TYPES = {
             id: Administrate::Field::Number.with_options(searchable: true),
             name: Administrate::Field::String,
@@ -47,7 +48,7 @@ describe Administrate::Search do
           }.freeze
         end
 
-        class FooDashboard
+        class FooDashboard < Administrate::BaseDashboard
           ATTRIBUTE_TYPES = {
             role: Administrate::Field::BelongsTo.with_options(
               searchable: true,
@@ -81,7 +82,7 @@ describe Administrate::Search do
       scoped_object = User.default_scoped
       search = Administrate::Search.new(
         scoped_object,
-        Administrate::SearchSpecMocks::UserDashboard,
+        Administrate::SearchSpecMocks::UserDashboard.new,
         nil,
       )
       expect(scoped_object).to receive(:all)
@@ -96,7 +97,7 @@ describe Administrate::Search do
       scoped_object = User.default_scoped
       search = Administrate::Search.new(
         scoped_object,
-        Administrate::SearchSpecMocks::UserDashboard,
+        Administrate::SearchSpecMocks::UserDashboard.new,
         "   ",
       )
       expect(scoped_object).to receive(:all)
@@ -111,7 +112,7 @@ describe Administrate::Search do
       scoped_object = User.default_scoped
       search = Administrate::Search.new(
         scoped_object,
-        Administrate::SearchSpecMocks::UserDashboard,
+        Administrate::SearchSpecMocks::UserDashboard.new,
         "test",
       )
       expected_query = [
@@ -136,7 +137,7 @@ describe Administrate::Search do
       scoped_object = User.default_scoped
       search = Administrate::Search.new(
         scoped_object,
-        Administrate::SearchSpecMocks::UserDashboard,
+        Administrate::SearchSpecMocks::UserDashboard.new,
         "Тест Test",
       )
       expected_query = [
@@ -166,7 +167,7 @@ describe Administrate::Search do
       let(:search) do
         Administrate::Search.new(
           scoped_object,
-          Administrate::SearchSpecMocks::FooDashboard,
+          Administrate::SearchSpecMocks::FooDashboard.new,
           "Тест Test",
         )
       end
@@ -228,7 +229,7 @@ describe Administrate::Search do
       scoped_object = User.default_scoped
       search = Administrate::Search.new(
         scoped_object,
-        Administrate::SearchSpecMocks::UserDashboard,
+        Administrate::SearchSpecMocks::UserDashboard.new,
         "vip:",
       )
       expect(scoped_object).to \


### PR DESCRIPTION
`BaseDashboard` offers a clear easily overrideable interface for customizing which attributes are used for the index, show, and edit/update actions in `#collection_attributes`, `#show_page_attributes` and `#form_attributes`, respectively. This PR brings search into the same pattern and adds `BaseDashboard#search_attributes` allowing the dashboard customizer to easily change the logic which is used for filtering attributes for searching. 

A typical use case might entail implementing an app-specific field option and using that to customize the field filtering.