### PR TITLE
Enable ordering the BelongsTo fields by using order option.

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -122,7 +122,9 @@ module Administrate
       @order ||= Administrate::Order.new(
         sorting_attribute,
         sorting_direction,
-        association_attribute: order_by_field(dashboard_attribute(sorting_attribute)),
+        association_attribute: order_by_field(
+          dashboard_attribute(sorting_attribute),
+        ),
       )
     end
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -119,7 +119,21 @@ module Administrate
     end
 
     def order
-      @order ||= Administrate::Order.new(sorting_attribute, sorting_direction)
+      @order ||= Administrate::Order.new(
+        sorting_attribute,
+        sorting_direction,
+        order_by_field(dashboard_attribute(sorting_attribute)),
+      )
+    end
+
+    def order_by_field(dashboard)
+      return unless dashboard.try(:options)
+
+      dashboard.options.fetch(:order, nil)
+    end
+
+    def dashboard_attribute(attribute)
+      dashboard.attribute_types[attribute.to_sym] if attribute
     end
 
     def sorting_attribute

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -122,7 +122,7 @@ module Administrate
       @order ||= Administrate::Order.new(
         sorting_attribute,
         sorting_direction,
-        order_by_field(dashboard_attribute(sorting_attribute)),
+        association_attribute: order_by_field(dashboard_attribute(sorting_attribute)),
       )
     end
 

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -77,8 +77,9 @@ which are specified through the `.with_options` class method:
 
 **Field::BelongsTo**
 
-`:order` - Specifies the order of the dropdown menu, can be ordered by more
-than one column. e.g.: `"name, email DESC"`.
+`:order` - Specifies the column used to order the records. It will apply both in
+the table views and in the dropdown menu on the record forms.
+You can set multiple columns as well with direction. E.g.: `"name, email DESC"`.
 
 `:scope` - Specifies a custom scope inside a callable. Useful for preloading.
 Example: `.with_options(scope: -> { MyModel.includes(:rel).limit(5) })`

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,9 +1,9 @@
 module Administrate
   class Order
-    def initialize(attribute = nil, direction = nil, field = nil)
+    def initialize(attribute = nil, direction = nil, association_attribute: nil)
       @attribute = attribute
       @direction = sanitize_direction(direction)
-      @field = field
+      @association_attribute = association_attribute
     end
 
     def apply(relation)
@@ -33,7 +33,7 @@ module Administrate
 
     private
 
-    attr_reader :attribute, :field
+    attr_reader :attribute, :association_attribute
 
     def sanitize_direction(direction)
       %w[asc desc].include?(direction.to_s) ? direction.to_sym : :asc
@@ -96,7 +96,7 @@ module Administrate
     end
 
     def order_by_attribute_query
-      "#{attribute.tableize}.#{field} #{direction}"
+      "#{attribute.tableize}.#{association_attribute} #{direction}"
     end
 
     def has_many_attribute?(relation)

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -18,10 +18,6 @@ module Administrate
       relation
     end
 
-    def column_exist?(table, column_name)
-      table.columns_hash.key?(column_name.to_s)
-    end
-
     def ordered_by?(attr)
       attr.to_s == attribute.to_s
     end
@@ -89,6 +85,10 @@ module Administrate
         column_exist?(reflect_association(relation).klass, field.to_sym)
 
       order_by_id_query(relation)
+    end
+
+    def column_exist?(table, column_name)
+      table.columns_hash.key?(column_name.to_s)
     end
 
     def order_by_id_query(relation)

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -75,7 +75,7 @@ module Administrate
     def order_by_attribute(relation)
       if ordering_by_association_column?(relation)
         relation.joins(
-          attribute.to_sym
+          attribute.to_sym,
         ).reorder(Arel.sql(order_by_attribute_query))
       else
         order_by_id(relation)
@@ -83,7 +83,10 @@ module Administrate
     end
 
     def ordering_by_association_column?(relation)
