### PR TITLE
WIP: Test in all currently supported Ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,39 @@ jobs:
           POSTGRES_DB: ruby27
           POSTGRES_PASSWORD: ""
 
+  ruby-30:
+    <<: *default_job
+    docker:
+      - image: circleci/ruby:3.0-node-browsers-legacy
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:10.1-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby30
+          POSTGRES_PASSWORD: ""
+
+  ruby-31:
+    <<: *default_job
+    docker:
+      - image: circleci/ruby:3.1-node-browsers-legacy
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:10.1-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby31
+          POSTGRES_PASSWORD: ""
+
 workflows:
   version: 2
   multiple-rubies:
     jobs:
-      - ruby-27
       - ruby-26
+      - ruby-27
+      - ruby-30
+      - ruby-31


### PR DESCRIPTION
As it says on the tin. List taken from https://en.wikipedia.org/wiki/Ruby_(programming_language)#Table_of_versions

I thought that in preparation for supporting Rails 7 we should also update the list of tested rubies. Interestingly, Rails 7 requires 2.7+, but 2.6 is not deprecated just yet (will be soon on 2021-04-05).