### PR TITLE
Use a dedicated ActiveSupport::Deprecation instance

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -42,7 +42,7 @@ module Administrate
         end
 
         if policy_scope.respond_to? :resolve_admin
-          ActiveSupport::Deprecation.warn(
+          Administrate.deprecator.warn(
             "Pundit policy scope `resolve_admin` method is deprecated. " +
             "Please use a namespaced pundit policy instead.",
           )

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -2,7 +2,7 @@ require "administrate/engine"
 
 module Administrate
   def self.warn_of_missing_resource_class
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "Calling Field::Base.permitted_attribute without the option " +
       ":resource_class is deprecated. If you are seeing this " +
       "message, you are probably using a custom field type that" +
@@ -12,7 +12,7 @@ module Administrate
   end
 
   def self.warn_of_deprecated_option(name)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The option :#{name} is deprecated. " +
       "Administrate should detect it automatically. " +
       "Please file an issue at " +
@@ -22,7 +22,7 @@ module Administrate
   end
 
   def self.warn_of_deprecated_method(klass, method)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The method #{klass}##{method} is deprecated. " +
       "If you are seeing this message you are probably " +
       "using a dashboard that depends explicitly on it. " +
@@ -32,10 +32,14 @@ module Administrate
   end
 
   def self.warn_of_deprecated_authorization_method(method)
-    ActiveSupport::Deprecation.warn(
+    deprecator.warn(
       "The method `#{method}` is deprecated. " +
       "Please use `accessible_action?` instead, " +
       "or see the documentation for other options.",
     )
+  end
+
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new(VERSION, "Administrate")
   end
 end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -34,7 +34,7 @@ module Administrate
       end
 
       def searchable_field
-        ActiveSupport::Deprecation.warn(
+        Administrate.deprecator.warn(
           "searchable_field is deprecated, use searchable_fields instead",
         )
         options.fetch(:searchable_field)

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     end
 
     it "triggers a deprecation warning" do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
       get :index
-      expect(ActiveSupport::Deprecation).to(
+      expect(Administrate.deprecator).to(
         have_received(:warn).
           with(/`show_action\?` is deprecated/),
       )
@@ -99,9 +99,9 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     end
 
     it "triggers a deprecation warning" do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
       get :index
-      expect(ActiveSupport::Deprecation).to(
+      expect(Administrate.deprecator).to(
         have_received(:warn).
           with(/`valid_action\?` is deprecated/),
       )

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -108,7 +108,7 @@ describe Admin::OrdersController, type: :controller do
 
   context "with deprecated Punditize concern" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       class OrderPolicy
         class Scope
@@ -147,7 +147,7 @@ describe Admin::OrdersController, type: :controller do
         locals = capture_view_locals { get :index }
 
         expect(locals[:resources]).to contain_exactly(order1, order3)
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/`resolve_admin` method is deprecated/)
       end
     end
@@ -162,7 +162,7 @@ describe Admin::OrdersController, type: :controller do
       it "allows me to edit my records" do
         order = create :order, customer: user
         expect { get :edit, params: { id: order.id } }.not_to raise_error
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/`resolve_admin` method is deprecated/)
       end
 
@@ -171,7 +171,7 @@ describe Admin::OrdersController, type: :controller do
         order = create(:order, customer: other_user)
         expect { get :show, params: { id: order.id } }.
           to raise_error(ActiveRecord::RecordNotFound)
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/`resolve_admin` method is deprecated/)
       end
     end
@@ -192,7 +192,7 @@ describe Admin::OrdersController, type: :controller do
         send_request(order: order)
         expect(response).to redirect_to([:admin, order])
         expect(order.reload.address_line_one).to eq("22 Acacia Avenue")
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/`resolve_admin` method is deprecated/)
       end
 
@@ -202,7 +202,7 @@ describe Admin::OrdersController, type: :controller do
         expect do
           send_request(order: order)
         end.to raise_error(ActiveRecord::RecordNotFound)
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/`resolve_admin` method is deprecated/)
       end
     end

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -43,9 +43,12 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  if Gem::Version.new(Rails.version) <= Gem::Version.new("6.1")
+
+  if Rails.gem_version <= Gem::Version.new("6.1")
     config.action_view.raise_on_missing_translations = true
   else
     config.i18n.raise_on_missing_translations = true
   end
+
+  config.active_support.cache_format_version = 7.0 if Rails.gem_version >= Gem::Version.new("7.0")
 end

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -50,5 +50,7 @@ Rails.application.configure do
     config.i18n.raise_on_missing_translations = true
   end
 
-  config.active_support.cache_format_version = 7.0 if Rails.gem_version >= Gem::Version.new("7.0")
+  if Rails.gem_version >= Gem::Version.new("7.0")
+    config.active_support.cache_format_version = 7.0
+  end
 end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -15,7 +15,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
       run_generator ["customer"]
 
-      expect(dashboard).to exist
+      expect(Pathname.new(dashboard)).to exist
       expect(dashboard).to have_correct_syntax
     end
 
@@ -424,7 +424,7 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
       run_generator ["customer"]
 
-      expect(controller).to exist
+      expect(Pathname.new(controller)).to exist
       expect(controller).to have_correct_syntax
     end
 

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -13,7 +13,7 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
       run_generator
 
