### PR TITLE
Has one translations

### DIFF
--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -28,7 +28,7 @@ All show page attributes of has_one relationship would be rendered
       <div>
       <dt class="attribute-label">
         <%= t(
-          "helpers.label.#{resource_name}.#{attribute.name}",
+          "helpers.label.#{field.associated_class_name.underscore}.#{attribute.name}",
           default: attribute.name.titleize,
         ) %>
       </dt>

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -31,12 +31,6 @@ module Administrate
         end
       end
 
-      private
-
-      def associated_dashboard
-        "#{associated_class_name}Dashboard".constantize.new
-      end
-
       def associated_class_name
         if option_given?(:class_name)
           deprecated_option(:class_name)
@@ -46,6 +40,12 @@ module Administrate
             attribute,
           )
         end
+      end
+
+      private
+
+      def associated_dashboard
+        "#{associated_class_name}Dashboard".constantize.new
       end
 
       def primary_key

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -3,10 +3,12 @@ require "administrate/field/has_one"
 
 describe "fields/has_one/_show", type: :view do
   before do
+    view.extend Administrate::ApplicationHelper
     allow(view).to receive(:accessible_action?).and_return(true)
+    allow(view).to receive(:namespace).and_return(:admin)
   end
 
-  context "without an associated record" do
+  context "without a persisted record" do
     it "displays nothing" do
       has_one = Administrate::Field::HasOne.new(
         :product_meta_tag,
@@ -23,124 +25,156 @@ describe "fields/has_one/_show", type: :view do
     end
   end
 
-  context "with an associated record" do
+  context "with a persisted record" do
+    before do
+      field_resource = create(:product_meta_tag)
+      @path_to_field_resource = polymorphic_path([:admin, field_resource])
+
+      nested_simple_field = instance_double(
+        "Administrate::Field::String",
+        name: "simple_string_field",
+        truncate: "string value",
+        html_class: "string",
+        to_partial_path: "fields/string/index",
+      )
+
+      nested_show_page_for_has_one = instance_double(
+        "Administrate::Page::Show",
+        resource: double(
+          class: ProductMetaTag,
+        ),
+        attributes: [
+          nested_simple_field,
+        ],
+      )
+
+      @has_one_field = instance_double(
+        "Administrate::Field::HasOne",
+        display_associated_resource: "The Nested Resource",
+        data: field_resource,
+        linkable?: true,
+        nested_show: nested_show_page_for_has_one,
+        associated_class_name: "NestedHasOne",
+      )
+
+      @page_double = instance_double("Administrate::Page::Show")
+    end
+
+    def render_field
+      render(
+        partial: "fields/has_one/show",
+        locals: {
+          field: @has_one_field,
+          page: @page_double,
+          resource_name: "parent_resource",
+        },
+      )
+    end
+
+    it "uses the correct labels for fields" do
+      I18n.backend.translations(do_init: true)[:en].deep_merge!(
+        helpers: {
+          label: {
+            nested_has_one: {
+              simple_string_field: "Just a Simple String",
+            },
+          },
+        },
+      )
+
+      render_field
+      expect(rendered.strip).to include("Just a Simple String")
+    end
+
     context "when linking the record is allowed" do
       it "renders a link to the record" do
-        product = create(:product)
-        product_path = polymorphic_path([:admin, product])
-        nested_show = instance_double(
-          "Administrate::Page::Show",
-          resource: double(
-            class: ProductMetaTag,
-          ),
-          attributes: [],
-          resource_name: "Product Tag",
-        )
-        has_one = instance_double(
-          "Administrate::Field::HasOne",
-          display_associated_resource: product.name,
-          data: product,
-          linkable?: true,
-          nested_show: nested_show,
-        )
-
-        render(
-          partial: "fields/has_one/show",
-          locals: {
-            field: has_one,
-            namespace: :admin,
-            resource_name: "product_meta_tag",
-          },
-        )
-
-        link = "<a href=\"#{product_path}\">#{product.name}</a>"
+        render_field
+        link = "<a href=\"#{@path_to_field_resource}\">The Nested Resource</a>"
         expect(rendered.strip).to include(link)
-      end
-
-      it "renders nested attribute relationships" do
-        view.extend Administrate::ApplicationHelper
-
-        product = create(:product)
-        page = create(:page, product: product)
-
-        nested_has_many = instance_double(
-          "Administrate::Field::HasMany",
-          associated_collection: [page],
-          attribute: :page,
-          data: [page],
-          resources: [page],
-          html_class: "has-many",
-          name: "Page",
-          to_partial_path: "fields/has_many/index",
-          order_from_params: {},
-        )
-
-        nested_show = instance_double(
-          "Administrate::Page::Show",
-          resource: double(
-            class: ProductMetaTag,
-          ),
-          attributes: [nested_has_many],
-          resource_name: "Product Tag",
-        )
-
-        has_one = instance_double(
-          "Administrate::Field::HasOne",
-          display_associated_resource: product.name,
-          data: product,
-          linkable?: true,
-          nested_show: nested_show,
-        )
-
-        page_double = instance_double("Administrate::Page::Show")
-
-        render(
-          partial: "fields/has_one/show",
-          locals: {
-            field: has_one,
-            namespace: :admin,
-            page: page_double,
-            resource_name: "product_meta_tag",
-          },
-        )
-
-        has_many_count = "1 page"
-        expect(rendered.strip).to include(has_many_count)
       end
     end
 
     context "when linking the record is not allowed" do
       it "displays the record without a link" do
         allow(view).to receive(:accessible_action?).and_return(false)
-        product = create(:product)
-        nested_show = instance_double(
-          "Administrate::Page::Show",
-          resource: double(
-            class: ProductMetaTag,
-          ),
-          attributes: [],
-          resource_name: "Product Tag",
-        )
-        has_one = instance_double(
-          "Administrate::Field::HasOne",
-          display_associated_resource: product.name,
-          data: product,
-          linkable?: true,
-          nested_show: nested_show,
-        )
-
-        render(
-          partial: "fields/has_one/show",
-          locals: {
-            field: has_one,
-            namespace: :admin,
-            resource_name: "product_meta_tag",
-          },
-        )
-
-        expect(rendered.strip).to include(product.name)
-        expect(rendered.strip).not_to include("<a ")
+        render_field
+        expect(rendered.strip).to include("The Nested Resource")
+        expect(rendered.strip).not_to include("<a")
       end
+    end
+  end
+
+  context "when there are nested associations" do
+    it "renders them" do
+      # Let's pretend that a Customer has these associations:
+      #
+      #   has_one :page # The "nested_resource"
+      #   has_many :payments # The "nested_collection"
+      #
+      # Here we render a HasOne field (a Customer)
+      # that in turn has a HasOne and a HasMany
+      field_resource = create(:customer)
+      nested_resource = create(:page)
+      nested_collection = create_list(:payment, 2)
+
+      nested_has_many = instance_double(
+        "Administrate::Field::HasMany",
+        attribute: :payments,
+        data: nested_collection,
+        html_class: "has-many",
+        name: "payments",
+        to_partial_path: "fields/has_many/index",
+      )
+
+      nested_show_page_for_nested_has_one = instance_double(
+        "Administrate::Page::Show",
+        resource: double(
+          class: ProductMetaTag,
+        ),
+        attributes: [],
+      )
+
+      nested_has_one = instance_double(
+        "Administrate::Field::HasOne",
+        attribute: :page,
+        data: nested_resource,
+        linkable?: true,
+        nested_show: nested_show_page_for_nested_has_one,
+        html_class: "has-one",
+        to_partial_path: "fields/has_one/show",
+        display_associated_resource: "Resource Doubly Nested with HasOne",
+        name: "page",
+      )
+
+      nested_show_page_for_top_has_one = instance_double(
+        "Administrate::Page::Show",
+        attributes: [nested_has_one, nested_has_many],
+      )
+
+      has_one_field = instance_double(
+        "Administrate::Field::HasOne",
+        display_associated_resource: "Resource Nested with HasOne",
+        data: field_resource,
+        linkable?: true,
+        nested_show: nested_show_page_for_top_has_one,
+        associated_class_name: "NameOfAssociatedClass",
+      )
+
+      page_double = instance_double("Administrate::Page::Show")
+
+      render(
+        partial: "fields/has_one/show",
+        locals: {
+          field: has_one_field,
+          page: page_double,
+          resource_name: "product_meta_tag",
+        },
+      )
+
+      expect(rendered.strip).to include("Resource Nested with HasOne")
+      expect(rendered.strip).to include("Resource Doubly Nested with HasOne")
+      expect(rendered.strip).to include("Payments")
+      expect(rendered.strip).to include("2 payments")
     end
   end
 end


### PR DESCRIPTION
Fixes #2185.

The template `app/views/fields/has_one/_show.html.erb` wasn't using the correct i18n key to translate the field names of the associated record.

This PR includes a heavy revamp of `spec/administrate/views/fields/has_one/_show_spec.rb`, which needed some TLC in order to work with it.

The diff for `lib/administrate/field/associative.rb` looks a bit misleading. The actual change is that I moved the definition of `associated_class_name` to be above the `private` declaration.