### PR TITLE
Use correct key in unconventional associations

### DIFF
--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -7,6 +7,10 @@ module Administrate
         reflection(resource_class, attr).foreign_key
       end
 
+      def self.association_primary_key_for(resource_class, attr)
+        reflection(resource_class, attr).association_primary_key
+      end
+
       def self.associated_class(resource_class, attr)
         reflection(resource_class, attr).klass
       end
@@ -48,11 +52,11 @@ module Administrate
         "#{associated_class_name}Dashboard".constantize.new
       end
 
-      def primary_key
+      def association_primary_key
         if option_given?(:primary_key)
           deprecated_option(:primary_key)
         else
-          :id
+          self.class.association_primary_key_for(resource.class, attribute)
         end
       end
 

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -52,6 +52,12 @@ module Administrate
         "#{associated_class_name}Dashboard".constantize.new
       end
 
+      def primary_key
+        # Deprecated, renamed `association_primary_key`
+        Administrate.warn_of_deprecated_method(self.class, :primary_key)
+        association_primary_key
+      end
+
       def association_primary_key
         if option_given?(:primary_key)
           deprecated_option(:primary_key)

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -23,12 +23,15 @@ module Administrate
 
       def associated_resource_options
         candidate_resources.map do |resource|
-          [display_candidate_resource(resource), resource.send(primary_key)]
+          [
+            display_candidate_resource(resource),
+            resource.send(association_primary_key),
+          ]
         end
       end
 
       def selected_option
-        data && data.send(primary_key)
+        data&.send(association_primary_key)
       end
 
       def include_blank_option

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -30,15 +30,18 @@ module Administrate
       end
 
       def associated_resource_options
-        candidate_resources.map do |resource|
-          [display_candidate_resource(resource), resource.send(primary_key)]
+        candidate_resources.map do |associated_resource|
+          [
+            display_candidate_resource(associated_resource),
+            associated_resource.send(association_primary_key),
+          ]
         end
       end
 
       def selected_options
         return if data.empty?
 
-        data.map { |object| object.send(primary_key) }
+        data.map { |object| object.send(association_primary_key) }
       end
 
       def limit

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -87,4 +87,15 @@ describe "customer edit page" do
     expect(page).to have_text(new_email)
     expect(page).to have_flash("Custom name was successfully updated.")
   end
+
+  it "handles complex associations" do
+    country = create(:country, code: "CO")
+    customer = create(:customer, territory: country)
+
+    visit edit_admin_customer_path(customer)
+    click_on "Update Customer"
+
+    customer.reload
+    expect(customer.territory).to eq(country)
+  end
 end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -196,7 +196,7 @@ describe Administrate::Field::BelongsTo do
       remove_constants :Foo, :FooDashboard
     end
 
-    it "determines what primary key is used on the relationship for the form" do
+    it "is the associated table key that matches our foreign key" do
       association =
         Administrate::Field::BelongsTo.with_options(
           primary_key: "uuid", class_name: "Foo",

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -241,14 +241,42 @@ describe Administrate::Field::HasMany do
   end
 
   describe "#selected_options" do
-    it "returns a collection of primary keys" do
-      model = double("model", id: 123)
-      value = MockRelation.new([model])
+    it "returns a collection of keys to use for the association" do
+      associated_resource1 = double(
+        "AssociatedResource1",
+        associated_resource_key: "associated-1",
+      )
+      associated_resource2 = double(
+        "AssociatedResource2",
+        associated_resource_key: "associated-2",
+      )
+      attribute_value = MockRelation.new(
+        [
+          associated_resource1,
+          associated_resource2,
+        ],
+      )
+
+      primary_resource = double(
+        "Resource",
+        class: double(
+          "ResourceClass",
+          reflect_on_association: double(
+            "ResourceReflection",
+            association_primary_key: "associated_resource_key",
+          ),
+        ),
+      )
 
       association = Administrate::Field::HasMany
-      field = association.new(:customers, value, :show)
+      field = association.new(
+        :customers,
+        attribute_value,
+        :show,
+        resource: primary_resource,
+      )
 
-      expect(field.selected_options).to eq([123])
+      expect(field.selected_options).to eq(["associated-1", "associated-2"])
     end
 
     context "when there are no records" do

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -87,7 +87,7 @@ describe Administrate::Field::HasMany do
       remove_constants :Foo, :FooDashboard
     end
 
-    it "determines what primary key is used on the relationship for the form" do
+    it "is the key matching the associated foreign key" do
       association =
         Administrate::Field::HasMany.with_options(
           primary_key: "uuid", class_name: "Foo",


### PR DESCRIPTION
A fix for a bug that you can reproduce right now easily: visit the demo app (https://administrate-prototype.herokuapp.com/admin/customers), select any customer, edit, save, and the customer will lose their `territory` value.

This is a bug introduced with https://github.com/thoughtbot/administrate/pull/1633, where I failed to use `associated_primary_key` to refer to the key on the other side of a foreign key.

Specifically in our demo app, the `Customer` model belongs to `Country` . However instead of the conventional matching of `Customer#country_id` to `Country#id`, it should match `Customer#country_code` to `Country#code`. While `foreign_key` gives us `country_code`, we wrongly use `primary_key` for the counterpart. Instead we should use `association_primary_key` which gives us `code`.

Fixes https://github.com/thoughtbot/administrate/issues/2169