### PR TITLE
Update documentation URL to correct Heroku URL

### DIFF
--- a/lib/generators/administrate/dashboard/templates/controller.rb.erb
+++ b/lib/generators/administrate/dashboard/templates/controller.rb.erb
@@ -40,7 +40,7 @@ module <%= namespace.to_s.camelize %>
     #     transform_values { |value| value == "" ? nil : value }
     # end
 
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # See https://administrate-demo.herokuapp.com/customizing_controller_actions
     # for more information
   end
 end


### PR DESCRIPTION
https://administrate-prototype.herokuapp.com no longer works, but https://administrate-demo.herokuapp.com does. 

This fixes the broken URLs. 👍