### PR TITLE
Use `camelize` rather than `classify` when supplying a namespace

### DIFF
--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -1,5 +1,5 @@
-module <%= namespace.to_s.classify %>
-  class <%= class_name.pluralize %>Controller < <%= namespace.to_s.classify %>::ApplicationController
+module <%= namespace.to_s.camelize %>
+  class <%= class_name.pluralize %>Controller < <%= namespace.to_s.camelize %>::ApplicationController
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/lib/generators/administrate/install/templates/application_controller.rb.erb
+++ b/lib/generators/administrate/install/templates/application_controller.rb.erb
@@ -4,7 +4,7 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-module <%= namespace.classify %>
+module <%= namespace.camelize %>
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 


### PR DESCRIPTION
`classify` will singularise a namespace, and that feels like unintended behaviour. E.g. if I use `--namespace=operations`, with `classify`, the generated module name is `Operation`, but I would expect this to be `Operations`.

Swapping `classify` for `camelize` solves this issue for me, but this may not be what you intended with this, so no problem if this isn't relevant.

Thanks for a great gem!