### PR TITLE
gemspec: Drop unused directive test_files

### DIFF
--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.files = Dir["{app,config,db,lib,docs}/**/*", "LICENSE", "Rakefile"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_dependency "actionpack", ">= 5.0"
   s.add_dependency "actionview", ">= 5.0"


### PR DESCRIPTION
This directive is not used by RubyGems.org.