### PR TITLE
Better description for option

### DIFF
--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -5,7 +5,12 @@ require "administrate/namespace"
 module Administrate
   class ViewGenerator < Rails::Generators::Base
     include Administrate::GeneratorHelpers
-    class_option :namespace, type: :string, default: :admin
+    class_option(
+      :namespace,
+      type: :string,
+      desc: "Namespace where the admin dashboards live",
+      default: "admin",
+    )
 
     def self.template_source_path
       File.expand_path(

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -27,7 +27,12 @@ module Administrate
       COLLECTION_ATTRIBUTE_LIMIT = 4
       READ_ONLY_ATTRIBUTES = %w[id created_at updated_at]
 
-      class_option :namespace, type: :string, default: :admin
+      class_option(
+        :namespace,
+        type: :string,
+        desc: "Namespace where the admin dashboards live",
+        default: "admin",
+      )
 
       source_root File.expand_path("../templates", __FILE__)
 

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -14,7 +14,12 @@ module Administrate
       include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
 
-      class_option :namespace, type: :string, default: "admin"
+      class_option(
+        :namespace,
+        type: :string,
+        desc: "Namespace where the admin dashboards will live",
+        default: "admin",
+      )
 
       def run_routes_generator
         if dashboard_resources.none?

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -13,7 +13,12 @@ module Administrate
     class RoutesGenerator < Rails::Generators::Base
       include Administrate::GeneratorHelpers
       source_root File.expand_path("../templates", __FILE__)
-      class_option :namespace, type: :string, default: "admin"
+      class_option(
+        :namespace,
+        type: :string,
+        desc: "Namespace where the admin dashboards live",
+        default: "admin",
+      )
 
       def insert_dashboard_routes
         if valid_dashboard_models.any?

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -14,7 +14,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         expect(Rails::Generators).
           to invoke_generator(
             "administrate:views:#{generator}",
-            [resource, "--namespace", :admin],
+            [resource, "--namespace", "admin"],
           )
       end
     end
@@ -27,7 +27,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
 
       expect(Rails::Generators).to invoke_generator(
         "administrate:views:index",
-        [resource, "--namespace", :admin],
+        [resource, "--namespace", "admin"],
         behavior: :revoke,
       )
     end
@@ -44,7 +44,7 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         %w[index show new edit].each do |generator|
           expect(Rails::Generators). to invoke_generator(
             "administrate:views:#{generator}",
-            [application_resource_path, "--namespace", :admin],
+            [application_resource_path, "--namespace", "admin"],
           )
         end
       end


### PR DESCRIPTION
The default text is otherwise the following, which isn't very descriptive:

```
  [--namespace=NAMESPACE]                                # Indicates when to generate namespace
                                                         # Default: admin
```

This also changes the default in the view generator to be `"admin"` instead of `:admin` for consistency.