### PR TITLE
Enable ordering by HasOne fields

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -52,11 +52,16 @@ module Administrate
     end
 
     def order_by_association(relation)
-      return order_by_count(relation) if has_many_attribute?(relation)
-
-      return order_by_attribute(relation) if belongs_to_attribute?(relation)
-
-      relation
+      case relation_type(relation)
+      when :has_many
+        order_by_count(relation)
+      when :belongs_to
+        order_by_belongs_to(relation)
+      when :has_one
+        order_by_has_one(relation)
+      else
+        relation
+      end
     end
 
     def order_by_count(relation)
@@ -68,18 +73,30 @@ module Administrate
         reorder(Arel.sql(query))
     end
 
+    def order_by_belongs_to(relation)
+      return order_by_attribute(relation) if ordering_by_association_column?(relation)
+
+      order_by_id(relation)
+    end
+
+    def order_by_has_one(relation)
+      return order_by_attribute(relation) if ordering_by_association_column?(relation)
+
+      order_by_association_id(relation)
+    end
+
+    def order_by_attribute(relation)
+      relation.joins(
+        attribute.to_sym,
+      ).reorder(Arel.sql(order_by_attribute_query))
+    end
+
     def order_by_id(relation)
       relation.reorder(Arel.sql(order_by_id_query(relation)))
     end
 
-    def order_by_attribute(relation)
-      if ordering_by_association_column?(relation)
-        relation.joins(
-          attribute.to_sym,
-        ).reorder(Arel.sql(order_by_attribute_query))
-      else
-        order_by_id(relation)
-      end
+    def order_by_association_id(relation)
+      relation.reorder(Arel.sql(order_by_association_id_query(relation)))
     end
 
     def ordering_by_association_column?(relation)
@@ -97,16 +114,16 @@ module Administrate
       "#{relation.table_name}.#{foreign_key(relation)} #{direction}"
     end
 
+    def order_by_association_id_query(relation)
+      "#{association_table_name}.id #{direction}"
+    end
+
     def order_by_attribute_query
-      "#{attribute.tableize}.#{association_attribute} #{direction}"
+      "#{association_table_name}.#{association_attribute} #{direction}"
     end
 
-    def has_many_attribute?(relation)
-      reflect_association(relation).macro == :has_many
-    end
-
-    def belongs_to_attribute?(relation)
-      reflect_association(relation).macro == :belongs_to
+    def relation_type(relation)
+      reflect_association(relation).macro
     end
 
     def reflect_association(relation)
@@ -115,6 +132,10 @@ module Administrate
 
     def foreign_key(relation)
       reflect_association(relation).foreign_key
+    end
+
+    def association_table_name
+      attribute.tableize
     end
   end
 end

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -74,15 +74,19 @@ module Administrate
     end
 
     def order_by_belongs_to(relation)
-      return order_by_attribute(relation) if ordering_by_association_column?(relation)
-
-      order_by_id(relation)
+      if ordering_by_association_column?(relation)
+        order_by_attribute(relation)
+      else
+        order_by_id(relation)
+      end
     end
 
     def order_by_has_one(relation)
-      return order_by_attribute(relation) if ordering_by_association_column?(relation)
-
-      order_by_association_id(relation)
+      if ordering_by_association_column?(relation)
+        order_by_attribute(relation)
+      else
+        order_by_association_id(relation)
+      end
     end
 
     def order_by_attribute(relation)
@@ -96,7 +100,7 @@ module Administrate
     end
 
     def order_by_association_id(relation)
-      relation.reorder(Arel.sql(order_by_association_id_query(relation)))
+      relation.reorder(Arel.sql(order_by_association_id_query))
     end
 
     def ordering_by_association_column?(relation)
@@ -114,7 +118,7 @@ module Administrate
       "#{relation.table_name}.#{foreign_key(relation)} #{direction}"
     end
 
-    def order_by_association_id_query(relation)
+    def order_by_association_id_query
       "#{association_table_name}.id #{direction}"
     end
 

--- a/spec/example_app/app/dashboards/product_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_dashboard.rb
@@ -19,7 +19,7 @@ class ProductDashboard < Administrate::BaseDashboard
     name: Field::String,
     pages: Field::HasMany,
     price: Field::Number.with_options(prefix: "$", decimals: 2),
-    product_meta_tag: Field::HasOne,
+    product_meta_tag: Field::HasOne.with_options(order: "meta_title"),
     release_year: Field::Select.with_options(
       collection: -> { (Time.current.year - 10)..Time.current.year },
     ),

--- a/spec/example_app/app/dashboards/product_meta_tag_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_meta_tag_dashboard.rb
@@ -16,4 +16,8 @@ class ProductMetaTagDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = ATTRIBUTES
   FORM_ATTRIBUTES = ATTRIBUTES
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTES
+
+  def display_resource(tag)
+    tag.meta_title
+  end
 end

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -17,7 +17,7 @@ describe "product form has_one relationship" do
 
     click_on "Create Product"
 
-    expect(page).to have_link(ProductMetaTag.last.id.to_s)
+    expect(page).to have_link("Example meta title")
     expect(page).to have_flash(
       t("administrate.controller.create.success", resource: "Product")
     )
