### PR TITLE
Pass associated_class to collection from show

### DIFF
--- a/app/views/fields/has_many/_show.html.erb
+++ b/app/views/fields/has_many/_show.html.erb
@@ -28,6 +28,7 @@ from the associated resource class's dashboard.
     page: page,
     resources: field.resources(page_number, order),
     table_title: field.name,
+    resource_class: field.associated_class,
   ) %>
   <% if field.more_than_limit? %>
     <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>


### PR DESCRIPTION
This fixes an issue where the embedded collection is using the parent's class to define i18n headers.

Example: Ressource order has_many order_items.
Order dashboard declares `order_items: Field::HasMany`

When the show which includes the `order_items` association is rendered within the collection partial it uses the parent's resource (`Order`) instead of `OrderItem` to determine the header label default.

Not sure how to add a test for this behavior.