### PR TITLE
Update Bundler to 2.4.22 on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
       - run: google-chrome --version
 
       # Install bundler
-      - run: gem install bundler:2.3.5
+      - run: gem install bundler:2.4.22
 
       # Restore Cached Dependencies
       - restore_cache:


### PR DESCRIPTION
In #2465 we updated bundler, but we should've changed it in the Circle config too.