### PR TITLE
Updated Views::IndexGenerator to copy all partials

### DIFF
--- a/lib/generators/administrate/views/index_generator.rb
+++ b/lib/generators/administrate/views/index_generator.rb
@@ -9,7 +9,11 @@ module Administrate
         def copy_template
           copy_resource_template("index")
           copy_resource_template("_collection")
+          copy_resource_template("_collection_header_actions")
+          copy_resource_template("_collection_item_actions")
           copy_resource_template("_index_header")
+          copy_resource_template("_pagination")
+          copy_resource_template("_search")
         end
       end
     end


### PR DESCRIPTION
I believe this is an oversight from when the templates were split in a previous version.
Please review.