### PR TITLE
Update front_matter_parser gem from 1.0.0 to 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       activesupport
       capybara
       i18n
-    front_matter_parser (1.0.0)
+    front_matter_parser (1.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)


### PR DESCRIPTION
Update "front_matter_parser" to be compatible with Psych 4. Psych 4 is the
version included in Ruby 3.1.
See https://github.com/waiting-for-dev/front_matter_parser/pull/11.

"front_matter_parser" was explicitly locked at 1.0.0 in Administrate in #2023
to avoid an incompatibility with Ruby 2.5.

Then it was unlocked in #2027 when support for Ruby 2.5 was dropped.

However, front_matter_parser was also dependabot-ignored in https://github.com/thoughtbot/administrate/pull/2021#issuecomment-886107091,
and I think it was never un-ignored, so dependabot hasn't suggested an upgrade.

I believe if we update it via this PR then dependabot will automatically start
monitoring it again.