### PR TITLE
Change ApplicationController's routes's class to Set to speed up "valid_action?"

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -107,13 +107,11 @@ module Administrate
 
     helper_method :valid_action?
     def valid_action?(name, resource = resource_class)
-      !!routes.detect do |controller, action|
-        controller == resource.to_s.underscore.pluralize && action == name.to_s
-      end
+      routes.include?([resource.to_s.underscore.pluralize, name.to_s])
     end
 
     def routes
-      @routes ||= Namespace.new(namespace).routes
+      @routes ||= Namespace.new(namespace).routes.to_set
     end
 
     def records_per_page


### PR DESCRIPTION
I changed ApplicationController's routes's class to Set to speed up `valid_action?`.

Let `N` be number of routes.
`valid_action?` checks all routes in current version. So the time complexity is `O(N)` .
When we store `routes` as Set, the time complexity is `O(log N)` .

My application has hundreds of routes. `valid_action?` took a long time.