### PR TITLE
Add Ruby 3.1 to Circle tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.2.4
 
 commands:
   shared_steps:
@@ -86,7 +86,7 @@ jobs:
     <<: *default_job
     steps:
       - shared_steps
-      # Run the tests against the versions of Rails that support Ruby 3
+      # Run the tests against the versions of Rails that support Ruby 3.0
       - run: bundle exec appraisal install
       - run: bundle exec appraisal rails60 rspec
       - run: bundle exec appraisal rails61 rspec
@@ -102,10 +102,30 @@ jobs:
           POSTGRES_DB: ruby30
           POSTGRES_PASSWORD: ""
 
+  ruby-31:
+    <<: *default_job
+    steps:
+      - shared_steps
+      # Run the tests against the versions of Rails that support Ruby 3.1
+      - run: bundle exec appraisal install
+      - run: bundle exec appraisal rails61 rspec
+    docker:
+      - image: cimg/ruby:3.1-browsers
+        environment:
+          PGHOST: localhost
+          PGUSER: administrate
+          RAILS_ENV: test
+      - image: postgres:10.1-alpine
+        environment:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: ruby31
+          POSTGRES_PASSWORD: ""
+
 workflows:
   version: 2
   multiple-rubies:
     jobs:
+      - ruby-31
       - ruby-30
       - ruby-27
       - ruby-26

--- a/spec/example_app/config/secrets.yml
+++ b/spec/example_app/config/secrets.yml
@@ -1,15 +1,11 @@
-default: &default
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-
 development:
-  <<: *default
   secret_key_base: 1a022e4f335d24af3d6bd622b9daef5a44808afbe16d4f1c8bed03675ab91ecd9c76ddc1a30f3fbb668b02c00abcba2ecc3714c95943b8f4af86289a2a46d5e1
 
 test:
   secret_key_base: test_secret
 
 staging:
-  <<: *default
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 production:
-  <<: *default
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
This PR builds on #2127 and #2128 to add test coverage for Ruby 3.1.
~~i.e.: **Ignore the first 2 commits in this PR.**~~ (update: Those PRs were merged and I've rebased this)

A couple things:

- Remove usage of YAML aliases in the test `example_app` to work around a Psych 4 incompatibility with Rails 6. (See the commit message on that commit for more details).
- Add Circle configs for testing Ruby 3.1, and limit it to testing Rails 6.1. I don't think Rails 6.0 is compatible with Ruby 3.1 (e.g. see [here](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html)) and I was seeing some test failures that seemed to confirm that, iirc.  When Rails 7 test coverage is added then Ruby 3.1 can cover that as well of course.
- This uses CircleCI's new `cimg/ruby` docker image, which replaces the old `circleci/ruby` docker image, because the Ruby 3.1 hasn't been added to the latter and it sounds like it won't be. We could probably update everything to `cimg/ruby` if we want. Or we could test it out a bit on Ruby 3.1 for a while first.

Does that all seem reasonable?

