### PR TITLE
Adapt to deprecations in the Faker API

### DIFF
--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -30,7 +30,7 @@ customer_attributes = Array.new(100) do
   name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
   {
     name: name,
-    email: Faker::Internet.safe_email(name: name),
+    email: Faker::Internet.email(name: name),
     territory: countries.sample,
     password: Faker::Internet.password,
   }


### PR DESCRIPTION
Faker is deprecating `Faker::Internet.safe_email` in order to comply with [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) by default. See https://github.com/faker-ruby/faker/pull/2733

Administrate uses Faker for its seeds and currently is pinned to its latest version. Therefore we get the following warning multiple times when running `db:seed`:

```
NOTE: Faker::Internet.safe_email is deprecated; use email instead. It will be removed on or after 2023-10.
Faker::Internet.safe_email called from /home/pablobm/Documents/projects/administrate/gem/spec/example_app/db/seeds.rb:33
```

This PR adapts the seeds file to the new API, removing the warnings.