### PR TITLE
allow grouping fields (new, edit and show)

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -33,17 +33,25 @@ and renders all form fields for a resource's editable attributes.
     </div>
   <% end %>
 
-  <% page.attributes(controller.action_name).each do |attribute| -%>
-    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
-      <%= render_field attribute, f: f %>
+  <% page.attributes(controller.action_name).each do |title, attributes| -%>
+    <fieldset class="<%= "field-unit--nested" if title.present? %>">
+      <% if title.present? %>
+        <legend><%= t "helpers.label.#{f.object_name}.#{title}", default: title %></legend>
+      <% end %>
 
-      <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
-      <% if I18n.exists?(hint_key) -%>
-        <div class="field-unit__hint">
-          <%= I18n.t(hint_key) %>
+      <% attributes.each do |attribute| %>
+        <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+          <%= render_field attribute, f: f %>
+
+          <% hint_key = "administrate.field_hints.#{page.resource_name}.#{attribute.name}" %>
+          <% if I18n.exists?(hint_key) -%>
+            <div class="field-unit__hint">
+              <%= I18n.t(hint_key) %>
+            </div>
+          <% end -%>
         </div>
-      <% end -%>
-    </div>
+      <% end %>
+    </fieldset>
   <% end -%>
 
   <div class="form-actions">

--- a/app/views/administrate/application/show.html.erb
+++ b/app/views/administrate/application/show.html.erb
@@ -42,16 +42,24 @@ as well as a link to its edit page.
 
 <section class="main-content__body">
   <dl>
-    <% page.attributes.each do |attribute| %>
-      <dt class="attribute-label" id="<%= attribute.name %>">
-      <%= t(
-        "helpers.label.#{resource_name}.#{attribute.name}",
-        default: page.resource.class.human_attribute_name(attribute.name),
-      ) %>
-      </dt>
+    <% page.attributes.each do |title, attributes| %>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{page.resource_name}.#{title}", default: title %></legend>
+        <% end %>
 
-      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute, page: page %></dd>
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label" id="<%= attribute.name %>">
+          <%= t(
+            "helpers.label.#{resource_name}.#{attribute.name}",
+            default: page.resource.class.human_attribute_name(attribute.name),
+          ) %>
+          </dt>
+
+          <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+              ><%= render_field attribute, page: page %></dd>
+        <% end %>
+      </fieldset>
     <% end %>
   </dl>
 </section>

--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -19,10 +19,20 @@ The form will be rendered as nested_from to parent relationship.
 <%= f.fields_for field.attribute, field.data || field.nested_form.resource.class.new do |has_one_f| %>
   <fieldset class="field-unit--nested">
     <legend><%= t "helpers.label.#{f.object_name}.#{field.name}", default: field.name.titleize %></legend>
-    <% field.nested_form.attributes.each do |attribute| -%>
-      <div class="field-unit field-unit--<%= attribute.html_class %>">
-        <%= render_field attribute, f: has_one_f %>
-      </div>
+    <% field.nested_form.attributes.each do |title, attributes| -%>
+
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{f.object_name}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <div class="field-unit field-unit--<%= attribute.html_class %>">
+            <%= render_field attribute, f: has_one_f %>
+          </div>
+        <% end %>
+      </fieldset>
+
     <% end -%>
   </fieldset>
 <% end %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -24,18 +24,24 @@ All show page attributes of has_one relationship would be rendered
         [namespace, field.data],
       ) %>
     </legend>