-      association_attribute && column_exist?(reflect_association(relation).klass, association_attribute.to_sym)
+      association_attribute &&
+        column_exist?(
+          reflect_association(relation).klass, association_attribute.to_sym
+        )
     end
 
     def column_exist?(table, column_name)

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -73,18 +73,17 @@ module Administrate
     end
 
     def order_by_attribute(relation)
-      return order_by_id(relation) unless field
-
-      relation.joins(
-        attribute.to_sym,
-      ).reorder(Arel.sql(form_query(relation)))
+      if ordering_by_association_column?(relation)
+        relation.joins(
+          attribute.to_sym
+        ).reorder(Arel.sql(order_by_attribute_query))
+      else
+        order_by_id(relation)
+      end
     end
 
-    def form_query(relation)
-      return order_by_attribute_query if
-        column_exist?(reflect_association(relation).klass, field.to_sym)
-
-      order_by_id_query(relation)
+    def ordering_by_association_column?(relation)
+      association_attribute && column_exist?(reflect_association(relation).klass, association_attribute.to_sym)
     end
 
     def column_exist?(table, column_name)

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -10,7 +10,7 @@ class OrderDashboard < Administrate::BaseDashboard
     address_city: Field::String,
     address_state: Field::String,
     address_zip: Field::String,
-    customer: Field::BelongsTo,
+    customer: Field::BelongsTo.with_options(order: "name"),
     line_items: Field::HasMany,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -68,4 +68,18 @@ feature "order index page" do
       "Cannot delete record because dependent payments exist", type: :error
     )
   end
+
+  scenario "user sorts by belongs_to field" do
+    create(:order, customer: create(:customer, name: "Alpha"))
+    create(:order, customer: create(:customer, name: "Charlie"))
+    create(:order, customer: create(:customer, name: "Bravo"))
+
+    visit admin_orders_path
+
+    click_on "Customer"
+    expect(page).to have_content(/Alpha.*Bravo.*Charlie/)
+
+    click_on "Customer"
+    expect(page).to have_content(/Charlie.*Bravo.*Alpha/)
+  end
 end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -154,26 +154,6 @@ describe Administrate::Order do
     end
   end
 
-  describe "#column_exist?" do
-    context "when the table has the column defined" do
-      let(:table) { double(columns_hash: { "name" => :value }) }
-      let(:column) { :name }
-
-      it "returns true" do
-        expect(described_class.new.column_exist?(table, column)).to eql(true)
-      end
-    end
-
-    context "when the table has not the column defined" do
-      let(:table) { double(columns_hash: { "name" => :value }) }
-      let(:column) { :invalid_column_name }
-
-      it "returns false" do
-        expect(described_class.new.column_exist?(table, column)).to eql(false)
-      end
-    end
-  end
-
   describe "#ordered_by?" do
     it "returns true if the order is by the given attribute" do
       order = Administrate::Order.new(:name, :desc)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -106,7 +106,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(to_sym: :user, tableize: "users"),
             nil,
-            "name",
+            association_attribute: "name",
           )
           relation = relation_with_association(
             :belongs_to,
@@ -131,7 +131,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(table_name: "users", to_sym: :user),
             nil,
-            "invalid_column_name",
+            association_attribute: "invalid_column_name",
           )
           relation = relation_with_association(
             :belongs_to,


### PR DESCRIPTION
Enable ordering the BelongsTo fields by using order option. The change let the gem users to be able to order the fields by the column they'll specify, instead of ordering by `id`.

I've also updated the query to solve the possible issues with `PG::AmbiguousColumn` errors - for now it's not handled in any way, so if the user is using the tables that use the same columns names, then the error will apear and the only way to fix that is to monkey patch the gem. To solve that, I've added the column name as the prefix for both possible forms of the query.

Based on #1215
And kinda related to #1805 the result is exactly as presented on videos attached to this task's description.