### PR TITLE
Manage browser drivers with webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "timecop"
+  gem "webdrivers"
   gem "webmock"
   gem "xpath", "3.2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,10 @@ GEM
     unicorn (6.0.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -352,6 +356,7 @@ DEPENDENCIES
   timecop
   uglifier
   unicorn
+  webdrivers
   webmock
   xpath (= 3.2.0)
   yard

--- a/bin/setup
+++ b/bin/setup
@@ -23,11 +23,6 @@ bundle exec rake db:setup dev:prime
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
-if ! command -v chromedriver > /dev/null; then
-  printf 'chromedriver is not installed.\n'
-  printf 'See https://chromedriver.chromium.org for install instructions.\n'
-fi
-
 # Only if this isn't CI
 # if [ -z "$CI" ]; then
 # fi

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "webmock/rspec"
-
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -12,5 +10,3 @@ RSpec.configure do |config|
 
   config.order = :random
 end
-
-WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,11 @@
+require "webmock/rspec"
+
+# Allow downloading webdrivers for Selenium
+driver_hosts = Webdrivers::Common.subclasses.
+  map { |driver| URI(driver.base_url).host }
+
+# Downloading the Firefox driver involves a redirect
+driver_hosts += ["github-releases.githubusercontent.com"]
+
+# Additionally, avoid conflict with Selenium (localhost)
+WebMock.disable_net_connect!(allow_localhost: true, allow: driver_hosts)


### PR DESCRIPTION
Introduce the [webdrivers](https://github.com/titusfortner/webdrivers) gem to improve the developer experience. It should spare everyone having to install Chromedriver manually.