### PR TITLE
Index eager load performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Administrate
 
-[![CircleCI](https://img.shields.io/circleci/project/github/thoughtbot/administrate.svg)](https://circleci.com/gh/thoughtbot/administrate/tree/master)
+[![CircleCI](https://img.shields.io/circleci/project/github/thoughtbot/administrate.svg)](https://circleci.com/gh/thoughtbot/administrate/tree/main)
 [![Gem Version](https://badge.fury.io/rb/administrate.svg)](https://badge.fury.io/rb/administrate)
 [![Code Climate](https://codeclimate.com/github/thoughtbot/administrate/badges/gpa.svg)](https://codeclimate.com/github/thoughtbot/administrate)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -52,7 +52,7 @@ module Administrate
     end
 
     def sanitized_order_params(page, current_field_name)
-      collection_names = page.item_includes + [current_field_name]
+      collection_names = page.item_associations + [current_field_name]
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -20,4 +20,14 @@ module Administrate
       "if you think otherwise.",
     )
   end
+
+  def self.warn_of_deprecated_method(klass, method)
+    ActiveSupport::Deprecation.warn(
+      "The method #{klass}##{method} is deprecated. " +
+      "If you are seeing this message you are probably " +
+      "using a dashboard that depends explicitly on it. " +
+      "Please make sure you update it to a version that " +
+      "does not use a deprecated API"
+    )
+  end
 end

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -27,7 +27,7 @@ module Administrate
       "If you are seeing this message you are probably " +
       "using a dashboard that depends explicitly on it. " +
       "Please make sure you update it to a version that " +
-      "does not use a deprecated API"
+      "does not use a deprecated API",
     )
   end
 end

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -94,6 +94,8 @@ module Administrate
     end
 
     def item_includes
+      # Deprecated, internal usage has moved to #item_associations
+      Administrate.warn_of_deprecated_method(self.class, :item_includes)
       attribute_includes(show_page_attributes)
     end
 

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -97,6 +97,10 @@ module Administrate
       attribute_includes(show_page_attributes)
     end
 
+    def item_associations
+      attribute_associated(show_page_attributes)
+    end
+
     private
 
     def attribute_not_found_message(attr)
@@ -104,6 +108,14 @@ module Administrate
     end
 
     def attribute_includes(attributes)
+      attributes.map do |key|
+        field = attribute_type_for(key)
+
+        key if field.eager_load?
+      end.compact
+    end
+
+    def attribute_associated(attributes)
       attributes.map do |key|
         field = attribute_type_for(key)
 

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -17,7 +17,7 @@ module Administrate
       end
 
       def self.eager_load?
-        self <= BelongsTo || self <= HasOne
+        false
       end
 
       def self.searchable?

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -16,6 +16,10 @@ module Administrate
         self < Associative
       end
 
+      def self.eager_load?
+        self <= BelongsTo || self <= HasOne
+      end
+
       def self.searchable?
         false
       end

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -13,6 +13,10 @@ module Administrate
         end
       end
 
+      def self.eager_load?
+        true
+      end
+
       def permitted_attribute
         foreign_key
       end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -25,6 +25,10 @@ module Administrate
         deferred_class.associative?
       end
 
+      def eager_load?
+        deferred_class.eager_load?
+      end
+
       def searchable?
         options.fetch(:searchable, deferred_class.searchable?)
       end

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -26,6 +26,10 @@ module Administrate
         { "#{attr}_attributes": related_dashboard_attributes }
       end
 
+      def self.eager_load?
+        true
+      end
+
       def nested_form
         @nested_form ||= Administrate::Page::Form.new(
           resolver.dashboard_class.new,

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -23,6 +23,10 @@ module Administrate
         dashboard.try(:item_includes) || []
       end
 
+      def item_associations
+        dashboard.try(:item_associations) || []
+      end
+
       private
 
       def attribute_field(dashboard, resource, attribute_name, page)


### PR DESCRIPTION
Attempted fix for [Can't avoid under/overfetching](https://github.com/thoughtbot/administrate/issues/1697#)

Hey @pablobm - I took your suggestion from [point 1 here](https://github.com/thoughtbot/administrate/issues/1697#issuecomment-1004606731) and ran it a little further to get the tests passing.

- Update `attribute_includes` to restrict eager loading to BelongsTo and HasOne association fields
- Also created `item_associations` and `attribute_associated` methods with the old behaviour so that `sanitized_order_params` in ApplicationHelper still works correctly - it was needed to fix a few specs I think related to column sorting.
- No new specs, as there should be no behavioural change to users.

---

Old request logs from the test app (excluding renders):

```
Started GET "/admin/customers?search=jesus" for 127.0.0.1 at 2022-06-13 20:38:22 -0700
   (1.2ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by Admin::CustomersController#index as HTML
  Parameters: {"search"=>"jesus"}
  Customer Load (2.4ms)  SELECT "customers".* FROM "customers" LEFT OUTER JOIN "countries" ON "countries"."code" = "customers"."country_code" WHERE "customers"."hidden" = $1 AND (LOWER(CAST("customers"."email" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("customers"."name" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("customers"."kind" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("countries"."name" AS CHAR(256))) LIKE '%jesus%') LIMIT $2 OFFSET $3  [["hidden", false], ["LIMIT", 20], ["OFFSET", 0]]
  Order Load (0.4ms)  SELECT "orders".* FROM "orders" WHERE "orders"."customer_id" = $1  [["customer_id", 1]]
  LogEntry Load (0.4ms)  SELECT "log_entries".* FROM "log_entries" WHERE "log_entries"."logeable_type" = $1 AND "log_entries"."logeable_id" = $2  [["logeable_type", "Customer"], ["logeable_id", 1]]
  Country Load (0.6ms)  SELECT "countries".* FROM "countries" WHERE "countries"."code" = $1  [["code", "CN"]]
  LineItem Load (0.4ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 1]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.2ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 2]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.2ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 3]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.3ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 4]]
  ↳ app/models/order.rb:16:in `map'
Completed 200 OK in 1502ms (Views: 1442.8ms | ActiveRecord: 22.1ms | Allocations: 803206)
```

Same request, with these changes:

```
Started GET "/admin/customers?search=jesus" for 127.0.0.1 at 2022-06-13 20:39:38 -0700
   (0.4ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by Admin::CustomersController#index as HTML
  Parameters: {"search"=>"jesus"}
  Customer Load (2.4ms)  SELECT "customers".* FROM "customers" LEFT OUTER JOIN "countries" ON "countries"."code" = "customers"."country_code" WHERE "customers"."hidden" = $1 AND (LOWER(CAST("customers"."email" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("customers"."name" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("customers"."kind" AS CHAR(256))) LIKE '%jesus%' OR LOWER(CAST("countries"."name" AS CHAR(256))) LIKE '%jesus%') LIMIT $2 OFFSET $3  [["hidden", false], ["LIMIT", 20], ["OFFSET", 0]]
  Country Load (0.2ms)  SELECT "countries".* FROM "countries" WHERE "countries"."code" = $1  [["code", "CN"]]
  Order Load (0.6ms)  SELECT "orders".* FROM "orders" WHERE "orders"."customer_id" = $1  [["customer_id", 1]]
  ↳ app/models/customer.rb:24:in `map'
  LineItem Load (1.0ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 1]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.3ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 2]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.1ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 3]]
  ↳ app/models/order.rb:16:in `map'
  LineItem Load (0.1ms)  SELECT "line_items".* FROM "line_items" WHERE "line_items"."order_id" = $1  [["order_id", 4]]
  ↳ app/models/order.rb:16:in `map'
   (0.6ms)  SELECT COUNT(*) FROM "log_entries" WHERE "log_entries"."logeable_id" = $1 AND "log_entries"."logeable_type" = $2  [["logeable_id", 1], ["logeable_type", "Customer"]]
  ↳ app/views/fields/has_many_variant/_index.html.erb:6
Completed 200 OK in 1394ms (Views: 1348.5ms | ActiveRecord: 18.2ms | Allocations: 799880)
```

This change converted the log_entries from an eager load to just a count. The orders association would also have converted, except that there's that silly `lifetime_value` calculation that does some manual math on the orders, so it gets loaded in for that anyway (and is its own N+1 problem, but that's not Administrate's fault).