### PR TITLE
Avoid open-ended dependencies

### DIFF
--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib,docs}/**/*", "config/locales/**/*", "LICENSE", "Rakefile"]
 
-  s.add_dependency "actionpack", ">= 5.0"
-  s.add_dependency "actionview", ">= 5.0"
-  s.add_dependency "activerecord", ">= 5.0"
+  s.add_dependency "actionpack", ">= 6.0", "< 8.0"
+  s.add_dependency "actionview", ">= 6.0", "< 8.0"
+  s.add_dependency "activerecord", ">= 6.0", "< 8.0"
 
-  s.add_dependency "jquery-rails", ">= 4.0"
-  s.add_dependency "kaminari", ">= 1.0"
+  s.add_dependency "jquery-rails", "~> 4.6.0"
+  s.add_dependency "kaminari", "~> 1.2.2"
   s.add_dependency "sassc-rails", "~> 2.1"
   s.add_dependency "selectize-rails", "~> 0.6"
 


### PR DESCRIPTION
With the current dependency specification, we get the following warnings when building the gem:

```
WARNING:  open-ended dependency on actionpack (>= 5.0) is not recommended
  if actionpack is semantically versioned, use:
    add_runtime_dependency 'actionpack', '~> 5.0'
WARNING:  open-ended dependency on actionview (>= 5.0) is not recommended
  if actionview is semantically versioned, use:
    add_runtime_dependency 'actionview', '~> 5.0'
WARNING:  open-ended dependency on activerecord (>= 5.0) is not recommended
  if activerecord is semantically versioned, use:
    add_runtime_dependency 'activerecord', '~> 5.0'
WARNING:  open-ended dependency on kaminari (>= 1.0) is not recommended
  if kaminari is semantically versioned, use:
    add_runtime_dependency 'kaminari', '~> 1.0'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```

I think this makes sense. We don't know which changes Rails 8 or Kaminari 2 may bring.