### PR TITLE
Fix Selenium deprecation warnings on headless/opts

### DIFF
--- a/spec/support/webdrivers.rb
+++ b/spec/support/webdrivers.rb
@@ -6,16 +6,12 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
-  options.headless!
+  options.add_argument "--headless=new"
   options.add_argument "--window-size=1680,1050"
   options.add_argument "--disable-gpu"
   options.add_argument "--disable-dev-shm-usage"
 
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :chrome,
-    capabilities: [options],
-  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
Our configuration was causing this:

```
2023-01-27 15:35:01 WARN Selenium [:logger_info] Details on how to use and modify Selenium logger:
  https://selenium.dev/documentation/webdriver/troubleshooting/logging#ruby
2023-01-27 15:35:01 WARN Selenium [DEPRECATION] [:headless] `Options#headless!` is deprecated. Use `Options#add_argument('--headless=new')` instead.
2023-01-27 15:35:01 WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead.
```