### PR TITLE
Add Ruby 3 to Circle tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,30 @@ jobs:
           POSTGRES_DB: ruby27
           POSTGRES_PASSWORD: ""
 
+  ruby-30:
+    <<: *default_job
+    steps:
+      - shared_steps
+      # Run the tests against the versions of Rails that support Ruby 3
+      - run: bundle exec appraisal install
+      - run: bundle exec appraisal rails60 rspec
+      - run: bundle exec appraisal rails61 rspec
+    docker:
+      - image: circleci/ruby:3.0
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:10.1-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby30
+          POSTGRES_PASSWORD: ""
+
 workflows:
   version: 2
   multiple-rubies:
     jobs:
+      - ruby-30
       - ruby-27
       - ruby-26


### PR DESCRIPTION
Start testing the code on Ruby 3, without making it the default yet.

If we get to a point where there are gem conflicts for `ruby5x` that won't even _install_ under Ruby 3 then we'd need to do something more complex, but this should work for now I think, and get Ruby 3 under test coverage at least?

Notes:

- We have to exclude Rails < 6.0 in `.circleci/config.yml` when running tests on Ruby 3, since only Rails 6 and above support Ruby 3.
- ✅ ~~**This won't actually _run_ any of the rspec tests on Ruby 3 until https://github.com/thoughtbot/administrate/pull/2125 is merged**, since the tests aren't currently actually running on Circle for Rails >= 6 and Ruby 3 only runs on Rails >= 6.~~
