### PR TITLE
Trying to fix CI (issue with selenium-webdrivers)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", "= 4.9.0"
   gem "shoulda-matchers"
   gem "timecop"
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -363,7 +363,7 @@ DEPENDENCIES
   pundit
   rack-timeout
   redcarpet
-  selenium-webdriver
+  selenium-webdriver (= 4.9.0)
   sentry-raven
   shoulda-matchers
   timecop


### PR DESCRIPTION
For some reason, we can't get v4.9.1 from CircleCI:

```
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Your bundle is locked to selenium-webdriver (4.9.1) from rubygems repository
https://rubygems.org/ or installed locally, but that version can no longer be
found in that source. That means the author of selenium-webdriver (4.9.1) has
removed it. You'll need to update your bundle to a version other than
selenium-webdriver (4.9.1) that hasn't been removed in order to install.

Exited with code exit status 7

CircleCI received exit code 7
```