### PR TITLE
Correct grammar on German error messages

### DIFF
--- a/config/locales/administrate.de.yml
+++ b/config/locales/administrate.de.yml
@@ -21,8 +21,8 @@ de:
         more: "%{count} von %{total_count}"
         none: Keine
     form:
-      error: error
-      errors: "%{pluralized_errors} haben das Speichern dieses %{resource_name} verhindert:"
+      error: Fehler
+      errors: "%{resource_name} konnte nicht gespeichert werden, es gab %{pluralized_errors}."
     navigation:
       back_to_app: Zurück zur App
     search:


### PR DESCRIPTION
There are two changes, the first is simply adding a translation for the word 'error'.
The second improves on the grammar for notifying the user of errors.

The string "%{pluralized_errors} haben das Speichern dieses %{resource_name} verhindert:" is not always grammatically correct. That would depend on the amount of errors. The word "haben" has a singular and a plural form. The singular, for one error, needs to be "hat".
Also the `resource_name` would need to have a different grammatical case => "Genitiv".

To prevent adding logic to solve this, I rewrote the sentence to be simpler and always fit.