### PR TITLE
Enable running workflows from forks

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -1,6 +1,11 @@
 ---
 name: Bundler Audit
-on: [push]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   audit:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,11 @@
 ---
-name: "CodeQL"
-
+name: CodeQL
 on:
   push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: '44 6 * * 4'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 ---
-name: CI
-on: [push]
+name: Tests
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:


### PR DESCRIPTION
The simple `push` event doesn't support pull requests from forks where
the author doesn't already have write access to the repository.

This adds the default set of events on the `pull_request` event which
lets forks run the test suite.

In addition, this expands that pattern to our other workflows
(`bundle-audit` and `codeql-analysis`), whilst restricting the `push`
workflow to only occur on `main` (which should mean re-triggering
workflows on merge). This is to stop duplicating the builds when
triggered by an actor with write access.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request https://securitylab.github.com/research/github-actions-preventing-pwn-requests