### PR TITLE
New feature: field hints for forms inputs

### DIFF
--- a/app/assets/stylesheets/administrate/components/_field-unit.scss
+++ b/app/assets/stylesheets/administrate/components/_field-unit.scss
@@ -2,6 +2,7 @@
   @include administrate-clearfix;
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: $base-spacing;
   position: relative;
   width: 100%;
@@ -23,6 +24,12 @@
   .optgroup-header {
     font-weight: $bold-font-weight;
   }
+}
+
+.field-unit__hint {
+  font-size: 90%;
+  margin-left: calc(15% + 2rem);
+  width: 100%;
 }
 
 .field-unit--nested {

--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -36,6 +36,13 @@ and renders all form fields for a resource's editable attributes.
   <% page.attributes(controller.action_name).each do |attribute| -%>
     <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
       <%= render_field attribute, f: f %>
+
+      <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
+      <% if I18n.exists?(hint_key) -%>
+        <div class="field-unit__hint">
+          <%= I18n.t(hint_key) %>
+        </div>
+      <% end -%>
     </div>
   <% end -%>
 

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -385,3 +385,21 @@ FORM_ATTRIBUTES_EDIT = [
 ```
 
 Or for custom action with constant name `"FORM_ATTRIBUTES_#{action.upcase}"`
+
+### Form Fields' Hints
+
+You can show a brief text element below an input field by setting the
+corresponding translation key using the path:
+
+`administrate.field_hints.#{model_name}.#{field_name}`
+
+For example, with a Customer dashboard with an email field you can add a
+string value that will be used as text hint:
+
+```yml
+en:
+  administrate:
+    field_hints:
+      customer:
+        email: field_hint
+```

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -105,4 +105,27 @@ describe "edit form" do
       expect(element_selections.first("option").value).not_to eq("")
     end
   end
+
+  context "fields hints" do
+    it "displays a field hint element within the field unit" do
+      field_hint = "The typology of customer"
+
+      translations = {
+        administrate: {
+          field_hints: {
+            customer: {
+              kind: field_hint,
+            },
+          },
+        },
+      }
+
+      with_translations(:en, translations) do
+        visit new_admin_customer_path
+
+        css_hint_element = ".field-unit > .field-unit__hint"
+        expect(page).to have_css(css_hint_element, text: field_hint)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey!
Thank you for the nice gem! 😄 
I use it from quite some time and now I'm here to propose a small feature: adding optional hints (as small text lines) below form input fields.
I'm opening the PR in draft as proof of concept, if you like the idea I could complete it (with tests / anything needed).

I'm using this feature in a couple of projects, I think it can help offering context information to the users.

The changes should be minimal, I just added a div below `div.field-unit__field` and set basic styles for the new element.
I also had to add `flex-wrap: wrap;` to `.field-unit` in order to place the new div on a new line.
In another version I was passing the hint via field options but now I prefer the translations way because in any case the string would be stored there for my projects.

Sample locale:

```yml
en:
  administrate:
    field_hints:
      book:
        content: Brief summary of the book
```

The effect is like the following:

<img width="683" alt="image" src="https://github.com/thoughtbot/administrate/assets/6893256/25500456-22a4-4363-8ae4-42f88b6c6034">

Please let me know your opinion 🙏 