### PR TITLE
Use `field.name` rather than `field.nested_form.resource_name` for `Field::HasOne` labels

### DIFF
--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -18,7 +18,7 @@ The form will be rendered as nested_from to parent relationship.
 
 <%= f.fields_for field.attribute, field.data || field.nested_form.resource.class.new do |has_one_f| %>
   <fieldset class="field-unit--nested">
-    <legend><%= t "helpers.label.#{f.object_name}.#{field.nested_form.resource_name}", default: field.nested_form.resource_name.titleize %></legend>
+    <legend><%= t "helpers.label.#{f.object_name}.#{field.name}", default: field.name.titleize %></legend>
     <% field.nested_form.attributes.each do |attribute| -%>
       <div class="field-unit field-unit--<%= attribute.html_class %>">
         <%= render_field attribute, f: has_one_f %>

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -8,6 +8,7 @@ describe "fields/has_one/_form", type: :view do
       attribute: "Meta",
       data: nil,
       nested_form: nested_form,
+      name: "product_tag"
     )
 
     render(

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -8,7 +8,7 @@ describe "fields/has_one/_form", type: :view do
       attribute: "Meta",
       data: nil,
       nested_form: nested_form,
-      name: "product_tag"
+      name: "product_tag",
     )
 
     render(


### PR DESCRIPTION
If a model has multiple has_one relationships to the same model (e.g. two has_one associations with different scopes), we can't override the field label for the two associations, we can only change the translation for both at the same time, as the translation is based on the associated class name, not the association name.

This change uses the association name as the lookup field and default value for the label for has_one relationships, allowing multiple relations to the same class to have their own translated labels.

This is a potential breaking change for apps that have set a translation label based on the class name, but have a custom-named association (e.g. if a model has the association `:external_user` pointing to a `User` class, the translated label would be listed under `user` and would need to be changed to `external_user`.