### PR TITLE
Move pagination into partial

### DIFF
--- a/app/views/administrate/application/_pagination.html.erb
+++ b/app/views/administrate/application/_pagination.html.erb
@@ -1,0 +1,1 @@
+<%= paginate resources, param_name: '_page' %>

--- a/app/views/administrate/application/index.html.erb
+++ b/app/views/administrate/application/index.html.erb
@@ -42,5 +42,5 @@ It renders the `_table` partial to display details about the resources.
     table_title: "page-title"
   ) %>
 
-  <%= paginate resources, param_name: '_page' %>
+  <%= render("pagination", resources: resources) %>
 </section>


### PR DESCRIPTION
Related to #2216, allows the user to override the pagination partial without having to override the entire [index.html.erb](https://github.com/thoughtbot/administrate/blob/main/app/views/administrate/application/index.html.erb) template.

Useful for using custom pagination options e.g:
https://github.com/kaminari/kaminari#paginating-without-issuing-select-count-query