### PR TITLE
Add Rails 7 to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,15 +47,19 @@ commands:
 
 default_job: &default_job
   working_directory: ~/administrate
-  steps:
-    - shared_steps
-    # Run the tests against multiple versions of Rails
-    - run: bundle exec appraisal install
-    - run: bundle exec appraisal rspec
 
 jobs:
   ruby-26:
     <<: *default_job
+    steps:
+      - shared_steps
+      # Run the tests against the versions of Rails that support Ruby 2.6
+      - run: bundle exec appraisal install
+      - run: bundle exec appraisal rails50 rspec
+      - run: bundle exec appraisal rails51 rspec
+      - run: bundle exec appraisal rails52 rspec
+      - run: bundle exec appraisal rails60 rspec
+      - run: bundle exec appraisal rails61 rspec
     docker:
       - image: circleci/ruby:2.6.3
         environment:
@@ -70,6 +74,16 @@ jobs:
 
   ruby-27:
     <<: *default_job
+    steps:
+      - shared_steps
+      # Run the tests against the versions of Rails that support Ruby 2.7
+      - run: bundle exec appraisal install
+      - run: bundle exec appraisal rails50 rspec
+      - run: bundle exec appraisal rails51 rspec
+      - run: bundle exec appraisal rails52 rspec
+      - run: bundle exec appraisal rails60 rspec
+      - run: bundle exec appraisal rails61 rspec
+      - run: bundle exec appraisal rails70 rspec
     docker:
       - image: circleci/ruby:2.7
         environment:
@@ -90,6 +104,7 @@ jobs:
       - run: bundle exec appraisal install
       - run: bundle exec appraisal rails60 rspec
       - run: bundle exec appraisal rails61 rspec
+      - run: bundle exec appraisal rails70 rspec
     docker:
       - image: circleci/ruby:3.0
         environment:
@@ -109,6 +124,7 @@ jobs:
       # Run the tests against the versions of Rails that support Ruby 3.1
       - run: bundle exec appraisal install
       - run: bundle exec appraisal rails61 rspec
+      - run: bundle exec appraisal rails70 rspec
     docker:
       - image: cimg/ruby:3.1-browsers
         environment:

--- a/Appraisals
+++ b/Appraisals
@@ -37,3 +37,7 @@ end
 appraise "rails61" do
   gem "rails", "~> 6.1"
 end
+
+appraise "rails70" do
+  gem "rails", "~> 6.1"
+end


### PR DESCRIPTION
And refactor ".circleci/config" a bit.  With all the current variations & limitations it seems like it's probably better to just list
the supported configurations explicitly rather than trying to share config blocks.

**NOTE**: I haven't actually tried running administrate on a Rails 7 app! But I intend to upgrade to Rails 7 and I saw that tests pass for it here so I thought it'd be worth opening a PR at least.