### PR TITLE
Correctly detect filters with non-word params

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -31,7 +31,7 @@ module Administrate
       private
 
       def filter?(word)
-        valid_filters&.any? { |filter| word.match?(/^#{filter}:.*$/) }
+        valid_filters&.any? { |filter| word.match?(/^#{filter}:/) }
       end
 
       def parse_query(query)

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -31,7 +31,7 @@ module Administrate
       private
 
       def filter?(word)
-        valid_filters&.any? { |filter| word.match?(/^#{filter}:\w*$/) }
+        valid_filters&.any? { |filter| word.match?(/^#{filter}:.*$/) }
       end
 
       def parse_query(query)


### PR DESCRIPTION
Change the filter regex to return valid filter matches when the filter attribute isn't an ascii word object.

This fixes #2228 as well as allowing using comma separated values when filtering

It shouldn't matter when checking for the existence of a `filter` whether the characters to the right of the `:` in the `word` object contain things like unicode characters or punctuation.
