### PR TITLE
Dart-sass compatibility

### DIFF
--- a/app/assets/stylesheets/administrate/base/_forms.scss
+++ b/app/assets/stylesheets/administrate/base/_forms.scss
@@ -85,7 +85,7 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: $small-spacing * 0.5;
 }
 
 [type="file"] {

--- a/app/assets/stylesheets/administrate/components/_flashes.scss
+++ b/app/assets/stylesheets/administrate/components/_flashes.scss
@@ -3,8 +3,8 @@
     background-color: $color;
     color: mix($black, $color, 60%);
     display: block;
-    margin-bottom: $base-spacing / 2;
-    padding: $base-spacing / 2;
+    margin-bottom: $base-spacing * 0.5;
+    padding: $base-spacing * 0.5;
     text-align: center;
 
     a {

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -14,7 +14,7 @@ $heading-line-height: 1.2 !default;
 // Other Sizes
 $base-border-radius: 4px !default;
 $base-spacing: $base-line-height * 1em !default;
-$small-spacing: $base-spacing / 2 !default;
+$small-spacing: $base-spacing * 0.5 !default;
 
 // Colors
 $white: #fff !default;


### PR DESCRIPTION
When updating to dartsass-rails (to replace the deprecated sassc-rails), and get my hands on some SCSS module hawtness, SASS issues deprecation warnings that look like this:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($base-spacing, 2) or calc($base-spacing / 2)
```

The easy fix, while maintaining backwards compatibility, is multiply by 0.5 instead of dividing by two -- that syntax works effectively in dart-sass as well as sassc.