### PR TITLE
Update bundler from 2.3.10 to 2.4.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,4 +382,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.10
+   2.4.22


### PR DESCRIPTION
One benefit is the more concise output when running `bundle install` (or `bundle`)