### PR TITLE
Handle Selenium "options" deprecation

### DIFF
--- a/spec/support/webdrivers.rb
+++ b/spec/support/webdrivers.rb
@@ -5,19 +5,16 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.headless!
+  options.add_argument "--window-size=1680,1050"
+  options.add_argument "--disable-gpu"
+  options.add_argument "--disable-dev-shm-usage"
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(
-      "goog:chromeOptions" => {
-        "args" => [
-          "window-size=1680,1050",
-          "headless",
-          "disable-gpu",
-          "disable-dev-shm-usage",
-        ],
-      },
-    ),
+    capabilities: [options],
   )
 end
 


### PR DESCRIPTION
Silences this warning while running "bundle exec rspec":

    WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for
    driver initialization is deprecated. Use :capabilities with an Array of
    value capabilities/options if necessary instead.