### PR TITLE
Consistent custom dashboards

### DIFF
--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -26,7 +26,7 @@ module Administrate
 
     def model_from_resource(resource_name)
       dashboard = dashboard_from_resource(resource_name)
-      dashboard.try(:model) || resource_name.to_sym
+      dashboard.try(:model) || resource_name.singularize.to_sym
     end
 
     def display_resource_name(resource_name, opts = {})

--- a/docs/adding_controllers_without_related_model.md
+++ b/docs/adding_controllers_without_related_model.md
@@ -9,7 +9,7 @@ To do that, you must define an `index` route, as only controllers with index
 routes are displayed in the sidebar and then add a custom dashboard:
 
 ```erb
-# app/views/admin/stats/index.html.erb 
+# app/views/admin/stats/index.html.erb
 
 <div style="padding: 20px">
   <h1>Stats</h1>
@@ -25,7 +25,7 @@ routes are displayed in the sidebar and then add a custom dashboard:
 require "administrate/custom_dashboard"
 
 class StatDashboard < Administrate::CustomDashboard
-  resource "Stats" # used by administrate in the views
+  resource "Stat" # used by administrate in the views
 end
 ```
 

--- a/docs/adding_controllers_without_related_model.md
+++ b/docs/adding_controllers_without_related_model.md
@@ -11,11 +11,10 @@ routes are displayed in the sidebar and then add a custom dashboard:
 ```erb
 # app/views/admin/stats/index.html.erb
 
-<div style="padding: 20px">
+<div>
   <h1>Stats</h1>
   <br>
   <p><b>Total Customers:</b> <%= @stats[:customer_count] %></p>
-  <br>
   <p><b>Total Orders:</b> <%= @stats[:order_count] %></p>
 </div>
 ```

--- a/docs/adding_controllers_without_related_model.md
+++ b/docs/adding_controllers_without_related_model.md
@@ -6,7 +6,7 @@ Sometimes you may want to add a custom controller that has no resource
 related to it (for example for a statistics page).
 
 To do that, you must define an `index` route, as only controllers with index
-routes are displayed in the sidebar and then add a custom dashboard:
+routes are displayed in the sidebar, and then add a custom dashboard:
 
 ```erb
 # app/views/admin/stats/index.html.erb

--- a/lib/administrate/custom_dashboard.rb
+++ b/lib/administrate/custom_dashboard.rb
@@ -4,11 +4,11 @@ module Administrate
 
     class << self
       def resource_name(_opts)
-        named_resource.pluralize.titleize
+        @named_resource.pluralize.titleize
       end
 
       def resource(resource_name)
-        define_singleton_method(:named_resource) { resource_name }
+        @named_resource = resource_name
       end
     end
   end

--- a/spec/example_app/app/dashboards/stat_dashboard.rb
+++ b/spec/example_app/app/dashboards/stat_dashboard.rb
@@ -1,5 +1,5 @@
 require "administrate/custom_dashboard"
 
 class StatDashboard < Administrate::CustomDashboard
-  resource "Stats"
+  resource "Stat"
 end

--- a/spec/example_app/app/policies/stat_policy.rb
+++ b/spec/example_app/app/policies/stat_policy.rb
@@ -1,0 +1,2 @@
+class StatPolicy < ApplicationPolicy
+end

--- a/spec/example_app/app/policies/stats_policy.rb
+++ b/spec/example_app/app/policies/stats_policy.rb
@@ -1,2 +1,0 @@
-class StatsPolicy < ApplicationPolicy
-end

--- a/spec/example_app/app/views/admin/stats/index.html.erb
+++ b/spec/example_app/app/views/admin/stats/index.html.erb
@@ -1,7 +1,6 @@
 <div style="padding: 20px">
   <h1>Stats</h1>
   <br>
-  <p><b>Total Customers:</b> <%= @stats[:customer_count] %></h1>
-  <br>
-  <p><b>Total Orders:</b> <%= @stats[:order_count] %></h1>
+  <p><b>Total Customers:</b> <%= @stats[:customer_count] %></p>
+  <p><b>Total Orders:</b> <%= @stats[:order_count] %></p>
 </div>


### PR DESCRIPTION
Working on https://github.com/thoughtbot/administrate/pull/1941, I noticed that model-less dashboards (also known as "custom dashboards") do not behave very consistently. Eventually I found myself having to fix this before I could work on the former PR.

There are some twists and turns in the code that handles them:

1. There doesn't seem to be a way to have the navigation show a singular name for the dashboard. So for instance in the example app we have "Stats", but I couldn't create one with the name "Home".
2. When used with Punditize, it requires the policy to use a plural name (`HomesPolicy`) instead of singular like for any other resource.
3. The example `StatsDashboard` declares `resource "Stats"`, which is a weird mix of singular and plural (in the end it doesn't seem to matter which one you use here).
4. Internally this complicates things when working with authorization.

This PR introduces consistency, not fixing point 1 but at least addressing the other points and allowing me to proceed with my work at #1941. Original I was going to bundle it as part of the larger PR, but I thought it deserved scrutiny enough to have its own one.

As for the issue with singular names, this looks like a larger problem that should be looked into with more time, and it's probably related to how we currently can't generate dashboards for singular resources.