### PR TITLE
Provide a stylelint config that we can tweak

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -3,3 +3,5 @@ ruby:
 scss:
   enabled: true
   config_file: .scss-lint.yml
+stylelint:
+  config_file: .stylelintrc.json

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@thoughtbot/stylelint-config"
+}


### PR DESCRIPTION
Over at https://github.com/thoughtbot/administrate/pull/2116, Hound is being very noisy about automatically-generated CSS that we can't control.

It looked like the issue could be scss-lint, which is specifically configured in `.hound.yml`. However I looked up the warning messages and actually they come from stylelint. I have no idea of what configuration of stylelint is being used, but I figured that we can import thoughtbot's one as a baseline. So here it is. Now we have a way to explicitly tell Hound to be silent about specific files.