### PR TITLE
Bump github actions/checkout to v4

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -6,7 +6,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Bundler Audit'
         uses: andrewmcodes/bundler-audit-action@main
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1


### PR DESCRIPTION
This Pull Request has been created because [actions/checkout](https://github.com/actions/checkout) has been bumped to [version 4](https://github.com/actions/checkout/releases/tag/v4.0.0) on the 04/09/2023

This Pull Request changes all the CI that use `actions/checkout@v2` in favour of the newer `actions/checkout@v4`
