### PR TITLE
Remove "rspec-rails" from gemspec

### DIFF
--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "~> 2.1"
   s.add_dependency "selectize-rails", "~> 0.6"
 
-  s.add_development_dependency "rspec-rails"
-
   s.description = <<-DESCRIPTION
 Administrate is heavily inspired by projects like Rails Admin and ActiveAdmin,
 but aims to provide a better user experience for site admins,


### PR DESCRIPTION
"rspec-rails" is already declared in the "test" section of the Gemfile.

This was generating this Bundler warning:

    Your Gemfile lists the gem rspec-rails (>= 0) more than once.
    You should probably keep only one of them.
    Remove any duplicate entries and specify the gem only once.
    While it's not a problem now, it could cause errors if you change the
    version of one of them later.