### PR TITLE
Fix generator path for namespaced models

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -37,15 +37,18 @@ module Administrate
       source_root File.expand_path("../templates", __FILE__)
 
       def create_dashboard_definition
+        scope = regular_class_path.join("/")
+
         template(
           "dashboard.rb.erb",
-          Rails.root.join("app/dashboards/#{file_name}_dashboard.rb")
+          Rails.root.join("app/dashboards/#{scope}/#{file_name}_dashboard.rb")
         )
       end
 
       def create_resource_controller
+        scope = "#{namespace}/#{regular_class_path.join("/")}"
         destination = Rails.root.join(
-          "app/controllers/#{namespace}/#{file_name.pluralize}_controller.rb"
+          "app/controllers/#{scope}/#{file_name.pluralize}_controller.rb"
         )
 
         template("controller.rb.erb", destination)

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -431,5 +431,28 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       remove_constants :Foo
       Manager.send(:remove_const, :FoosController)
     end
+
+    it "uses the given model namespace to create controllers" do
+      ActiveRecord::Schema.define { create_table :foo_bars }
+      module Foo
+        def self.table_name_prefix
+          "foo_"
+        end
+
+        class Bar < Administrate::Generators::TestRecord; end
+      end
+
+      run_generator ["Foo::Bar"]
+      path = file("app/controllers/admin/foo/bars_controller.rb")
+      result = File.foreach(path).first(2).join
+      expected = <<~EXPECTED
+        module Admin
+          class Foo::BarsController < Admin::ApplicationController
+      EXPECTED
+
+      expect(result).to eq(expected)
+    ensure
+      remove_constants :Foo
+    end
   end
 end


### PR DESCRIPTION
Running a generator with a model that is namespaced, for example `Foo::Bar` puts the generated files in:
- `app/controllers/admin/bars_controller.rb`
- `app/dashboards/bar_dashboard.rb`

The correct location is:
- `app/controllers/admin/foo/bars_controller.rb`
- `app/dashboards/foo/bar_dashboard.rb`

This change ensures files are generated in the proper location. Without it the directory needs to be created and files need to be moved manually.

I've also added a `docker-compose.yml` file for easy running of specs on local.