### PR TITLE
Guess correct class name for namespaced associations

### DIFF
--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -12,7 +12,7 @@ module Administrate
       end
 
       def self.associated_class_name(resource_class, attr)
-        reflection(resource_class, attr).class_name
+        associated_class(resource_class, attr).name
       end
 
       def self.reflection(resource_class, attr)

--- a/spec/example_app/app/controllers/admin/blog/tags_controller.rb
+++ b/spec/example_app/app/controllers/admin/blog/tags_controller.rb
@@ -1,0 +1,6 @@
+module Admin
+  module Blog
+    class TagsController < Admin::ApplicationController
+    end
+  end
+end

--- a/spec/example_app/app/dashboards/blog/post_dashboard.rb
+++ b/spec/example_app/app/dashboards/blog/post_dashboard.rb
@@ -9,6 +9,7 @@ module Blog
       title: Field::String,
       published_at: Field::DateTime,
       body: Field::Text,
+      tags: Field::HasMany,
     }
 
     READ_ONLY_ATTRIBUTES = [
@@ -20,6 +21,7 @@ module Blog
     COLLECTION_ATTRIBUTES = [
       :id,
       :title,
+      :tags,
       :published_at,
     ]
 

--- a/spec/example_app/app/dashboards/blog/tag_dashboard.rb
+++ b/spec/example_app/app/dashboards/blog/tag_dashboard.rb
@@ -1,0 +1,31 @@
+require "administrate/base_dashboard"
+
+module Blog
+  class TagDashboard < Administrate::BaseDashboard
+    ATTRIBUTE_TYPES = {
+      id: Field::Number,
+      name: Field::String,
+      created_at: Field::DateTime,
+      updated_at: Field::DateTime,
+      posts: Field::HasMany,
+    }.freeze
+
+    COLLECTION_ATTRIBUTES = %i[
+      id
+      name
+      posts
+      created_at
+    ].freeze
+
+    FORM_ATTRIBUTES = %i[
+      name
+      posts
+    ].freeze
+
+    SHOW_PAGE_ATTRIBUTES = COLLECTION_ATTRIBUTES
+
+    def display_resource(resource)
+      resource.name
+    end
+  end
+end

--- a/spec/example_app/app/models/blog/post.rb
+++ b/spec/example_app/app/models/blog/post.rb
@@ -1,5 +1,7 @@
 module Blog
   class Post < ApplicationRecord
+    has_and_belongs_to_many :tags
+
     validates :title, :body, presence: true
   end
 end

--- a/spec/example_app/app/models/blog/tag.rb
+++ b/spec/example_app/app/models/blog/tag.rb
@@ -1,0 +1,7 @@
+module Blog
+  class Tag < ApplicationRecord
+    has_and_belongs_to_many :posts
+
+    validates :name, presence: true
+  end
+end

--- a/spec/example_app/app/policies/blog/tag_policy.rb
+++ b/spec/example_app/app/policies/blog/tag_policy.rb
@@ -1,0 +1,4 @@
+module Blog
+  class TagPolicy < ApplicationPolicy
+  end
+end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
     namespace :blog do
       resources :posts
+      resources :tags
     end
 
     resources :stats, only: [:index]

--- a/spec/example_app/db/migrate/20220804132651_create_blog_tags.rb
+++ b/spec/example_app/db/migrate/20220804132651_create_blog_tags.rb
@@ -1,0 +1,9 @@
+class CreateBlogTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :blog_tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/example_app/db/migrate/20220804133503_create_blog_posts_tags.rb
+++ b/spec/example_app/db/migrate/20220804133503_create_blog_posts_tags.rb
@@ -1,0 +1,9 @@
+class CreateBlogPostsTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :blog_posts_tags do |t|
+      t.belongs_to :post
+      t.belongs_to :tag
+      t.timestamps
+    end
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_081950) do
+ActiveRecord::Schema.define(version: 2022_08_04_133503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,21 @@ ActiveRecord::Schema.define(version: 2020_07_14_081950) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "blog_posts_tags", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_blog_posts_tags_on_post_id"
+    t.index ["tag_id"], name: "index_blog_posts_tags_on_tag_id"
+  end
+
+  create_table "blog_tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "countries", id: :serial, force: :cascade do |t|

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -59,19 +59,25 @@ end
 
 Product.find_each do |p|
   Page.create!(
-    title: "Something about #{p.name}",
+    title: "Rules of #{p.name}",
     body: Faker::Lorem.paragraph,
     product: p,
   )
-  Page.create!(
-    title: "The secrets of the game #{p.name}",
+end
+
+tag_secrets = Blog::Tag.create!(name: "secrets")
+tag_recommendations = Blog::Tag.create!(name: "recommendations")
+
+Product.find_each do |p|
+  Blog::Post.create!(
+    title: "The secrets of #{p.name}",
     body: Faker::Lorem.paragraph,
-    product: p,
+    tags: [tag_secrets],
   )
-  Page.create!(
-    title: "If you liked #{p.name}, you will love these games",
+  Blog::Post.create!(
+    title: "If you liked #{p.name}, you will love these products",
     body: Faker::Lorem.paragraph,
-    product: p,
+    tags: [tag_recommendations],
   )
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,6 +61,10 @@ FactoryBot.define do
     body { "Empty" }
   end
 
+  factory :blog_tag, class: "Blog::Tag" do
+    name { Faker::NatoPhoneticAlphabet.code_word.downcase }
+  end
+
   factory :series do
     sequence(:name) { |n| "Series #{n}" }
   end

--- a/spec/features/associations_spec.rb
+++ b/spec/features/associations_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe "Associations" do
+  it "can associate to namespaced models on dashboards" do
+    post = create(:blog_post)
+    tag = create(:blog_tag, name: "foobarisms")
+    post.tags << tag
+
+    visit admin_blog_post_url(post)
+
+    expect(page).to have_css(".cell-data", text: "foobarisms")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1978 https://github.com/thoughtbot/administrate/issues/2209

At `lib/administrate/field/associative.rb`, we are currently using the wrong incantation to figure out the name of the associated class. What we have works most of the time, but will drop the namespace if there's one.

For example: if `Blog::Post.has_many :tags` of type `Blog::Tag`s, it will incorrectly guess that the class name of `:tags` is `"Tag"` instead of `"Blog::Tag"`.

This breaks the `Blog::PostDashboard`, which thinks it has to link to `TagDashboard` instead of `Blog::TagDashboard`.

The fix is just the one liner in that file. The rest is putting together an instance of this in the example app, and a spec to test it.