### PR TITLE
Fix rspec invocation in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
       - run: bundle exec rake db:setup
 
       # Run the tests
-      - run: bundle exec rake
+      - run: bundle exec rspec
 
 default_job: &default_job
   working_directory: ~/administrate
@@ -42,7 +42,7 @@ default_job: &default_job
     - shared_steps
     # Run the tests against multiple versions of Rails
     - run: bundle exec appraisal install
-    - run: bundle exec appraisal rake
+    - run: bundle exec appraisal rspec
 
 jobs:
   ruby-26:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ commands:
       # Run the tests
       - run: bundle exec rspec
 
+      # Check vulnerabilities
+      - run: bundle exec rake bundler:audit
+
 default_job: &default_job
   working_directory: ~/administrate
   steps:


### PR DESCRIPTION
The tests weren't actually running for Rails >= v6. Only the "bundler:audit" task was.

E.g. see the output and the test time (only 3s) in [this CircleCI run](https://app.circleci.com/pipelines/github/thoughtbot/administrate/1604/workflows/b1c92739-9bd6-4746-8200-ee0d42c64aaa/jobs/8676):

![image](https://user-images.githubusercontent.com/23050/150435125-b1e25d36-507d-41d1-8e9a-6592c865275b.png)

See also the `bundle exec appraisal rake` part of that same test run. The tests only ran for Rails < v6.