### PR TITLE
Hide link if user is not authorized to access resource

### DIFF
--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -16,7 +16,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.associated_class) %>
+  <% if valid_action?(:show, field.associated_class) && show_action?(:show, field.associated_class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -16,7 +16,7 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <% if valid_action?(:show, field.associated_class) %>
+  <% if valid_action?(:show, field.associated_class) && show_action?(:show, field.associated_class) %>
     <%= link_to(
       field.display_associated_resource,
       [namespace, field.data],

--- a/spec/administrate/views/fields/belongs_to/_index_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_index_spec.rb
@@ -15,15 +15,27 @@ describe "fields/belongs_to/_index", type: :view do
   end
 
   context "if associated resource has a show route" do
-    it "displays link" do
-      allow(view).to receive(:valid_action?).and_return(true)
-      render_belongs_to_index
-      expect(rendered.strip).to include(link)
+    context "and the user has permission to access it" do
+      it "displays link" do
+        allow(view).to receive(:valid_action?).and_return(true)
+        allow(view).to receive(:show_action?).and_return(true)
+        render_belongs_to_index
+        expect(rendered.strip).to include(link)
+      end
+    end
+
+    context "and the user does not have permission to access it" do
+      it "hides link" do
+        allow(view).to receive(:valid_action?).and_return(true)
+        allow(view).to receive(:show_action?).and_return(false)
+        render_belongs_to_index
+        expect(rendered.strip).to_not include(link)
+      end
     end
   end
 
   context "if associated resource has no show route" do
-    it "displays link" do
+    it "hides link" do
       allow(view).to receive(:valid_action?).and_return(false)
       render_belongs_to_index
       expect(rendered.strip).to_not include(link)

--- a/spec/administrate/views/fields/belongs_to/_show_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_show_spec.rb
@@ -15,15 +15,27 @@ describe "fields/belongs_to/_show", type: :view do
   end
 
   context "if associated resource has a show route" do
-    it "displays link" do
-      allow(view).to receive(:valid_action?).and_return(true)
-      render_belongs_to_show
-      expect(rendered.strip).to include(link)
+    context "and the user has permission to access it" do
+      it "displays link" do
+        allow(view).to receive(:valid_action?).and_return(true)
+        allow(view).to receive(:show_action?).and_return(true)
+        render_belongs_to_show
+        expect(rendered.strip).to include(link)
+      end
+    end
+
+    context "and the user does not have permission to access it" do
+      it "hides link" do
+        allow(view).to receive(:valid_action?).and_return(true)
+        allow(view).to receive(:show_action?).and_return(false)
+        render_belongs_to_show
+        expect(rendered.strip).to_not include(link)
+      end
     end
   end
 
   context "if associated resource has no show route" do
-    it "displays link" do
+    it "hides link" do
       allow(view).to receive(:valid_action?).and_return(false)
       render_belongs_to_show
       expect(rendered.strip).to_not include(link)


### PR DESCRIPTION
When using pundit we should not display links to associated resources unless the user has access to those resources.