### PR TITLE
Fix the bundle audit workflow

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Bundler Audit'
-        uses: andrewmcodes/bundler-audit-action@main
+        uses: thoughtbot/bundler-audit-action@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Bundler Audit GitHub Action is currently not working as intended. We're getting an error when running it:

```
Build container for action use: '/home/runner/work/_actions/andrewmcodes/bundler-audit-action/main/Dockerfile'.
Error: Docker build failed with exit code [1](https://github.com/thoughtbot/administrate/actions/runs/7242901249/job/19728958725?pr=2474#step:2:1)
```
There's a PR to fix the issue on the repository, but we can use the thoughtbot fork in the meantime. 