-      expect(controller).to exist
+      expect(Pathname.new(controller)).to exist
       expect(controller).to have_correct_syntax
       expect(controller).to contain <<-RB.strip_heredoc
         module Admin
@@ -27,7 +27,7 @@ describe Administrate::Generators::InstallGenerator, :generator do
 
       run_generator ["--namespace", "manager"]
 
-      expect(controller).to exist
+      expect(Pathname.new(controller)).to exist
       expect(controller).to have_correct_syntax
       expect(controller).to contain <<-RB.strip_heredoc
         module Manager

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -73,8 +73,8 @@ describe Administrate::Search do
     Administrate.send(:remove_const, :SearchSpecMocks)
   end
 
-  before { ActiveSupport::Deprecation.silenced = true }
-  after { ActiveSupport::Deprecation.silenced = false }
+  before { Administrate.deprecator.silenced = true }
+  after { Administrate.deprecator.silenced = false }
 
   describe "#run" do
     it "returns all records when no search term" do
@@ -159,7 +159,7 @@ describe Administrate::Search do
 
     context "when searching through associations" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       let(:scoped_object) { Administrate::SearchSpecMocks::Foo }
@@ -217,7 +217,7 @@ describe Administrate::Search do
 
         search.run
 
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:class_name is deprecated/)
       end
     end

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -88,7 +88,7 @@ describe Administrate::Field::BelongsTo do
 
   describe "class_name option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
     end
 
     it "determines the associated_class" do
@@ -134,7 +134,7 @@ describe Administrate::Field::BelongsTo do
         resource: line_item,
       )
       field.associated_class
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:class_name is deprecated/)
     end
   end
@@ -179,7 +179,7 @@ describe Administrate::Field::BelongsTo do
 
   describe "primary_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       Foo = Class.new
       FooDashboard = Class.new
@@ -217,14 +217,14 @@ describe Administrate::Field::BelongsTo do
       field = association.new(:foo, double(uuid: nil), :baz)
       field.selected_option
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:primary_key is deprecated/)
     end
   end
 
   describe "foreign_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
     end
 
     it "determines what foreign key is used on the relationship for the form" do
@@ -244,7 +244,7 @@ describe Administrate::Field::BelongsTo do
 
       field.permitted_attribute
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:foreign_key is deprecated/)
     end
   end

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -8,7 +8,7 @@ describe Administrate::Field::Deferred do
   describe "#permitted_attribute" do
     context "when given a `foreign_key` option" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       it "returns the value given" do
@@ -26,7 +26,7 @@ describe Administrate::Field::Deferred do
           foreign_key: :bar,
         )
         deferred.permitted_attribute(:foo, resource_class: LineItem)
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:foreign_key is deprecated/)
       end
     end

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -36,7 +36,7 @@ describe Administrate::Field::HasMany do
     let(:dashboard_double) { double(collection_attributes: []) }
 
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       FooDashboard = Class.new
       allow(FooDashboard).to receive(:new).and_return(dashboard_double)
@@ -63,14 +63,14 @@ describe Administrate::Field::HasMany do
       field = association.new(:customers, [], :show)
       field.associated_collection
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:class_name is deprecated/)
     end
   end
 
   describe "primary_key option" do
     before do
-      allow(ActiveSupport::Deprecation).to receive(:warn)
+      allow(Administrate.deprecator).to receive(:warn)
 
       Foo = Class.new
       FooDashboard = Class.new
@@ -108,7 +108,7 @@ describe Administrate::Field::HasMany do
       field = association.new(:customers, [], :show)
       field.associated_resource_options
 
-      expect(ActiveSupport::Deprecation).to have_received(:warn).
+      expect(Administrate.deprecator).to have_received(:warn).
         with(/:primary_key is deprecated/)
     end
   end

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -43,7 +43,7 @@ describe Administrate::Field::HasOne do
   describe ".permitted_attribute" do
     context "with custom class_name" do
       before do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
+        allow(Administrate.deprecator).to receive(:warn)
       end
 
       it "returns attributes from correct dashboard" do
@@ -71,7 +71,7 @@ describe Administrate::Field::HasOne do
           field_name,
           resource_class: Product,
         )
-        expect(ActiveSupport::Deprecation).to have_received(:warn).
+        expect(Administrate.deprecator).to have_received(:warn).
           with(/:class_name is deprecated/)
       end
     end


### PR DESCRIPTION
#### Description
Rails 7.1 started deprecating the direct usage of `ActiveSupport::Deprecation` methods. Instead, the preferred way is to instantiate the class and use the custom instance.

This PR adds the deprecator instance and switches the warn calls to use it. 
Compatible with Rails 4.0+

#### Deprecation example
Each deprecation originating from Administrate is accompanied by a [Rails 7.1 deprecation](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/deprecation/instance_delegator.rb#L37).
```
DEPRECATION WARNING: The method `valid_action?` is deprecated. Please use `accessible_action?` instead, or see the documentation for other options. (called from index at /backend/app/controllers/concerns/admin_search.rb:13)
DEPRECATION WARNING: Calling warn on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use your own Deprecation object instead) (called from index at /backend/app/controllers/concerns/admin_search.rb:13)
```
