### PR TITLE
Replace sassc-rails with dartsass-sprockets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ coverage and (where necessary) have internationalisation support.
 Administrate's demo application can be run like any Rails application:
 
 ```sh
-bundle exec rails s
+bundle exec rails server
 ```
 
 This will start the application defined in `spec/example_app`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,9 +5,9 @@ PATH
       actionpack (>= 5.0)
       actionview (>= 5.0)
       activerecord (>= 5.0)
+      dartsass-sprockets
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
-      sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
 
 GEM
@@ -109,6 +109,14 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-ruby (3.0.1)
+      sass-embedded (~> 1.54)
+    dartsass-sprockets (3.0.0)
+      dartsass-ruby (~> 3.0)
+      railties (>= 4.0.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -134,7 +142,6 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
     formulaic (0.4.1)
       activesupport
       capybara
@@ -142,6 +149,7 @@ GEM
     front_matter_parser (1.0.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.22.2)
     hashdiff (1.0.1)
     highline (2.1.0)
     i18n (1.12.0)
@@ -274,14 +282,9 @@ GEM
     rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.59.3)
+      google-protobuf (~> 3.21)
+      rake (>= 10.0.0)
     selectize-rails (0.12.6)
     selenium-webdriver (4.8.1)
       rexml (~> 3.2, >= 3.2.5)
@@ -302,7 +305,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
-    tilt (2.0.11)
+    tilt (2.1.0)
     timecop (0.9.6)
     timeout (0.3.1)
     tzinfo (2.0.6)

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
-  s.add_dependency "sassc-rails", "~> 2.1"
+  s.add_dependency "dartsass-sprockets"
   s.add_dependency "selectize-rails", "~> 0.6"
 
   s.description = <<-DESCRIPTION

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -1,6 +1,6 @@
 require "jquery-rails"
 require "kaminari"
-require "sassc-rails"
+require "dartsass-sprockets"
 require "selectize-rails"
 require "sprockets/railtie"
 


### PR DESCRIPTION
sassc-rails gem deprecated long time ago. And can't compile sass file with new features. E.g. `graphiql-rails` has sass files that can't be compiled with sassc-rails.

```
Error: Function hsla is missing argument $lightness.
```

So, replace it with `dart sass-sprockets`.