### PR TITLE
Fix Rails 6.0 `load_server` incompatibility

### DIFF
--- a/spec/example_app/config.ru
+++ b/spec/example_app/config.ru
@@ -3,4 +3,7 @@
 require_relative "config/environment"
 
 run Rails.application
-Rails.application.load_server
+
+if Gem::Version.new(Rails.version) >= Gem::Version.new("6.1")
+  Rails.application.load_server
+end


### PR DESCRIPTION
Back when we upgraded Rails, we added this as it's now standard. But we still support 6.0 which doesn't have this.

This was noticed when running `bundle exec appraisal rails60 rails rspec` locally where the tests all fail for this version of Rails. Running `rails s` hinted that this might be the problem and not calling it means the tests now run.

https://github.com/thoughtbot/administrate/pull/1841