### PR TITLE
Checkout first to avoid failure due to ChromeDriver file in target dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ commands:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
 
+      - run: ls -l ~/administrate
       - checkout
 
       # Install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,10 @@ orbs:
 commands:
   shared_steps:
     steps:
+      - checkout
+
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-
-      - run: ls -l ~/administrate
-      - run: for i in ~/administrate/*; do echo "=== $i"; cat $i; done
-      - checkout
 
       # Install bundler
       - run: gem install bundler:2.3.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ commands:
       - browser-tools/install-chromedriver
 
       - run: ls -l ~/administrate
+      - run: for i in ~/administrate/*; do echo "=== $i"; cat $i; done
       - checkout
 
       # Install bundler


### PR DESCRIPTION
CI started breaking on 11 Jan for no good reason. After some research, it appears that the step to download ChromeDriver now leaves an artefact in the working directory: a license file `LICENSE.chromedriver`. When Git sees it, it refuses to checkout the code, as the target directory is neither empty nor a Git repository.

To fix this, I have moved the checkout step to run first, before ChromeDriver is downloaded.

Note that the build will still fail due to the bundle audit. After this is merged, I should be able to merge the dependabot PRs and fix that.