### PR TITLE
Drop support for Ruby 2.6, which reached EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,29 +49,6 @@ default_job: &default_job
   working_directory: ~/administrate
 
 jobs:
-  ruby-26:
-    <<: *default_job
-    steps:
-      - shared_steps
-      # Run the tests against the versions of Rails that support Ruby 2.6
-      - run: bundle exec appraisal install
-      - run: bundle exec appraisal rails50 rspec
-      - run: bundle exec appraisal rails51 rspec
-      - run: bundle exec appraisal rails52 rspec
-      - run: bundle exec appraisal rails60 rspec
-      - run: bundle exec appraisal rails61 rspec
-    docker:
-      - image: circleci/ruby:2.6.3
-        environment:
-          PGHOST: localhost
-          PGUSER: administrate
-          RAILS_ENV: test
-      - image: postgres:10.1-alpine
-        environment:
-          POSTGRES_USER: administrate
-          POSTGRES_DB: ruby26
-          POSTGRES_PASSWORD: ""
-
   ruby-27:
     <<: *default_job
     steps:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@ title: Getting Started
 ---
 
 Administrate is released as a Ruby gem, and can be installed on Rails
-applications version 5.0 or greater. We support Ruby 2.6 and up.
+applications version 5.0 or greater. We support Ruby 2.7 and up.
 
 First, add the following to your Gemfile:
 


### PR DESCRIPTION
More importantly, the latest Capybara doesn't support Ruby 2.6, and builds are failing.

Argh, it looks like it's my fault: I merged the Capybara update yesterday without realising that the build was failing.