### PR TITLE
belongs_to resource can become a superclass first

### DIFF
--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -19,7 +19,7 @@ By default, the relationship is rendered as a link to the associated object.
   <% if accessible_action?(field.data, :show) %>
     <%= link_to(
       field.display_associated_resource,
-      [namespace, field.data],
+      [namespace, becomes(field.data)],
     ) %>
   <% else %>
     <%= field.display_associated_resource %>


### PR DESCRIPTION
BelongsTo partial now allows a resource to become something else via `Admin::ApplicationController#becomes`