### PR TITLE
Add Administrate::Punditize methods as module methods

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -9,31 +9,27 @@ module Administrate
         include Pundit
       end
 
-      included do
-        private
+      private
 
-        def policy_namespace
-          []
-        end
-
-        def scoped_resource
-          namespaced_scope = policy_namespace + [super]
-          policy_scope!(pundit_user, namespaced_scope)
-        end
-
-        def authorize_resource(resource)
-          namespaced_resource = policy_namespace + [resource]
-          authorize namespaced_resource
-        end
-
-        def authorized_action?(resource, action)
-          namespaced_resource = policy_namespace + [resource]
-          policy = Pundit.policy!(pundit_user, namespaced_resource)
-          policy.send("#{action}?".to_sym)
-        end
+      def policy_namespace
+        []
       end
 
-      private
+      def scoped_resource
+        namespaced_scope = policy_namespace + [super]
+        policy_scope!(pundit_user, namespaced_scope)
+      end
+
+      def authorize_resource(resource)
+        namespaced_resource = policy_namespace + [resource]
+        authorize namespaced_resource
+      end
+
+      def authorized_action?(resource, action)
+        namespaced_resource = policy_namespace + [resource]
+        policy = Pundit.policy!(pundit_user, namespaced_resource)
+        policy.send("#{action}?".to_sym)
+      end
 
       def policy_scope!(user, scope)
         policy_scope_class = Pundit::PolicyFinder.new(scope).scope!


### PR DESCRIPTION
Instead of adding them via `included do`.

---------

Note: It's easiest to view this diff if you hide whitespace changes: 
<img width="261" alt="image" src="https://github.com/thoughtbot/administrate/assets/23050/7b9fdf1e-115e-44fc-b28d-aa13fdf861b1">

---------

If these methods are added via `included do` it makes it hard to override the method in an app's controller.

Example:

```ruby
module Admin
  class ApplicationController < Administrate::ApplicationController
    include Administrate::Punditize

    def scoped_resource
      super.where(archived: false)
    end
  end
end
```

That example will skip pundit completely, because the `def scoped_resource` from `Administrate::Punditize` was added via `included do`, which means it will behave as if we had defined the method inline twice in `Admin ::ApplicationController`, which will result in the first definition from `Administrate::Punditize` being ignored. And the `super` in the code snippet above will refer to the non-punditized definition provided in the base class `Administrate::ApplicationController`:
https://github.com/thoughtbot/administrate/blob/cda8da9b4229b3fdedb7aedfe22359e83bb65e71/app/controllers/administrate/application_controller.rb#L192-L194

This seems unexpected to me, and makes it hard to add functionality that layers on top of what `Administrate::Punditize` does.

However, if we define `def scoped_resource` as a module method in `Administrate::Punditize` then `super` in `Admin::ApplicationController` will refer to the method defined in `Administrate::Punditize`.

Are there gotchas that I'm missing? Is there a reason that some of the methods
in `Administrate::Punditize` were defined via `included do` and others were
added as module methods?
