### PR TITLE
Make search easier to override and adapt to custom use cases

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -5,9 +5,7 @@ module Administrate
     def index
       authorize_resource(resource_class)
       search_term = params[:search].to_s.strip
-      resources = Administrate::Search.new(scoped_resource,
-                                           dashboard,
-                                           search_term).run
+      resources = filter_resources(scoped_resource, search_term: search_term)
       resources = apply_collection_includes(resources)
       resources = order.apply(resources)
       resources = resources.page(params[:_page]).per(records_per_page)
@@ -80,6 +78,14 @@ module Administrate
     end
 
     private
+
+    def filter_resources(resources, search_term:)
+      Administrate::Search.new(
+        resources,
+        dashboard,
+        search_term,
+      ).run
+    end
 
     def after_resource_destroyed_path(_requested_resource)
       { action: :index }

--- a/spec/example_app/app/controllers/admin/log_entries_controller.rb
+++ b/spec/example_app/app/controllers/admin/log_entries_controller.rb
@@ -1,4 +1,30 @@
 module Admin
   class LogEntriesController < Admin::ApplicationController
+    def filter_resources(resources, search_term:)
+      return resources if search_term.blank?
+
+      customer_ids = Customer.where(
+        [
+          "name ILIKE ?",
+          "%#{search_term}%",
+        ],
+      ).pluck(:id)
+      order_ids = Order.joins(:customer).where(
+        [
+          "customers.name ILIKE ?",
+          "%#{search_term}%",
+        ],
+      ).pluck(:id)
+
+      customers_filter = resources.where(
+        logeable_type: "Customer",
+        logeable_id: customer_ids,
+      )
+      orders_filter = resources.where(
+        logeable_type: "Order",
+        logeable_id: order_ids,
+      )
+      customers_filter.or(orders_filter)
+    end
   end
 end

--- a/spec/example_app/spec/features/log_search_spec.rb
+++ b/spec/example_app/spec/features/log_search_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Log search", type: :feature do
+  it "filters logs related to a customer name", :js do
+    c1 = create(:customer, name: "John Petrucci")
+    c2 = create(:customer, name: "John Myung")
+    c3 = create(:customer, name: "James LaBrie")
+    o1a = create(:order, customer: c1)
+    o2 = create(:order, customer: c2)
+    o3 = create(:order, customer: c3)
+    o1b = create(:order, customer: c1)
+
+    [c1, c2, o1a, c3, o2, o3, o1b].each do |record|
+      create(:log_entry, logeable: record)
+    end
+
+    visit admin_log_entries_path
+    expect(page).to have_records_table(rows: 7)
+
+    fill_in :search, with: "John"
+    submit_search
+    expect(page).to have_records_table(rows: 5)
+  end
+
+  def have_records_table(rows:)
+    have_css("[role=main] table tr[data-url]", count: rows)
+  end
+
+  def submit_search
+    page.execute_script("$('.search').submit()")
+  end
+end


### PR DESCRIPTION
Seeing https://github.com/thoughtbot/administrate/issues/2063 made me think about quick ways to customise Administrate's search.

I realised that `Administrate::ApplicationController#index` doesn't make it easy to override the way that search is performed, so this seems like a first "obvious" port of entry.

By factoring out lines 8-10 into their own method, now we can do things like shown in the provided spec. This should be enough for everyone to adapt the search to their own use case.

In the future, we can try rework `Administrate::Order` into something more configurable and "better". However we all know this is long term future, so this PR should get us going, for a long way, until then.