### PR TITLE
Limit the highest momentjs-rails version to 2.20.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
+      momentjs-rails (>= 2.8, <= 2.20.1)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
 

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
-  s.add_dependency "momentjs-rails", "~> 2.8"
+  s.add_dependency "momentjs-rails", ">= 2.8", "<= 2.20.1"
   s.add_dependency "sassc-rails", "~> 2.1"
   s.add_dependency "selectize-rails", "~> 0.6"
 


### PR DESCRIPTION
v2.29.1 causes "export declarations may only appear at top level of a
module" error.

See https://github.com/derekprior/momentjs-rails/issues/61.