### PR TITLE
Add "webrick" to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,7 @@ DEPENDENCIES
   uglifier
   unicorn
   webmock
+  webrick
   xpath (= 3.2.0)
   yard
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -36,6 +36,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -36,6 +36,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 


### PR DESCRIPTION
As of Ruby 3.0 webrick is no longer part of the Ruby standard library:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

Adding it for Ruby 2 in the "test" section should be fine also.

A recent update happened to add webrick to the Gemfile.lock indirectly, when
"yard" was updated since the new version of yard requires webrick. But it's
probably worth adding webrick to the Gemfile explicitly since we depend on it
for tests, not just for yard.