### PR TITLE
Update browsers used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,15 @@
 ---
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.2.3
+
 commands:
   shared_steps:
     steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+
       - checkout
 
       # Install bundler
@@ -48,7 +54,7 @@ jobs:
   ruby-26:
     <<: *default_job
     docker:
-      - image: circleci/ruby:2.6.3-node-browsers-legacy
+      - image: circleci/ruby:2.6.3
         environment:
           PGHOST: localhost
           PGUSER: administrate
@@ -62,7 +68,7 @@ jobs:
   ruby-27:
     <<: *default_job
     docker:
-      - image: circleci/ruby:2.7-node-browsers-legacy
+      - image: circleci/ruby:2.7
         environment:
           PGHOST: localhost
           PGUSER: administrate


### PR DESCRIPTION
Using a Ruby container with browsers tacked on appears to be a semi-deprecated practice at CircleCI. For one, it gives us an old version of Chromedriver (76.x) with Ruby 2.6 (but an updated one with Ruby 2.7). This is not representative of the market at the moment, so should be updated.