### PR TITLE
Make overriding create resource easier

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -40,7 +40,7 @@ module Administrate
     end
 
     def create
-      resource = resource_class.new(resource_params)
+      resource = new_resource(resource_params)
       authorize_resource(resource)
 
       if resource.save
@@ -267,8 +267,8 @@ module Administrate
     end
     helper_method :show_action?
 
-    def new_resource
-      resource_class.new
+    def new_resource(params={})
+      resource_class.new(params)
     end
     helper_method :new_resource
 

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -267,7 +267,7 @@ module Administrate
     end
     helper_method :show_action?
 
-    def new_resource(params={})
+    def new_resource(params = {})
       resource_class.new(params)
     end
     helper_method :new_resource


### PR DESCRIPTION
Use `new_resource` in the `create` action.  This will make it easier for subclasses to further initialize the model before creating the model.