### PR TITLE
Add correct hyperlinks on nested models in collections

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -106,12 +106,20 @@ module Administrate
     end
 
     helper_method :valid_action?
-    def valid_action?(name, resource = resource_class)
-      routes.include?([resource.to_s.underscore.pluralize, name.to_s])
+    def valid_action?(name, resource = resource_class, parent_resource = nil)
+      required_parts = routes[[resource.to_s.underscore.pluralize, name.to_s]]
+
+      return false if required_parts.nil?
+
+      if parent_resource.nil?
+        required_parts.difference(["id"]).empty?
+      else
+        required_parts.include?("#{parent_resource.to_s.underscore}_id")
+      end
     end
 
     def routes
-      @routes ||= Namespace.new(namespace).routes.to_set
+      @routes ||= Namespace.new(namespace).routes
     end
 
     def records_per_page

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -59,13 +59,22 @@ to display a collection of resources in an HTML table.
   <tbody>
     <% resources.each do |resource| %>
       <tr class="js-table-row"
-          <% if valid_action?(:show, resource.class) && show_action?(:show, resource) %>
-            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% if page.try(:resource).present? && valid_action?(:show, resource.class, page.resource.class) && show_action?(:show, resource) %>
+          <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, page.resource, resource])}) %>
+          <% elsif valid_action?(:show, resource.class, resource_name) && show_action?(:show, resource) %>
+          <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <% if valid_action?(:show, resource.class) && show_action?(:show, resource) -%>
+            <% if page.try(:resource).present? && valid_action?(:show, resource.class, page.resource.class) && show_action?(:show, resource) %>
+              <a href="<%= polymorphic_path([namespace, page.resource, resource]) -%>"
+                 tabindex="-1"
+                 class="action-show"
+              >
+                <%= render_field attribute %>
+              </a>
+            <% elsif valid_action?(:show, resource.class) && show_action?(:show, resource) -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"
                  tabindex="-1"
                  class="action-show"

--- a/app/views/administrate/application/_collection_header_actions.html.erb
+++ b/app/views/administrate/application/_collection_header_actions.html.erb
@@ -1,4 +1,6 @@
-<% [valid_action?(:edit, collection_presenter.resource_name),
-    valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+<% [
+    valid_action?(:edit, collection_presenter.resource_name, page.try(:resource).presence),
+    valid_action?(:destroy, collection_presenter.resource_name, page.try(:resource).presence)
+].count(true).times do %>
   <th scope="col"></th>
 <% end %>

--- a/app/views/administrate/application/_collection_item_actions.html.erb
+++ b/app/views/administrate/application/_collection_item_actions.html.erb
@@ -1,4 +1,10 @@
-<% if valid_action?(:edit, collection_presenter.resource_name) %>
+<% if page.try(:resource).present? && valid_action?(:edit, collection_presenter.resource_name, page.resource) %>
+  <td><%= link_to(
+    t("administrate.actions.edit"),
+    [:edit, namespace, page.resource, resource],
+    class: "action-edit",
+  ) if show_action?(:edit, resource) %></td>
+<% elsif valid_action?(:edit, collection_presenter.resource_name) %>
   <td><%= link_to(
     t("administrate.actions.edit"),
     [:edit, namespace, resource],
@@ -6,7 +12,15 @@
   ) if show_action?(:edit, resource) %></td>
 <% end %>
 
-<% if valid_action?(:destroy, collection_presenter.resource_name) %>
+<% if page.try(:resource).present? && valid_action?(:destroy, collection_presenter.resource_name, page.resource) %>
+  <td><%= link_to(
+    t("administrate.actions.destroy"),
+    [namespace, page.resource, resource],
+    class: "text-color-red",
+    method: :delete,
+    data: { confirm: t("administrate.actions.confirm") }
+  ) if show_action?(:destroy, resource) %></td>
+<% elsif valid_action?(:destroy, collection_presenter.resource_name) %>
   <td><%= link_to(
     t("administrate.actions.destroy"),
     [namespace, resource],

--- a/spec/administrate/namespace_spec.rb
+++ b/spec/administrate/namespace_spec.rb
@@ -2,6 +2,29 @@ require "rails_helper"
 require "administrate/namespace"
 
 describe Administrate::Namespace do
+  describe "#routes" do
+    it "returns the list of routes as a hash" do
+      namespace = Administrate::Namespace.new(:admin)
+
+      Rails.application.routes.draw do
+        namespace(:admin) do
+          resources :customers do
+            resources :orders, only: %i[show edit]
+          end
+        end
+      end
+
+      routes = namespace.routes.select { |route| route.first == "orders" }
+      expected_routes = {
+        ["orders", "edit"] => ["customer_id", "id"],
+        ["orders", "show"] => ["customer_id", "id"],
+      }
+      expect(routes).to eq(expected_routes)
+    ensure
+      reset_routes
+    end
+  end
+
   describe "#resources" do
     it "searches the routes for resources in the namespace" do
       namespace = Administrate::Namespace.new(:admin)


### PR DESCRIPTION
## Context

E.g. In the following routes, `Order` model can only be shown (or
edited) when it's accessed via it's nested `/customers/:customer_id/orders` route. If we imagine order ids to be dependent of customers (`Order#1` for `Customer#1` and `Order#1` for `Customer#2`):
```ruby
Rails.application.routes.draw do
  namespace(:admin) do
    resources :customers do
      resources :orders, only: [:show, :edit]
    end
  end
end
```

Until now, administrate would not link the associated models in collections when their actions can only work correctly with the existence of a parent resource (by defining a `Admin::OrdersController#find_resource` method to find the nested resource depending on URL `params`).

## Suggestion

This PR tries to allow models which are nested within a parent related model to be accessed via a nested URL.

I'm not 100% happy with the current codebase (it has lots of duplication) but I wanted to share the main idea which works for us @bump-sh.

Please let me know if this feature could see life in Administrate and how I can make this suggestion better?
Thanks!
