### PR TITLE
remove redundant ARIA roles from elements with implicit role

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -27,7 +27,6 @@ to display a collection of resources in an HTML table.
         cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
         cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
         scope="col"
-        role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
         <%= link_to(sanitized_order_params(page, collection_field_name).merge(
           collection_presenter.order_params_for(attr_name, key: collection_field_name)

--- a/app/views/administrate/application/_index_header.html.erb
+++ b/app/views/administrate/application/_index_header.html.erb
@@ -2,7 +2,7 @@
   <%= display_resource_name(page.resource_name) %>
 <% end %>
 
-<header class="main-content__header" role="banner">
+<header class="main-content__header">
   <h1 class="main-content__page-title" id="page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/_navigation.html.erb
+++ b/app/views/administrate/application/_navigation.html.erb
@@ -7,7 +7,7 @@ for all resources in the admin dashboard,
 as defined by the routes in the `admin/` namespace
 %>
 
-<nav class="navigation" role="navigation">
+<nav class="navigation">
   <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt button--nav") if defined?(root_url) %>
 
   <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>

--- a/app/views/administrate/application/edit.html.erb
+++ b/app/views/administrate/application/edit.html.erb
@@ -17,7 +17,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
 
 <% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
 
-<header class="main-content__header" role="banner">
+<header class="main-content__header">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -22,7 +22,7 @@ to do the heavy lifting.
   ) %>
 <% end %>
 
-<header class="main-content__header" role="banner">
+<header class="main-content__header">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -18,7 +18,7 @@ as well as a link to its edit page.
 
 <% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
 
-<header class="main-content__header" role="banner">
+<header class="main-content__header">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
   </h1>

--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -31,7 +31,7 @@ By default, it renders:
   <div class="app-container">
     <%= render "navigation" -%>
 
-    <main class="main-content" role="main">
+    <main class="main-content">
       <%= render "flashes" -%>
       <%= yield %>
     </main>

--- a/spec/example_app/app/views/admin/customers/_index_header.html.erb
+++ b/spec/example_app/app/views/admin/customers/_index_header.html.erb
@@ -2,7 +2,7 @@
   <%= display_resource_name(page.resource_name) %>
 <% end %>
 
-<header class="main-content__header" role="banner">
+<header class="main-content__header">
   <h1 class="main-content__page-title" id="page-title">
     <%= content_for(:title) %>
   </h1>

--- a/spec/example_app/spec/features/log_search_spec.rb
+++ b/spec/example_app/spec/features/log_search_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Log search", type: :feature do
   end
 
   def have_records_table(rows:)
-    have_css("[role=main] table tr[data-url]", count: rows)
+    have_css("table tr[data-url]", count: rows)
   end
 
   def submit_search


### PR DESCRIPTION
### What does this do?
Fixes #2244 by removing the `role` attribute from all HTML elements that have an implicit role.

### Why?
Because using the `role` attribute on HTML elements with implicit roles is bad practice.
