### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Global rule:
+*           @nickcharlton


### PR DESCRIPTION
As part of our work to easily identify the maintainers of our open source projects, this PR adds a [CODEOWNER](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file.

What it does:

Automatically include people as reviewers on pull requests
Provide a clear reference of who should be answering questions and making decisions
Make it easy to search for projects which need a new owner when needed
I'm adding only @nickcharlton as I've seen PRs from him lately. Let me know if it's incorrect. Thanks!