### PR TITLE
Field::Select to handle ActiveRecord enums correctly

### DIFF
--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -19,27 +19,14 @@ to be displayed on a resource's edit form page.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <% if field.selectable_options.first&.is_a?(Array) %>
-    <%= f.select(
+  <%=
+    f.select(
       field.attribute,
-      options_from_collection_for_select(
+      options_for_select(
         field.selectable_options,
-        :last,
-        :first,
         field.data,
       ),
       include_blank: field.include_blank_option
-    ) %>
-  <% else %>
-    <%= f.select(
-      field.attribute,
-      options_from_collection_for_select(
-        field.selectable_options,
-        :to_s,
-        :to_s,
-        field.data,
-      ),
-      include_blank: field.include_blank_option
-    ) %>
-  <% end %>
+    )
+  %>
 </div>

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -223,7 +223,7 @@ objects to display as.
 If the given value responds to `call`, this will be called and the result used instead. The call will receive an instance of the field as argument. For example:
 
 ```ruby
-  confirmation = Field::Select.with_options(
+  confirmation: Field::Select.with_options(
     collection: ->(field) {
       person = field.resource
       {

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -235,7 +235,7 @@ If the given value responds to `call`, this will be called and the result used i
   )
 ```
 
-Administrate will detect if the attribute is an `ActiveRecord::Enum` and extract the available options. Note that if a `collection` is provided it will take preference.
+Administrate will detect if the attribute is an `ActiveRecord::Enum` and extract the available options. Note that if a `collection` is provided it will take precedence.
 
 If no collection is provided and no enum can be detected, the list of options will be empty.
 

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -218,25 +218,31 @@ objects to display as.
 
 **Field::Select**
 
-`:collection` - Specify the options shown on the select field. It accept either
-an array or an object responding to `:call`. Defaults to `[]`.
+`:collection` - The options available to select. The format is the same as for Rails's own [`options_for_select`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-options_for_select).
 
-To customize option labels, pass an array of pairs where the first element is the value submitted with the form and the second element is the label shown to the user.
-
-For example:
+If the given value responds to `call`, this will be called and the result used instead. The call will receive an instance of the field as argument. For example:
 
 ```ruby
-  currency = Field::Select.with_options(
-    collection: [ ['usd', 'Dollar'], ['eur', 'Euro'], ['yen', 'Yen'] ]
+  confirmation = Field::Select.with_options(
+    collection: ->(field) {
+      person = field.resource
+      {
+        "no, #{person.name}" => "opt0",
+        "yes, #{person.name}" => "opt1",
+        "absolutely, #{person.name}" => "opt2",
+      }
+    },
   )
-
 ```
+
+Administrate will detect if the attribute is an `ActiveRecord::Enum` and extract the available options. Note that if a `collection` is provided it will take preference.
+
+If no collection is provided and no enum can be detected, the list of options will be empty.
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `true`.
 
-`:include_blank` - Specifies if the select element to be rendered should include
-blank option. Default is `false`.
+`:include_blank` - Similar to [the option of the same name accepted by Rails helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html). If provided, a "blank" option will be added first to the list of options, with the value of `include_blank` as label.
 
 **Field::String**
 

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -8,7 +8,14 @@ module Administrate
       end
 
       def selectable_options
-        values = options.fetch(:collection, [])
+        values =
+          if options.key?(:collection)
+            options.fetch(:collection)
+          elsif active_record_enum?
+            active_record_enum_values
+          else
+            []
+          end
 
         if values.respond_to? :call
           values = values.arity.positive? ? values.call(self) : values.call
@@ -19,6 +26,14 @@ module Administrate
 
       def include_blank_option
         options.fetch(:include_blank, false)
+      end
+
+      def active_record_enum?
+        resource.class.defined_enums.key?(attribute.to_s)
+      end
+
+      def active_record_enum_values
+        resource.class.defined_enums[attribute.to_s].map(&:first)
       end
     end
   end

--- a/lib/administrate/field/select.rb
+++ b/lib/administrate/field/select.rb
@@ -8,22 +8,17 @@ module Administrate
       end
 
       def selectable_options
-        collection
+        values = options.fetch(:collection, [])
+
+        if values.respond_to? :call
+          values = values.arity.positive? ? values.call(self) : values.call
+        end
+
+        values
       end
 
       def include_blank_option
         options.fetch(:include_blank, false)
-      end
-
-      private
-
-      def collection
-        values = options.fetch(:collection, [])
-        if values.respond_to? :call
-          return values.arity.positive? ? values.call(self) : values.call
-        end
-
-        @collection ||= values
       end
     end
   end

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -144,6 +144,30 @@ describe "fields/select/_form", type: :view do
     )
   end
 