@@ -60,7 +60,7 @@ describe "product form has_one relationship" do
 
     click_on "Update Product"
 
-    expect(page).to have_link(product.product_meta_tag.id.to_s)
+    expect(page).to have_link(product.product_meta_tag.meta_title.to_s)
     expect(page).to have_flash(
       t("administrate.controller.update.success", resource: "Product")
     )

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -37,4 +37,19 @@ RSpec.describe "product index page" do
 
     expect(current_path).to eq(new_admin_product_path)
   end
+
+  scenario "product sorted by has_one association" do
+    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Gamma"))
+    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Alpha"))
+    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Beta"))
+
+    visit admin_products_path
+    expect(page).to have_content(/Gamma.*Alpha.*Beta/)
+
+    click_on "Product Meta Tag"
+    expect(page).to have_content(/Alpha.*Beta.*Gamma/)
+
+    click_on "Product Meta Tag"
+    expect(page).to have_content(/Gamma.*Beta.*Alpha/)
+  end
 end

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -39,9 +39,18 @@ RSpec.describe "product index page" do
   end
 
   scenario "product sorted by has_one association" do
-    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Gamma"))
-    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Alpha"))
-    create(:product, product_meta_tag: build(:product_meta_tag, meta_title: "Beta"))
+    create(
+      :product,
+      product_meta_tag: build(:product_meta_tag, meta_title: "Gamma")
+    )
+    create(
+      :product,
+      product_meta_tag: build(:product_meta_tag, meta_title: "Alpha")
+    )
+    create(
+      :product,
+      product_meta_tag: build(:product_meta_tag, meta_title: "Beta")
+    )
 
     visit admin_products_path
     expect(page).to have_content(/Gamma.*Alpha.*Beta/)

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -41,15 +41,15 @@ RSpec.describe "product index page" do
   scenario "product sorted by has_one association" do
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Gamma")
+      product_meta_tag: build(:product_meta_tag, meta_title: "Gamma"),
     )
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Alpha")
+      product_meta_tag: build(:product_meta_tag, meta_title: "Alpha"),
     )
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Beta")
+      product_meta_tag: build(:product_meta_tag, meta_title: "Beta"),
     )
 
     visit admin_products_path

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -156,7 +156,7 @@ describe Administrate::Order do
     context "when relation has has_one association" do
       it "orders by id" do
         order = Administrate::Order.new(
-          double(to_sym: :user, tableize: "users")
+          double(to_sym: :user, tableize: "users"),
         )
         relation = relation_with_association(:has_one)
         allow(relation).to receive(:reorder).and_return(relation)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -155,7 +155,9 @@ describe Administrate::Order do
 
     context "when relation has has_one association" do
       it "orders by id" do
-        order = Administrate::Order.new(double(to_sym: :user, tableize: "users"))
+        order = Administrate::Order.new(
+          double(to_sym: :user, tableize: "users")
+        )
         relation = relation_with_association(:has_one)
         allow(relation).to receive(:reorder).and_return(relation)
 

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -152,6 +152,72 @@ describe Administrate::Order do
         end
       end
     end
+
+    context "when relation has has_one association" do
+      it "orders by id" do
+        order = Administrate::Order.new(double(to_sym: :user, tableize: "users"))
+        relation = relation_with_association(:has_one)
+        allow(relation).to receive(:reorder).and_return(relation)
+
+        ordered = order.apply(relation)
+
+        expect(relation).to have_received(:reorder).with(
+          "users.id asc",
+        )
+        expect(ordered).to eq(relation)
+      end
+
+      context "when `order` argument valid" do
+        it "orders by the column" do
+          order = Administrate::Order.new(
+            double(to_sym: :user, tableize: "users"),
+            nil,
+            association_attribute: "name",
+          )
+          relation = relation_with_association(
+            :has_one,
+            klass: double(
+              table_name: "users",
+              columns_hash: { "name" => :value },
+            ),
+          )
+          allow(relation).to receive(:joins).and_return(relation)
+          allow(relation).to receive(:reorder).and_return(relation)
+
+          ordered = order.apply(relation)
+          expect(relation).to have_received(:reorder).with(
+            "users.name asc",
+          )
+          expect(ordered).to eq(relation)
+        end
+      end
+
+      context "when `order` argument invalid" do
+        it "orders by id" do
+          order = Administrate::Order.new(
+            double(to_sym: :user, tableize: "users"),
+            nil,
+            association_attribute: "invalid_column_name",
+          )
+          relation = relation_with_association(
+            :has_one,
+            klass: double(
+              table_name: "users",
+              columns_hash: { name: :value },
+            ),
+          )
+          allow(relation).to receive(:joins).and_return(relation)
+          allow(relation).to receive(:reorder).and_return(relation)
+
+          ordered = order.apply(relation)
+
+          expect(relation).to have_received(:reorder).with(
+            "users.id asc",
+          )
+          expect(ordered).to eq(relation)
+        end
+      end
+    end
   end
 
   describe "#ordered_by?" do


### PR DESCRIPTION
Currently, users are able to sort by BelongsTo fields (using ID or selected attribute) and HasMany fields.

This PR adds support for sorting by HasOne fields using both ID or selected attribute (passed via `Field::HasOne.with_options(order: attribute_name)`.