-    <% field.nested_show.attributes.each do |attribute| -%>
-      <div>
-      <dt class="attribute-label">
-        <%= t(
-          "helpers.label.#{field.associated_class_name.underscore}.#{attribute.name}",
-          default: attribute.name.titleize,
-        ) %>
-      </dt>
-      <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
-        <%= render_field attribute, { page: page } %>
-      </dd>
-      </div>
+    <% field.nested_show.attributes.each do |title, attributes| -%>
+      <fieldset class="<%= "field-unit--nested" if title.present? %>">
+        <% if title.present? %>
+          <legend><%= t "helpers.label.#{namespace}.#{title}", default: title %></legend>
+        <% end %>
+
+        <% attributes.each do |attribute| %>
+          <dt class="attribute-label">
+            <%= t(
+              "helpers.label.#{field.associated_class_name.underscore}.#{attribute.name}",
+              default: attribute.name.titleize,
+            ) %>
+          </dt>
+          <dd class="attribute-data attribute-data--<%= attribute.html_class %>">
+            <%= render_field attribute, { page: page } %>
+          </dd>
+        <% end %>
+      </fieldset>
     <% end -%>
   </fieldset>
 <% end %>

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -403,3 +403,36 @@ en:
       customer:
         email: field_hint
 ```
+
+## Grouped Attributes
+
+You may have models with a large number of fields and therefore you might want to group them in a meaningul way:
+
+```ruby
+class UserDashboard < Administrate::BaseDashboard
+  SHOW_PAGE_ATTRIBUTES = {
+    "" => [:username],
+    "Personal Information" => [:first_name, :last_name, :email],
+    "Address" => [:address_line_one, :address_line_two, :address_city, :address_state, :address_country]
+  }
+
+  FORM_ATTRIBUTES = {
+    "" => [:username, :password, :password_confirmation],
+    "personal_information" => [:first_name, :last_name, :email],
+    "address" => [:address_line_one, :address_line_two, :address_city, :address_state, :address_country]
+  }
+end
+```
+
+You can optionally translate your group labels:
+
+```yaml
+en:
+  helpers:
+    label:
+      user:
+        address: Address
+        personal_information: Personal Information
+```
+
+If not defined (see `SHOW_PAGE_ATTRIBUTES` above), Administrate will default to the given strings.

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -69,7 +69,13 @@ module Administrate
     end
 
     def permitted_attributes(action = nil)
-      form_attributes(action).map do |attr|
+      attributes = form_attributes action
+
+      if attributes.is_a? Hash
+        attributes = attributes.values.flatten
+      end
+
+      attributes.map do |attr|
         attribute_types[attr].permitted_attribute(
           attr,
           resource_class: self.class.model,
@@ -83,7 +89,11 @@ module Administrate
     end
 
     def collection_attributes
-      self.class::COLLECTION_ATTRIBUTES
+      if self.class::COLLECTION_ATTRIBUTES.is_a?(Hash)
+        self.class::COLLECTION_ATTRIBUTES.values.flatten
+      else
+        self.class::COLLECTION_ATTRIBUTES
+      end
     end
 
     def search_attributes
@@ -107,7 +117,12 @@ module Administrate
     end
 
     def item_associations
-      attribute_associated(show_page_attributes)
+      attributes = if show_page_attributes.is_a?(Hash)
+                     show_page_attributes.values.flatten
+                   else
+                     show_page_attributes
+                   end
+      attribute_associated attributes
     end
 
     private

--- a/lib/administrate/page/form.rb
+++ b/lib/administrate/page/form.rb
@@ -11,8 +11,16 @@ module Administrate
       attr_reader :resource
 
       def attributes(action = nil)
-        dashboard.form_attributes(action).map do |attribute|
-          attribute_field(dashboard, resource, attribute, :form)
+        attributes = dashboard.form_attributes(action)
+
+        if attributes.is_a? Array
+          attributes = { "" => attributes }
+        end
+
+        attributes.transform_values do |attrs|
+          attrs.map do |attribute|
+            attribute_field(dashboard, resource, attribute, :form)
+          end
         end
       end
 

--- a/lib/administrate/page/show.rb
+++ b/lib/administrate/page/show.rb
@@ -15,8 +15,16 @@ module Administrate
       end
 
       def attributes
-        dashboard.show_page_attributes.map do |attr_name|
-          attribute_field(dashboard, resource, attr_name, :show)
+        attributes = dashboard.show_page_attributes
+
+        if attributes.is_a? Array
+          attributes = { "" => attributes }
+        end
+
+        attributes.transform_values do |attrs|
+          attrs.map do |attr_name|
+            attribute_field(dashboard, resource, attr_name, :show)
+          end
         end
       end
     end

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -43,9 +43,9 @@ describe "fields/has_one/_show", type: :view do
         resource: double(
           class: ProductMetaTag,
         ),
-        attributes: [
+        attributes: { "" => [
           nested_simple_field,
-        ],
+        ] },
       )
 
       @has_one_field = instance_double(
@@ -131,7 +131,7 @@ describe "fields/has_one/_show", type: :view do
         resource: double(
           class: ProductMetaTag,
         ),
-        attributes: [],
+        attributes: { "" => [] },
       )
 
       nested_has_one = instance_double(
@@ -148,7 +148,7 @@ describe "fields/has_one/_show", type: :view do
 
       nested_show_page_for_top_has_one = instance_double(
         "Administrate::Page::Show",
-        attributes: [nested_has_one, nested_has_many],
+        attributes: { "" => [nested_has_one, nested_has_many] },
       )
 
       has_one_field = instance_double(

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -35,6 +35,23 @@ class OrderDashboard < Administrate::BaseDashboard
     :shipped_at,
   ]
 
-  FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES
-  SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys
+  FORM_ATTRIBUTES = {
+    "" => %i[customer],
+    "details" => %i[
+      line_items
+      shipped_at
+      payments
+    ],
+    "address" => %i[
+      address_line_one
+      address_line_two
+      address_city
+      address_state
+      address_zip
+    ],
+  }.freeze
+  SHOW_PAGE_ATTRIBUTES = FORM_ATTRIBUTES.merge(
+    "" => %i[customer created_at updated_at],
+    "details" => %i[line_items total_price shipped_at payments],
+  ).freeze
 end

--- a/spec/example_app/config/locales/en.yml
+++ b/spec/example_app/config/locales/en.yml
@@ -6,6 +6,12 @@ en:
       with_weekday:
         "%a %m/%d/%y"
 
+  helpers:
+    label:
+      order:
+        address: Address
+        details: Details
+
   time:
     formats:
       default:

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -84,12 +84,14 @@ RSpec.describe Administrate::ApplicationHelper do
     end
 
     it "returns 'required' if field is required" do
-      name = page.attributes.detect { |i| i.attribute == :name }
+      name = page.attributes.values.flatten.detect { |i| i.attribute == :name }
       expect(requireness(name)).to eq("required")
     end
 
     it "returns 'optional' if field is not required" do
-      release_year = page.attributes.detect { |i| i.attribute == :release_year }
+      release_year = page.attributes.values.flatten.detect do |i|
+        i.attribute == :release_year
+      end
       expect(requireness(release_year)).to eq("optional")
     end
   end

--- a/spec/lib/pages/form_spec.rb
+++ b/spec/lib/pages/form_spec.rb
@@ -13,14 +13,18 @@ describe Administrate::Page::Form do
   describe "#attributes" do
     let(:line_item) { build(:line_item) }
     let(:page) { described_class.new(LineItemDashboard.new, line_item) }
-    let(:attributes) { page.attributes(action).map(&:attribute) }
+    let(:attributes) do
+      page.attributes(action).transform_values do |attributes|
+        attributes.map(&:attribute)
+      end
+    end
 
     context "for a new action" do
       let(:action) { "new" }
 
       it "returns the attributes from FORM_ATTRIBUTES_NEW" do
         expect(attributes).to match(
-          %i[
+          "" => %i[
             order
             product
           ],
@@ -33,7 +37,7 @@ describe Administrate::Page::Form do
 
       it "returns the attributes from FORM_ATTRIBUTES_NEW" do
         expect(attributes).to match(
-          %i[
+          "" => %i[
             order
             product
           ],
@@ -46,7 +50,7 @@ describe Administrate::Page::Form do
 
       it "returns the attributes from FORM_ATTRIBUTES_EDIT" do
         expect(attributes).to match(
-          %i[
+          "" => %i[
             order
             product
             quantity

--- a/spec/lib/pages/show_spec.rb
+++ b/spec/lib/pages/show_spec.rb
@@ -15,8 +15,8 @@ describe Administrate::Page::Show do
       customer = double(name: "Worf").as_null_object
       page = Administrate::Page::Show.new(CustomerDashboard.new, customer)
 
-      expect(page.attributes.first.resource).to eq(customer)
-      expect(page.attributes.first.resource.name).to eq("Worf")
+      expect(page.attributes[""].first.resource).to eq(customer)
+      expect(page.attributes[""].first.resource.name).to eq("Worf")
     end
   end
 end


### PR DESCRIPTION
Hi! I've been using administrate for a couple of years and I really like the approach and enjoy using it. Thanks :) 

A couple of times I needed to group fields when having models with a large number of fields and the lack of an official way made me do nasty things lol.

This PR adds the ability of grouping form attributes and show page attributes:

* it's backward compatible
* i18n ready
* has_one field allows grouping too

Let me know what you think!