### PR TITLE
Fix path in page customization documentation

### DIFF
--- a/docs/customizing_page_views.md
+++ b/docs/customizing_page_views.md
@@ -10,7 +10,7 @@ In general, you can override any of the views under Administrate's
 [/app/views][1].
 For example, say that you want to customize the template used for flash
 messages. You can provide your own as
-`/app/views/administrate/application/_flashes.html.erb`, and it will replace
+`app/views/admin/application/_flashes.html.erb`, and it will replace
 Administrate's own.
 
 Figuring out which views are available and where can be repetitive. You can


### PR DESCRIPTION
The path for the flashes view was incorrect which could have led to some confusion
on where the views are located. I've tested all the generators and everything works
as expected. Since its mentioned at the top of the documentation where all views
are located (for the case when someone doesn't want to use a generator or if ther
isn't one), I didn't add it again at the end.