### PR TITLE
Set empty string param values to nil

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -214,6 +214,8 @@ module Administrate
         end
       elsif data.is_a?(ActionController::Parameters)
         data.transform_values { |v| read_param_value(v) }
+      elsif data.is_a?(String) && data.blank?
+        nil
       else
         data
       end

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -132,6 +132,19 @@ describe Admin::CustomersController, type: :controller do
         expect(page.resource).to be_a_new(Customer)
       end
     end
+
+    describe "with empty string param" do
+      it "sets empty string value to nil" do
+        empty_string_attributes = { country_code: "" }
+
+        locals = capture_view_locals do
+          post :create, params: { customer: empty_string_attributes }
+        end
+
+        page = locals[:page]
+        expect(page.resource.country_code).to be_nil
+      end
+    end
   end
 
   describe "PUT update" do


### PR DESCRIPTION
When creating/updating a new resource, blank fields save as empty strings. This PR sets blank fields to nil instead. In most cases, nil is the desired value for the db over an empty string, so nil is the more sensible default. 

Ref #441