### PR TITLE
Stop saying Administrate doesn't have a DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ and to be easier for developers to customize.
 
 To accomplish these goals, Administrate follows a few guiding principles:
 
-- No DSLs (domain-specific languages)
+- Stay as close to standard Rails as possible, keeping the
+  Administrate-specific code as small as practical,
 - Support the simplest use cases, and let the user override defaults with
-  standard tools such as plain Rails controllers and views.
+  standard tools such as plain Rails controllers and views,
 - Break up the library into core components and plugins,
   so each component stays small and easy to maintain.
 


### PR DESCRIPTION
The original intent of the line in the README was to emphasise that it's not fully DSL-driven, instead as close to standard Rails as possible.

This rephrases to avoid saying "we don't have a DSL", but try and provide a more useful way to describe the projects' vision.

Closes #2267