### PR TITLE
Call .selectize() on all select fields

### DIFF
--- a/app/assets/javascripts/administrate/components/associative.js
+++ b/app/assets/javascripts/administrate/components/associative.js
@@ -1,5 +1,3 @@
 $(function() {
-  $('.field-unit--belongs-to select').selectize({});
-  $(".field-unit--has-many select").selectize({});
-  $('.field-unit--polymorphic select').selectize({});
+  $('.field-unit select').selectize({});
 });

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -40,7 +40,8 @@ describe "customer edit page" do
     customer = create(:customer, kind: :standard)
 
     visit edit_admin_customer_path(customer)
-    select "vip", from: "Kind"
+    find("#customer_kind-selectized").click
+    find(".option", text: "vip").click
     click_on "Update Customer"
 
     expect(page).to have_text("KIND")


### PR DESCRIPTION
This enables using selectize with custom fields that inherit from `Administrate::Field::Select` without having to declare them in `associative.js`. 