### PR TITLE
Titleize the column not the user defined locale

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -33,8 +33,8 @@ to display a collection of resources in an HTML table.
         )) do %>
         <%= t(
           "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: resource_class.human_attribute_name(attr_name),
-        ).titleize %>
+          default: resource_class.human_attribute_name(attr_name).titleize,
+        ) %>
             <% if collection_presenter.ordered_by?(attr_name) %>
               <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
                 <svg aria-hidden="true">

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe "customer show page" do
   end
 
   it "displays translated labels in has_many collection partials" do
-    custom_label = "Time Shipped"
+    custom_label = "Time shipped"
     customer = create(:customer)
     create(:order, customer: customer)
 


### PR DESCRIPTION
Solves #2014

Ran into this problem when I wanted to render a column with ID in the name. Assumed defining the label in a locale would resolve the issue but no joy.

Overriding a template to display a user defined locale seemed like overkill when it appears that `titleize` is incorrectly applied for the collection partial. Existing usage in other partials/templates is to `titleize` the column rather than the result of translate.

https://github.com/thoughtbot/administrate/blob/main/app/views/administrate/application/new.html.erb#L19
https://github.com/thoughtbot/administrate/blob/main/app/views/fields/has_one/_form.html.erb#L21
https://github.com/thoughtbot/administrate/blob/main/app/views/fields/has_one/_show.html.erb#L32