### PR TITLE
Un-pin capybara gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.36.0"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ DEPENDENCIES
   awesome_print
   bundler-audit
   byebug
-  capybara (= 3.36.0)
+  capybara
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.35.3"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.35.3"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.35.3"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -28,7 +28,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.35.3"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -28,7 +28,7 @@ end
 
 group :test do
   gem "ammeter"
-  gem "capybara", "3.35.3"
+  gem "capybara"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"


### PR DESCRIPTION
Several years ago in #1245 `capybara` was pinned with this message:

> Pin the capybara gem, until we can drop Ruby 2.2.0
> Any capybara versions above 3.0.0 require a newer Ruby than 2.2.0, which
> we will support in line with Rails requirements.

Ruby 2.2 support has been dropped, so I think we can drop the pinning now?

It doesn't really do much at this point anyway since dependabot is automatically
updating to the lastest versions soon after they are released.

Note: Merging this will probably generate some conflicts for #2118, or vice versa.
If one of the PRs gets merged I'll update the other.