### PR TITLE
Update Field::HasOne options documentation

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -128,6 +128,10 @@ set this to `0` or `false`. Default is `5`.
 
 **Field::HasOne**
 
+`:order` - Specifies the column used to order the records. It will apply both in
+the table views and in the dropdown menu on the record forms.
+You can set multiple columns as well with direction. E.g.: `"name, email DESC"`.
+
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `false`.
 


### PR DESCRIPTION
This updates the documentation for customizing the `Field::HasOne` with the `order` option, which was added in #2325. This also changes each of the field descriptions to an h4 tag for better accessibility and to provide links to those headers.