### PR TITLE
Add GitHub Actions as an ecosystem for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
+---
 version: 2
 
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: '02:00'
+      timezone: 'Etc/UTC'


### PR DESCRIPTION
This should help keep us on top of Actions versions, without having to do it manually.

This commit also formats using yamllint, to avoid some common YAML mistakes.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot