### PR TITLE
Drop support for Ruby 2.7, since it's EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,27 +51,6 @@ default_job: &default_job
   working_directory: ~/administrate
 
 jobs:
-  ruby-27:
-    <<: *default_job
-    steps:
-      - shared_steps
-      # Run the tests against the versions of Rails that support Ruby 2.7
-      - run: bundle exec appraisal install
-      - run: bundle exec appraisal rails60 rspec
-      - run: bundle exec appraisal rails61 rspec
-      - run: bundle exec appraisal rails70 rspec
-    docker:
-      - image: cimg/ruby:2.7-browsers
-        environment:
-          PGHOST: localhost
-          PGUSER: administrate
-          RAILS_ENV: test
-      - image: cimg/postgres:15.1
-        environment:
-          POSTGRES_USER: administrate
-          POSTGRES_DB: ruby27
-          POSTGRES_PASSWORD: ""
-
   ruby-30:
     <<: *default_job
     steps:
@@ -140,4 +119,3 @@ workflows:
       - ruby-32
       - ruby-31
       - ruby-30
-      - ruby-27

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@ title: Getting Started
 ---
 
 Administrate is released as a Ruby gem, and can be installed on Rails
-applications version 6.0 or greater. We support Ruby 2.7 and up.
+applications version 6.0 or greater. We support Ruby 3.0 and up.
 
 First, add the following to your Gemfile:
 


### PR DESCRIPTION
This was originally introduced in #2419, but is worth breaking out.