### PR TITLE
Document how to customize Field::Select option labels

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -221,6 +221,17 @@ objects to display as.
 `:collection` - Specify the options shown on the select field. It accept either
 an array or an object responding to `:call`. Defaults to `[]`.
 
+To customize option labels, pass an array of pairs where the first element is the value submitted with the form and the second element is the label shown to the user.
+
+For example:
+
+```ruby
+  currency = Field::Select.with_options(
+    collection: [ ['usd', 'Dollar'], ['eur', 'Euro'], ['yen', 'Yen'] ]
+  )
+
+```
+
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `true`.
 


### PR DESCRIPTION
Customizing select dropdowns helps keep the UI friendly without having to store lengthy values in a database column.

After looking through the `customizing_dashboard` docs I did not find a reference on how to do this. These resources helped me figure out how the select field's `_form` view handled option labels:
- https://github.com/thoughtbot/administrate/blob/main/app/views/fields/select/_form.html.erb
- https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/options_from_collection_for_select

These are before/after screenshots of this PR:
<img width="450" alt="Screen Shot 2022-07-15 at 7 13 08 PM" src="https://user-images.githubusercontent.com/822139/179326684-936401dc-d263-4d7e-b84e-3721b9b01204.png">
<img width="450" alt="Screen Shot 2022-07-15 at 7 12 53 PM" src="https://user-images.githubusercontent.com/822139/179326685-9a2013ed-a078-46b0-bca5-e30119945403.png">

Documenting support for this would imply supporting `[[value, label]]` as an input for `:collection` in `Field::Select.with_options`. If this is a concern I can write some tests to ensure this is accounted for in future releases.