### PR TITLE
Field::Polymorphic accepts a call-able for the classes option

### DIFF
--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -30,7 +30,8 @@ module Administrate
       end
 
       def classes
-        options.fetch(:classes, [])
+        klasses = options.fetch(:classes, [])
+        klasses.respond_to?(:call) ? klasses.call : klasses
       end
 
       private

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -71,11 +71,20 @@ describe Administrate::Field::Polymorphic do
     end
 
     context "present in options" do
-      it "returns an present value" do
+      it "returns a present value" do
         classes = ["one", "two", "three"]
         allow(field).to receive(:options).and_return(classes: classes)
 
         expect(field.send(:classes)).to eq(classes)
+      end
+    end
+
+    context "present in options as a call-able object" do
+      it "returns the called value" do
+        classes = -> { ["one", "two", "three"] }
+        allow(field).to receive(:options).and_return(classes: classes)
+
+        expect(field.send(:classes)).to eq(classes.call)
       end
     end
   end


### PR DESCRIPTION
This commit allows a field definition like this:

```ruby
ATTRIBUTE_TYPES = {
  listable: Field::Polymorphic.with_options(classes: -> { Listable.listable_classes })
}
```

In my app I use a pattern where I have polymorphic associations that use a module to come into being. The module defines the associations and any special behaviors, and the model on the other side of the polymorphic relationship just includes the module to get the association and all the behaviors. At that time, the module registers the calling class. In the example above, the module is `Listable`; any model that includes `Listable` then `has_many :lists, as: :listable`.

It's a great pattern. The trouble is, the administrate dashboards get parsed _before_ my models, so without the call-able `classes` option, `Listable.listable_classes` ends up empty all the time. By making it callable, it's evaluated at runtime, _after_ the models are parsed, so we get the correct class list. Yay for dynamic discovery!