### PR TITLE
Switch from pry-rails to pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.12"
-  gem "pry-rails"
+  gem "pry"
   gem "yard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,8 +212,6 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (5.0.1)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
@@ -337,9 +335,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (= 6.1.7.2)
-  actionview (= 6.1.7.2)
-  activerecord (= 6.1.7.2)
   administrate!
   administrate-field-image
   ammeter
@@ -358,7 +353,7 @@ DEPENDENCIES
   kaminari-i18n
   launchy
   pg
-  pry-rails
+  pry
   pundit
   rack-timeout
   redcarpet

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -20,8 +20,8 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "1.0.11"
-  gem "pry-rails"
+  gem "i18n-tasks", "1.0.12"
+  gem "pry"
   gem "yard"
 end
 

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -20,8 +20,8 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "1.0.11"
-  gem "pry-rails"
+  gem "i18n-tasks", "1.0.12"
+  gem "pry"
   gem "yard"
 end
 

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -20,8 +20,8 @@ group :development, :test do
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_bot_rails"
-  gem "i18n-tasks", "1.0.11"
-  gem "pry-rails"
+  gem "i18n-tasks", "1.0.12"
+  gem "pry"
   gem "yard"
 end
 


### PR DESCRIPTION
`pry-rails` is currently not being maintained, but also is failing from Ruby 3.2.

Moving to `pry` should only drop a few Rails-specific features, but ensure `pry` is still available.