### PR TITLE
Yield created resource if block is given

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -44,6 +44,7 @@ module Administrate
       authorize_resource(resource)
 
       if resource.save
+        yield(resource) if block_given?
         redirect_to(
           after_resource_created_path(resource),
           notice: translate_with_resource("create.success"),

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -93,3 +93,17 @@ To set custom redirects after the actions `create`, `update` and `destroy` you c
       [namespace, requested_resource.some_other_resource]
     end
 ```
+
+## Creating Records
+
+You can perform actions after creation by passing a `block` to `super` in the
+`create` method. The block will only be called if the resource is successfully
+created.
+
+```ruby
+def create
+  super do |resource|
+    # do something with the newly created resource
+  end
+end
+```

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     end
   end
 
+  describe "creation yeilds resource" do
+    controller(Admin::OrdersController) do
+      attr_reader :resource
+
+      def create
+        super do |resource|
+          @resource = resource
+        end
+      end
+    end
+
+    it "yields the created resource after creation" do
+      customer = create(:customer)
+      order_attributes = build(:order, customer: customer).attributes
+      params = order_attributes.except(
+        "id",
+        "created_at",
+        "updated_at",
+        "shipped_at",
+      )
+
+      post :create, params: { order: params }
+
+      expect(controller.resource).to be_a(Order)
+    end
+  end
+
   describe "authorization" do
     controller(Administrate::ApplicationController) do
       def resource_class


### PR DESCRIPTION
Creates an interface to allow you to trigger actions after a resource is created (for example run a background job).

Right now you can do this in the `after_resource_created_path` but it doesn't quite feel right to have a side affect in a method that is supposed to be determining the redirection path. 