### PR TITLE
Fix bug where layout wasn't respecting namespace argument

### DIFF
--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -9,7 +9,7 @@ module Administrate
         def copy_template
           copy_file(
             "../../layouts/administrate/application.html.erb",
-            "app/views/layouts/admin/application.html.erb"
+            "app/views/layouts/#{namespace}/application.html.erb"
           )
 
           call_generator("administrate:views:navigation")

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -16,6 +16,19 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
       expect(contents).to eq(expected_contents)
     end
 
+    it "copies the layout template into the `namespace=<namespace>` dir" do
+      allow(Rails::Generators).to receive(:invoke)
+      expected_contents = File.read(
+        "app/views/layouts/administrate/application.html.erb"
+      )
+      generated_file = file("app/views/layouts/console/application.html.erb")
+
+      run_generator ["--namespace", "console"]
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
+
     it "copies the flashes partial into the `admin/application` namespace" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = contents_for_application_template("_flashes")


### PR DESCRIPTION
When generating the layout, the namespace argument was ignored. 