+  it "prioritises given collections over enums" do
+    customer = create(:customer, name: "Dave")
+    field = Administrate::Field::Select.new(
+      :kind,
+      "platinum",
+      :_page_,
+      resource: customer,
+      collection: ["gold", "platinum"]
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="platinum"][selected="selected"]},
+      text: "platinum",
+    )
+    expect(rendered).not_to have_css(
+      %{select[name="customer[kind]"] option[value="vip"]},
+    )
+  end
+
   it "defaults to an empty list when there are no options" do
     customer = create(:customer, name: "Dave")
     field = Administrate::Field::Select.new(

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -23,6 +23,168 @@ describe "fields/select/_form", type: :view do
     )
   end
 
+  it "works when :collection is an array" do
+    customer = create(:customer)
+    field = Administrate::Field::Select.new(
+      :kind,
+      "yes",
+      :_page_,
+      resource: customer,
+      collection: ["no", "yes", "absolutely"],
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="yes"][selected="selected"]},
+      text: "yes",
+    )
+  end
+
+  it "works when :collection is a hash" do
+    customer = create(:customer)
+    field = Administrate::Field::Select.new(
+      :kind,
+      "opt1",
+      :_page_,
+      resource: customer,
+      collection: {
+        "no" => "opt0",
+        "yes" => "opt1",
+        "absolutely" => "opt2",
+      },
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="opt1"][selected="selected"]},
+      text: "yes",
+    )
+  end
+
+  it "works when :collection is a call-able" do
+    customer = create(:customer)
+    field = Administrate::Field::Select.new(
+      :kind,
+      "opt1",
+      :_page_,
+      resource: customer,
+      collection: -> {
+        {
+          "no" => "opt0",
+          "yes" => "opt1",
+          "absolutely" => "opt2",
+        }
+      },
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="opt1"][selected="selected"]},
+      text: "yes",
+    )
+  end
+
+  it "provides some context to that call-able" do
+    customer = create(:customer, name: "Dave")
+    field = Administrate::Field::Select.new(
+      :kind,
+      "opt1",
+      :_page_,
+      resource: customer,
+      collection: ->(f) {
+        person = f.resource
+        {
+          "no, #{person.name}" => "opt0",
+          "yes, #{person.name}" => "opt1",
+          "absolutely, #{person.name}" => "opt2",
+        }
+      },
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="opt1"][selected="selected"]},
+      text: "yes, Dave",
+    )
+  end
+
+  it "is an empty list when not set" do
+    customer = create(:customer, name: "Dave")
+    field = Administrate::Field::Select.new(
+      :kind,
+      "opt1",
+      :_page_,
+      resource: customer,
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).not_to have_css(
+      %{select[name="customer[kind]"] option}
+    )
+  end
+
+  describe "when :include_blank is provided" do
+    it "adds a blank option" do
+      customer = create(:customer, name: "Dave")
+      field = Administrate::Field::Select.new(
+        :kind,
+        "opt1",
+        :_page_,
+        resource: customer,
+        include_blank: "No answer",
+      )
+
+      render(
+        partial: "fields/select/form",
+        locals: { field: field, f: form_builder(customer) },
+      )
+      expect(rendered).to have_css(%{select[name="customer[kind]"] option}, text: "No answer")
+    end
+
+    it "works with a call-able collection" do
+      customer = create(:customer, name: "Dave")
+      field = Administrate::Field::Select.new(
+        :kind,
+        "opt1",
+        :_page_,
+        resource: customer,
+        collection: -> {
+          {
+            "no" => "opt0",
+            "yes" => "opt1",
+            "absolutely" => "opt2",
+          }
+        },
+        include_blank: "No answer",
+      )
+
+      render(
+        partial: "fields/select/form",
+        locals: { field: field, f: form_builder(customer) },
+      )
+      expect(rendered).to have_css(%{select[name="customer[kind]"] option}, text: "No answer")
+    end
+  end
+
   def form_builder(object)
     ActionView::Helpers::FormBuilder.new(
       object.model_name.singular,

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -26,7 +26,7 @@ describe "fields/select/_form", type: :view do
   it "works when :collection is an array" do
     customer = create(:customer)
     field = Administrate::Field::Select.new(
-      :kind,
+      :email_subscriber,
       "yes",
       :_page_,
       resource: customer,
@@ -38,7 +38,7 @@ describe "fields/select/_form", type: :view do
       locals: { field: field, f: form_builder(customer) },
     )
     expect(rendered).to have_css(
-      %{select[name="customer[kind]"]
+      %{select[name="customer[email_subscriber]"]
         option[value="yes"][selected="selected"]},
       text: "yes",
     )
@@ -47,7 +47,7 @@ describe "fields/select/_form", type: :view do
   it "works when :collection is a hash" do
     customer = create(:customer)
     field = Administrate::Field::Select.new(
-      :kind,
+      :email_subscriber,
       "opt1",
       :_page_,
       resource: customer,
@@ -63,7 +63,7 @@ describe "fields/select/_form", type: :view do
       locals: { field: field, f: form_builder(customer) },
     )
     expect(rendered).to have_css(
-      %{select[name="customer[kind]"]
+      %{select[name="customer[email_subscriber]"]
         option[value="opt1"][selected="selected"]},
       text: "yes",
     )
@@ -72,7 +72,7 @@ describe "fields/select/_form", type: :view do
   it "works when :collection is a call-able" do
     customer = create(:customer)
     field = Administrate::Field::Select.new(
-      :kind,
+      :email_subscriber,
       "opt1",
       :_page_,
       resource: customer,
@@ -90,7 +90,7 @@ describe "fields/select/_form", type: :view do
       locals: { field: field, f: form_builder(customer) },
     )
     expect(rendered).to have_css(
-      %{select[name="customer[kind]"]
+      %{select[name="customer[email_subscriber]"]
         option[value="opt1"][selected="selected"]},
       text: "yes",
     )
@@ -99,7 +99,7 @@ describe "fields/select/_form", type: :view do
   it "provides some context to that call-able" do
     customer = create(:customer, name: "Dave")
     field = Administrate::Field::Select.new(
-      :kind,
+      :email_subscriber,
       "opt1",
       :_page_,
       resource: customer,
@@ -118,16 +118,36 @@ describe "fields/select/_form", type: :view do
       locals: { field: field, f: form_builder(customer) },
     )
     expect(rendered).to have_css(
-      %{select[name="customer[kind]"]
+      %{select[name="customer[email_subscriber]"]
         option[value="opt1"][selected="selected"]},
       text: "yes, Dave",
     )
   end
 
-  it "is an empty list when not set" do
+  it "detects the values of an ActiveRecord::Enum" do
     customer = create(:customer, name: "Dave")
     field = Administrate::Field::Select.new(
       :kind,
+      "vip",
+      :_page_,
+      resource: customer,
+    )
+
+    render(
+      partial: "fields/select/form",
+      locals: { field: field, f: form_builder(customer) },
+    )
+    expect(rendered).to have_css(
+      %{select[name="customer[kind]"]
+        option[value="vip"][selected="selected"]},
+      text: "vip",
+    )
+  end
+
+  it "defaults to an empty list when there are no options" do
+    customer = create(:customer, name: "Dave")
+    field = Administrate::Field::Select.new(
+      :email_subscriber,
       "opt1",
       :_page_,
       resource: customer,
@@ -138,7 +158,7 @@ describe "fields/select/_form", type: :view do
       locals: { field: field, f: form_builder(customer) },
     )
     expect(rendered).not_to have_css(
-      %{select[name="customer[kind]"] option}
+      %{select[name="customer[email_subscriber]"] option}
     )
   end
 
@@ -146,7 +166,7 @@ describe "fields/select/_form", type: :view do
     it "adds a blank option" do
       customer = create(:customer, name: "Dave")
       field = Administrate::Field::Select.new(
-        :kind,
+        :email_subscriber,
         "opt1",
         :_page_,
         resource: customer,
@@ -157,13 +177,13 @@ describe "fields/select/_form", type: :view do
         partial: "fields/select/form",
         locals: { field: field, f: form_builder(customer) },
       )
-      expect(rendered).to have_css(%{select[name="customer[kind]"] option}, text: "No answer")
+      expect(rendered).to have_css(%{select[name="customer[email_subscriber]"] option}, text: "No answer")
     end
 
     it "works with a call-able collection" do
       customer = create(:customer, name: "Dave")
       field = Administrate::Field::Select.new(
-        :kind,
+        :email_subscriber,
         "opt1",
         :_page_,
         resource: customer,
@@ -181,7 +201,7 @@ describe "fields/select/_form", type: :view do
         partial: "fields/select/form",
         locals: { field: field, f: form_builder(customer) },
       )
-      expect(rendered).to have_css(%{select[name="customer[kind]"] option}, text: "No answer")
+      expect(rendered).to have_css(%{select[name="customer[email_subscriber]"] option}, text: "No answer")
     end
   end
 

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -11,7 +11,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
     log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),
     updated_at: Field::DateTime,
-    kind: Field::Select.with_options(collection: Customer::KINDS),
+    kind: Field::Select,
     territory: Field::BelongsTo.with_options(
       searchable: true,
       searchable_fields: ["name"],

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -11,10 +11,11 @@ class Customer < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true
 
-  KINDS = [
-    :standard,
-    :vip,
-  ].freeze
+  KINDS = {
+    "standard" => "kind:std",
+    "vip" => "kind:vip",
+  }.freeze
+  enum kind: KINDS
 
   def admin?
     false

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -48,6 +48,12 @@ describe "customer edit page" do
 
     expect(page).to have_text("KIND")
     expect(page).to have_text("vip")
+
+    visit edit_admin_customer_path(customer)
+    expect(page).to have_css(
+      ".selectize-input.items > [data-value]",
+      text: "vip",
+    )
   end
 
   it "displays an error when the submitted form is invalid" do

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -80,13 +80,11 @@ describe "edit form" do
 
   context "include_blank option for select" do
     it "should have blank option if set to true" do
-      dashboard = CustomerDashboard.new
-      fields = dashboard.attribute_types
-      kind = fields[:kind]
-      kind.options[:include_blank] = true
-
-      expect(kind.deferred_class).to eq(Administrate::Field::Select)
-      expect(kind.options[:include_blank]).to eq(true)
+      fields = CustomerDashboard::ATTRIBUTE_TYPES
+      fake_kind = fields[:kind].with_options(include_blank: true)
+      fake_fields = fields.dup
+      fake_fields[:kind] = fake_kind
+      stub_const("CustomerDashboard::ATTRIBUTE_TYPES", fake_fields)
 
       visit new_admin_customer_path
       element_selections = find("select[name=\"customer[kind]\"]")
@@ -95,13 +93,11 @@ describe "edit form" do
     end
 
     it "should not have blank option if set to false" do
-      dashboard = CustomerDashboard.new
-      fields = dashboard.attribute_types
-      kind = fields[:kind]
-      kind.options[:include_blank] = false
-
-      expect(kind.deferred_class).to eq(Administrate::Field::Select)
-      expect(kind.options[:include_blank]).to eq(false)
+      fields = CustomerDashboard::ATTRIBUTE_TYPES
+      fake_kind = fields[:kind].with_options(include_blank: false)
+      fake_fields = fields.dup
+      fake_fields[:kind] = fake_kind
+      stub_const("CustomerDashboard::ATTRIBUTE_TYPES", fake_fields)
 
       visit new_admin_customer_path
       element_selections = find("select[name=\"customer[kind]\"]")

--- a/spec/lib/fields/select_spec.rb
+++ b/spec/lib/fields/select_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+require "administrate/field/select"
+
+describe Administrate::Field::Select do
+  describe "#selectable_options" do
+    it "works when :collection is an array" do
+      customer = create(:customer)
+      field = described_class.new(
+        :email_subscriber,
+        "yes",
+        :_page_,
+        resource: customer,
+        collection: ["no", "yes", "absolutely"],
+      )
+
+      expect(field.selectable_options).to eq(
+        ["no", "yes", "absolutely"],
+      )
+    end
+
+    it "works when :collection is a hash" do
+      customer = create(:customer)
+      field = Administrate::Field::Select.new(
+        :email_subscriber,
+        "opt1",
+        :_page_,
+        resource: customer,
+        collection: {
+          "no" => "opt0",
+          "yes" => "opt1",
+          "absolutely" => "opt2",
+        },
+      )
+
+      expect(field.selectable_options).to eq(
+        "no" => "opt0",
+        "yes" => "opt1",
+        "absolutely" => "opt2",
+      )
+    end
+
+    it "works when :collection is a call-able" do
+      customer = create(:customer)
+      field = Administrate::Field::Select.new(
+        :email_subscriber,
+        "opt1",
+        :_page_,
+        resource: customer,
+        collection: -> {
+          {
+            "no" => "opt0",
+            "yes" => "opt1",
+            "absolutely" => "opt2",
+          }
+        },
+      )
+
+      expect(field.selectable_options).to eq(
+        "no" => "opt0",
+        "yes" => "opt1",
+        "absolutely" => "opt2",
+      )
+    end
+
+    it "provides some context to that call-able" do
+      customer = create(:customer, name: "Dave")
+      field = Administrate::Field::Select.new(
+        :email_subscriber,
+        "opt1",
+        :_page_,
+        resource: customer,
+        collection: ->(f) {
+          person = f.resource
+          {
+            "no, #{person.name}" => "opt0",
+            "yes, #{person.name}" => "opt1",
+            "absolutely, #{person.name}" => "opt2",
+          }
+        },
+      )
+
+      expect(field.selectable_options).to eq(
+        "no, Dave" => "opt0",
+        "yes, Dave" => "opt1",
+        "absolutely, Dave" => "opt2",
+      )
+    end
+
+    it "detects the values of an ActiveRecord::Enum" do
+      customer = create(:customer)
+      field = Administrate::Field::Select.new(
+        :kind,
+        "vip",
+        :_page_,
+        resource: customer,
+      )
+
+      expect(field.selectable_options).to eq(["standard", "vip"])
+    end
+
+    it "prioritises given collections over enums" do
+      customer = create(:customer)
+      field = Administrate::Field::Select.new(
+        :kind,
+        "platinum",
+        :_page_,
+        resource: customer,
+        collection: ["gold", "platinum"],
+      )
+
+      expect(field.selectable_options).to eq(["gold", "platinum"])
+    end
+
+    it "defaults to an empty list when there are no options" do
+      customer = create(:customer)
+      field = Administrate::Field::Select.new(
+        :email_subscriber,
+        "opt1",
+        :_page_,
+        resource: customer,
+      )
+
+      expect(field.selectable_options).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/administrate/issues/1939

In the spirit of "make the change easy, then make the easy change", this PR includes a refactor of `Field::Select`, moving the logic out of the template and into the field class, where the actual functionality (and any future one) can be handled and tested more easily.

I have also written more exhaustive specs for the behaviour of this field, which helped me not breaking existing functionality while refactoring (or so I hope!).