### PR TITLE
Lint Ruby with standardrb

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,18 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  standardrb:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: StandardRB Linter
+        uses: testdouble/standard-ruby-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   stylelint:
     runs-on: ubuntu-latest
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 ruby "3.2.2" unless ENV["CI"]
 
 gemspec
@@ -27,6 +27,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.13"
   gem "pry"
+  gem "standard"
   gem "yard"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
       terminal-table (>= 1.5.1)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
+    json (2.7.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -176,8 +177,10 @@ GEM
       kaminari
       rails
     kgio (2.11.4)
+    language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
+    lint_roller (1.1.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -205,6 +208,7 @@ GEM
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
@@ -274,6 +278,23 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rubocop (1.59.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.20.2)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+    ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     selenium-webdriver (4.17.0)
       base64 (~> 0.2)
@@ -295,6 +316,18 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    standard (1.33.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.59.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.3)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.3.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.20.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
@@ -355,6 +388,7 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers
   sprockets-rails (~> 3.4)
+  standard
   timecop
   uglifier
   unicorn

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,19 @@
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 
-require File.expand_path('../spec/example_app/config/application', __FILE__)
+require File.expand_path("../spec/example_app/config/application", __FILE__)
 
 RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Administrate'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_dir = "rdoc"
+  rdoc.title = "Administrate"
+  rdoc.options << "--line-numbers"
+  rdoc.rdoc_files.include("README.rdoc")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
 Bundler::GemHelper.install_tasks

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -18,18 +18,18 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord", ">= 6.0", "< 8.0"
   s.add_dependency "kaminari", "~> 1.2.2"
 
-  s.description = <<-DESCRIPTION
-Administrate is heavily inspired by projects like Rails Admin and ActiveAdmin,
-but aims to provide a better user experience for site admins,
-and to be easier for developers to customize.
-
-To do that, we're following a few simple rules:
-
-- No DSLs (domain-specific languages)
-- Support the simplest use cases,
-  and let the user override defaults with standard tools
-  such as plain Rails controllers and views.
-- Break up the library into core components and plugins,
-  so each component stays small and easy to maintain.
+  s.description = <<~DESCRIPTION
+    Administrate is heavily inspired by projects like Rails Admin and ActiveAdmin,
+    but aims to provide a better user experience for site admins,
+    and to be easier for developers to customize.
+    
+    To do that, we're following a few simple rules:
+    
+    - No DSLs (domain-specific languages)
+    - Support the simplest use cases,
+      and let the user override defaults with standard tools
+      such as plain Rails controllers and views.
+    - Break up the library into core components and plugins,
+      so each component stays small and easy to maintain.
   DESCRIPTION
 end

--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -15,13 +15,13 @@ module Administrate
         resources: resources,
         search_term: search_term,
         page: page,
-        show_search_bar: show_search_bar?,
+        show_search_bar: show_search_bar?
       }
     end
 
     def show
       render locals: {
-        page: Administrate::Page::Show.new(dashboard, requested_resource),
+        page: Administrate::Page::Show.new(dashboard, requested_resource)
       }
     end
 
@@ -29,13 +29,13 @@ module Administrate
       resource = new_resource
       authorize_resource(resource)
       render locals: {
-        page: Administrate::Page::Form.new(dashboard, resource),
+        page: Administrate::Page::Form.new(dashboard, resource)
       }
     end
 
     def edit
       render locals: {
-        page: Administrate::Page::Form.new(dashboard, requested_resource),
+        page: Administrate::Page::Form.new(dashboard, requested_resource)
       }
     end
 
@@ -47,11 +47,11 @@ module Administrate
         yield(resource) if block_given?
         redirect_to(
           after_resource_created_path(resource),
-          notice: translate_with_resource("create.success"),
+          notice: translate_with_resource("create.success")
         )
       else
         render :new, locals: {
-          page: Administrate::Page::Form.new(dashboard, resource),
+          page: Administrate::Page::Form.new(dashboard, resource)
         }, status: :unprocessable_entity
       end
     end
@@ -60,11 +60,11 @@ module Administrate
       if requested_resource.update(resource_params)
         redirect_to(
           after_resource_updated_path(requested_resource),
-          notice: translate_with_resource("update.success"),
+          notice: translate_with_resource("update.success")
         )
       else
         render :edit, locals: {
-          page: Administrate::Page::Form.new(dashboard, requested_resource),
+          page: Administrate::Page::Form.new(dashboard, requested_resource)
         }, status: :unprocessable_entity
       end
     end
@@ -84,12 +84,12 @@ module Administrate
       Administrate::Search.new(
         resources,
         dashboard,
-        search_term,
+        search_term
       ).run
     end
 
     def after_resource_destroyed_path(_requested_resource)
-      { action: :index }
+      {action: :index}
     end
 
     def after_resource_created_path(requested_resource)
@@ -103,7 +103,7 @@ module Administrate
     helper_method :nav_link_state
     def nav_link_state(resource)
       underscore_resource = resource.to_s.split("/").join("__")
-      resource_name.to_s.pluralize == underscore_resource ? :active : :inactive
+      (resource_name.to_s.pluralize == underscore_resource) ? :active : :inactive
     end
 
     # Whether the named action route exists for the resource class.
@@ -141,8 +141,8 @@ module Administrate
         sorting_attribute,
         sorting_direction,
         association_attribute: order_by_field(
-          dashboard_attribute(sorting_attribute),
-        ),
+          dashboard_attribute(sorting_attribute)
+        )
       )
     end
 
@@ -201,9 +201,9 @@ module Administrate
     end
 
     def resource_params
-      params.require(resource_class.model_name.param_key).
-        permit(dashboard.permitted_attributes(action_name)).
-        transform_values { |v| read_param_value(v) }
+      params.require(resource_class.model_name.param_key)
+        .permit(dashboard.permitted_attributes(action_name))
+        .transform_values { |v| read_param_value(v) }
     end
 
     def read_param_value(data)
@@ -236,13 +236,13 @@ module Administrate
     def translate_with_resource(key)
       t(
         "administrate.controller.#{key}",
-        resource: resource_resolver.resource_title,
+        resource: resource_resolver.resource_title
       )
     end
 
     def show_search_bar?
       dashboard.attribute_types_for(
-        dashboard.all_attributes,
+        dashboard.all_attributes
       ).any? { |_name, attribute| attribute.searchable? }
     end
 
@@ -279,7 +279,7 @@ module Administrate
       else
         raise Administrate::NotAuthorizedError.new(
           action: action_name,
-          resource: resource,
+          resource: resource
         )
       end
     end

--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -1,6 +1,6 @@
 module Administrate
   module Punditize
-    if Object.const_defined?("Pundit")
+    if Object.const_defined?(:Pundit)
       extend ActiveSupport::Concern
 
       if Pundit.const_defined?(:Authorization)
@@ -28,7 +28,7 @@ module Administrate
       def authorized_action?(resource, action)
         namespaced_resource = policy_namespace + [resource]
         policy = Pundit.policy!(pundit_user, namespaced_resource)
-        policy.send("#{action}?".to_sym)
+        policy.send(:"#{action}?")
       end
 
       def policy_scope!(user, scope)
@@ -38,13 +38,13 @@ module Administrate
           policy_scope = policy_scope_class.new(user, pundit_model(scope))
         rescue ArgumentError
           raise(Pundit::InvalidConstructorError,
-                "Invalid #<#{policy_scope_class}> constructor is called")
+            "Invalid #<#{policy_scope_class}> constructor is called")
         end
 
         if policy_scope.respond_to? :resolve_admin
           Administrate.deprecator.warn(
-            "Pundit policy scope `resolve_admin` method is deprecated. " +
-            "Please use a namespaced pundit policy instead.",
+            "Pundit policy scope `resolve_admin` method is deprecated. " \
+            "Please use a namespaced pundit policy instead."
           )
           policy_scope.resolve_admin
         else

--- a/app/helpers/administrate/application_helper.rb
+++ b/app/helpers/administrate/application_helper.rb
@@ -50,7 +50,7 @@ module Administrate
     def display_resource_name(resource_name, opts = {})
       dashboard_from_resource(resource_name).resource_name(
         count: opts[:singular] ? SINGULAR_COUNT : PLURAL_MANY_COUNT,
-        default: default_resource_name(resource_name, opts),
+        default: default_resource_name(resource_name, opts)
       )
     end
 
@@ -65,14 +65,14 @@ module Administrate
     def resource_index_route(resource_name)
       url_for(
         action: "index",
-        controller: "/#{namespace}/#{resource_name}",
+        controller: "/#{namespace}/#{resource_name}"
       )
     end
 
     def sanitized_order_params(page, current_field_name)
       collection_names = page.item_associations + [current_field_name]
       association_params = collection_names.map do |assoc_name|
-        { assoc_name => %i[order direction page per_page] }
+        {assoc_name => %i[order direction page per_page]}
       end
       params.permit(:search, :id, :_page, :per_page, association_params)
     end
@@ -87,7 +87,7 @@ module Administrate
 
     def default_resource_name(name, opts = {})
       resource_name = (opts[:singular] ? name.to_s : name.to_s.pluralize)
-      resource_name.gsub("/", "_").titleize
+      resource_name.tr("/", "_").titleize
     end
   end
 end

--- a/gemfiles/pundit21.gemfile
+++ b/gemfiles/pundit21.gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.13"
   gem "pry"
+  gem "standard"
   gem "yard"
 end
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.13"
   gem "pry"
+  gem "standard"
   gem "yard"
 end
 

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.13"
   gem "pry"
+  gem "standard"
   gem "yard"
 end
 

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.13"
   gem "pry"
+  gem "standard"
   gem "yard"
 end
 

--- a/lib/administrate.rb
+++ b/lib/administrate.rb
@@ -4,39 +4,39 @@ require "administrate/version"
 module Administrate
   def self.warn_of_missing_resource_class
     deprecator.warn(
-      "Calling Field::Base.permitted_attribute without the option " +
-      ":resource_class is deprecated. If you are seeing this " +
-      "message, you are probably using a custom field type that" +
-      "does this. Please make sure to update it to a version that " +
-      "does not use a deprecated API",
+      "Calling Field::Base.permitted_attribute without the option " \
+      ":resource_class is deprecated. If you are seeing this " \
+      "message, you are probably using a custom field type that" \
+      "does this. Please make sure to update it to a version that " \
+      "does not use a deprecated API"
     )
   end
 
   def self.warn_of_deprecated_option(name)
     deprecator.warn(
-      "The option :#{name} is deprecated. " +
-      "Administrate should detect it automatically. " +
-      "Please file an issue at " +
-      "https://github.com/thoughtbot/administrate/issues " +
-      "if you think otherwise.",
+      "The option :#{name} is deprecated. " \
+      "Administrate should detect it automatically. " \
+      "Please file an issue at " \
+      "https://github.com/thoughtbot/administrate/issues " \
+      "if you think otherwise."
     )
   end
 
   def self.warn_of_deprecated_method(klass, method)
     deprecator.warn(
-      "The method #{klass}##{method} is deprecated. " +
-      "If you are seeing this message you are probably " +
-      "using a dashboard that depends explicitly on it. " +
-      "Please make sure you update it to a version that " +
-      "does not use a deprecated API",
+      "The method #{klass}##{method} is deprecated. " \
+      "If you are seeing this message you are probably " \
+      "using a dashboard that depends explicitly on it. " \
+      "Please make sure you update it to a version that " \
+      "does not use a deprecated API"
     )
   end
 
   def self.warn_of_deprecated_authorization_method(method)
     deprecator.warn(
-      "The method `#{method}` is deprecated. " +
-      "Please use `accessible_action?` instead, " +
-      "or see the documentation for other options.",
+      "The method `#{method}` is deprecated. " \
+      "Please use `accessible_action?` instead, " \
+      "or see the documentation for other options."
     )
   end
 

--- a/lib/administrate/base_dashboard.rb
+++ b/lib/administrate/base_dashboard.rb
@@ -79,7 +79,7 @@ module Administrate
         attribute_types[attr].permitted_attribute(
           attr,
           resource_class: self.class.model,
-          action: action,
+          action: action
         )
       end.uniq
     end
@@ -118,10 +118,10 @@ module Administrate
 
     def item_associations
       attributes = if show_page_attributes.is_a?(Hash)
-                     show_page_attributes.values.flatten
-                   else
-                     show_page_attributes
-                   end
+        show_page_attributes.values.flatten
+      else
+        show_page_attributes
+      end
       attribute_associated attributes
     end
 

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -9,7 +9,6 @@ require "administrate/order"
 require "administrate/resource_resolver"
 require "administrate/search"
 require "administrate/namespace"
-require "administrate/namespace/resource"
 
 module Administrate
   class Engine < ::Rails::Engine
@@ -21,7 +20,7 @@ module Administrate
     initializer "administrate.assets.precompile" do |app|
       app.config.assets.precompile += [
         "administrate/application.js",
-        "administrate/application.css",
+        "administrate/application.css"
       ]
     end
 

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -41,7 +41,7 @@ module Administrate
         else
           self.class.associated_class_name(
             resource.class,
-            attribute,
+            attribute
           )
         end
       end

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -56,13 +56,13 @@ module Administrate
         return false unless resource.class.respond_to?(:validators_on)
 
         resource.class.validators_on(attribute).any? do |v|
-          next false unless v.class == ActiveRecord::Validations::PresenceValidator
+          next false unless v.instance_of?(ActiveRecord::Validations::PresenceValidator)
 
           options = v.options
           next false if options.include?(:if)
           next false if options.include?(:unless)
 
-          if on_option = options[:on]
+          if (on_option = options[:on])
             if on_option == :create && !resource.persisted?
               next true
             end

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -25,7 +25,7 @@ module Administrate
         candidate_resources.map do |resource|
           [
             display_candidate_resource(resource),
-            resource.send(association_primary_key),
+            resource.send(association_primary_key)
           ]
         end
       end

--- a/lib/administrate/field/date.rb
+++ b/lib/administrate/field/date.rb
@@ -6,7 +6,7 @@ module Administrate
       def date
         I18n.localize(
           data.to_date,
-          format: format,
+          format: format
         )
       end
 

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -6,7 +6,7 @@ module Administrate
       def date
         I18n.localize(
           data.in_time_zone(timezone).to_date,
-          format: format,
+          format: format
         )
       end
 
@@ -14,7 +14,7 @@ module Administrate
         I18n.localize(
           data.in_time_zone(timezone),
           format: format,
-          default: data,
+          default: data
         )
       end
 

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -35,7 +35,7 @@ module Administrate
 
       def searchable_field
         Administrate.deprecator.warn(
-          "searchable_field is deprecated, use searchable_fields instead",
+          "searchable_field is deprecated, use searchable_fields instead"
         )
         options.fetch(:searchable_field)
       end

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -18,14 +18,14 @@ module Administrate
         # be `country_ids` instead.
         #
         # See https://github.com/rails/rails/blob/b30a23f53b52e59d31358f7b80385ee5c2ba3afe/activerecord/lib/active_record/associations/builder/collection_association.rb#L48
-        { "#{attr.to_s.singularize}_ids".to_sym => [] }
+        {"#{attr.to_s.singularize}_ids": []}
       end
 
       def associated_collection(order = self.order)
         Administrate::Page::Collection.new(
           associated_dashboard,
           order: order,
-          collection_attributes: options[:collection_attributes],
+          collection_attributes: options[:collection_attributes]
         )
       end
 
@@ -37,7 +37,7 @@ module Administrate
         candidate_resources.map do |associated_resource|
           [
             display_candidate_resource(associated_resource),
-            associated_resource.send(association_primary_key),
+            associated_resource.send(association_primary_key)
           ]
         end
       end
@@ -59,7 +59,7 @@ module Administrate
       def permitted_attribute
         self.class.permitted_attribute(
           attribute,
-          resource_class: resource.class,
+          resource_class: resource.class
         )
       end
 
@@ -82,7 +82,7 @@ module Administrate
       def order_from_params(params)
         Administrate::Order.new(
           params.fetch(:order, sort_by),
-          params.fetch(:direction, direction),
+          params.fetch(:direction, direction)
         )
       end
 

--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -20,10 +20,10 @@ module Administrate
             end
           end
         related_dashboard_attributes =
-          Administrate::ResourceResolver.
-            new("admin/#{final_associated_class_name}").
-            dashboard_class.new.permitted_attributes + [:id]
-        { "#{attr}_attributes": related_dashboard_attributes }
+          Administrate::ResourceResolver
+            .new("admin/#{final_associated_class_name}")
+            .dashboard_class.new.permitted_attributes + [:id]
+        {"#{attr}_attributes": related_dashboard_attributes}
       end
 
       def self.eager_load?
@@ -33,14 +33,14 @@ module Administrate
       def nested_form
         @nested_form ||= Administrate::Page::Form.new(
           resolver.dashboard_class.new,
-          data || resolver.resource_class.new,
+          data || resolver.resource_class.new
         )
       end
 
       def nested_show
         @nested_show ||= Administrate::Page::Show.new(
           resolver.dashboard_class.new,
-          data || resolver.resource_class.new,
+          data || resolver.resource_class.new
         )
       end
 

--- a/lib/administrate/field/number.rb
+++ b/lib/administrate/field/number.rb
@@ -38,8 +38,8 @@ module Administrate
         formatter = options[:format][:formatter]
         formatter_options = options[:format][:formatter_options].to_h
 
-        ActiveSupport::NumberHelper.
-          try(formatter, result, **formatter_options) || result
+        ActiveSupport::NumberHelper
+          .try(formatter, result, **formatter_options) || result
       end
     end
   end

--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -4,7 +4,7 @@ module Administrate
   module Field
     class Polymorphic < BelongsTo
       def self.permitted_attribute(attr, _options = {})
-        { attr => %i{type value} }
+        {attr => %i[type value]}
       end
 
       def associated_resource_grouped_options
@@ -16,11 +16,11 @@ module Administrate
       end
 
       def permitted_attribute
-        { attribute => %i{type value} }
+        {attribute => %i[type value]}
       end
 
       def selected_global_id
-        data ? data.to_global_id : nil
+        data&.to_global_id
       end
 
       private

--- a/lib/administrate/generator_helpers.rb
+++ b/lib/administrate/generator_helpers.rb
@@ -7,7 +7,7 @@ module Administrate
     private
 
     def generator_options
-      { behavior: behavior }
+      {behavior: behavior}
     end
   end
 end

--- a/lib/administrate/namespace/resource.rb
+++ b/lib/administrate/namespace/resource.rb
@@ -21,7 +21,7 @@ module Administrate
       end
 
       def path
-        name.to_s.gsub("/", "_")
+        name.to_s.tr("/", "_")
       end
     end
   end

--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -48,7 +48,7 @@ module Administrate
     end
 
     def opposite_direction
-      direction == :asc ? :desc : :asc
+      (direction == :asc) ? :desc : :asc
     end
 
     def order_by_association(relation)
@@ -67,10 +67,10 @@ module Administrate
     def order_by_count(relation)
       klass = reflect_association(relation).klass
       query = klass.arel_table[klass.primary_key].count.public_send(direction)
-      relation.
-        left_joins(attribute.to_sym).
-        group(:id).
-        reorder(query)
+      relation
+        .left_joins(attribute.to_sym)
+        .group(:id)
+        .reorder(query)
     end
 
     def order_by_belongs_to(relation)
@@ -91,7 +91,7 @@ module Administrate
 
     def order_by_attribute(relation)
       relation.joins(
-        attribute.to_sym,
+        attribute.to_sym
       ).reorder(order_by_attribute_query)
     end
 

--- a/lib/administrate/page/base.rb
+++ b/lib/administrate/page/base.rb
@@ -12,7 +12,7 @@ module Administrate
       end
 
       def resource_path
-        @resource_path ||= resource_name.gsub("/", "_")
+        @resource_path ||= resource_name.tr("/", "_")
       end
 
       def collection_includes

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -5,7 +5,7 @@ module Administrate
     class Collection < Page::Base
       def attribute_names
         options.fetch(:collection_attributes, nil) ||
-        dashboard.collection_attributes
+          dashboard.collection_attributes
       end
 
       def attributes_for(resource)
@@ -25,7 +25,7 @@ module Administrate
       delegate :ordered_by?, to: :order
 
       def order_params_for(attr, key: resource_name)
-        { key => order.order_params_for(attr) }
+        {key => order.order_params_for(attr)}
       end
 
       private

--- a/lib/administrate/page/form.rb
+++ b/lib/administrate/page/form.rb
@@ -14,7 +14,7 @@ module Administrate
         attributes = dashboard.form_attributes(action)
 
         if attributes.is_a? Array
-          attributes = { "" => attributes }
+          attributes = {"" => attributes}
         end
 
         attributes.transform_values do |attrs|

--- a/lib/administrate/page/show.rb
+++ b/lib/administrate/page/show.rb
@@ -18,7 +18,7 @@ module Administrate
         attributes = dashboard.show_page_attributes
 
         if attributes.is_a? Array
-          attributes = { "" => attributes }
+          attributes = {"" => attributes}
         end
 
         attributes.transform_values do |attrs|

--- a/lib/administrate/resource_resolver.rb
+++ b/lib/administrate/resource_resolver.rb
@@ -35,7 +35,7 @@ module Administrate
     end
 
     def controller_path_parts
-      path_parts = controller_path.split("/")[1..-1]
+      path_parts = controller_path.split("/")[1..]
       path_parts << path_parts.pop.singularize
     end
 

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -59,8 +59,7 @@ module Administrate
         @scoped_resource.all
       else
         results = search_results(@scoped_resource)
-        results = filter_results(results)
-        results
+        filter_results(results)
       end
     end
 
@@ -112,9 +111,9 @@ module Administrate
     end
 
     def search_results(resources)
-      resources.
-        left_joins(tables_to_join).
-        where(query_template, *query_values)
+      resources
+        .left_joins(tables_to_join)
+        .where(query_template, *query_values)
     end
 
     def valid_filters
@@ -141,8 +140,8 @@ module Administrate
           end
         ActiveRecord::Base.connection.quote_table_name(unquoted_table_name)
       else
-        ActiveRecord::Base.connection.
-          quote_table_name(@scoped_resource.table_name)
+        ActiveRecord::Base.connection
+          .quote_table_name(@scoped_resource.table_name)
       end
     end
 

--- a/lib/administrate/view_generator.rb
+++ b/lib/administrate/view_generator.rb
@@ -9,13 +9,13 @@ module Administrate
       :namespace,
       type: :string,
       desc: "Namespace where the admin dashboards live",
-      default: "admin",
+      default: "admin"
     )
 
     def self.template_source_path
       File.expand_path(
         "../../../app/views/administrate/application",
-        __FILE__,
+        __FILE__
       )
     end
 
@@ -30,7 +30,7 @@ module Administrate
 
       copy_file(
         template_file,
-        "app/views/#{namespace}/#{resource_path}/#{template_file}",
+        "app/views/#{namespace}/#{resource_path}/#{template_file}"
       )
     end
 

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -13,14 +13,14 @@ module Administrate
         time: "Field::Time",
         text: "Field::Text",
         string: "Field::String",
-        uuid: "Field::String",
+        uuid: "Field::String"
       }
 
       ATTRIBUTE_OPTIONS_MAPPING = {
         # procs must be defined in one line!
-        enum: {  searchable: false,
-                 collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys } },
-        float: { decimals: 2 },
+        enum: {searchable: false,
+               collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }},
+        float: {decimals: 2}
       }
 
       DEFAULT_FIELD_TYPE = "Field::String.with_options(searchable: false)"
@@ -31,7 +31,7 @@ module Administrate
         :namespace,
         type: :string,
         desc: "Namespace where the admin dashboards live",
-        default: "admin",
+        default: "admin"
       )
 
       source_root File.expand_path("../templates", __FILE__)
@@ -39,13 +39,13 @@ module Administrate
       def create_dashboard_definition
         template(
           "dashboard.rb.erb",
-          Rails.root.join("app/dashboards/#{file_name}_dashboard.rb"),
+          Rails.root.join("app/dashboards/#{file_name}_dashboard.rb")
         )
       end
 
       def create_resource_controller
         destination = Rails.root.join(
-          "app/controllers/#{namespace}/#{file_name.pluralize}_controller.rb",
+          "app/controllers/#{namespace}/#{file_name.pluralize}_controller.rb"
         )
 
         template("controller.rb.erb", destination)
@@ -72,7 +72,7 @@ module Administrate
           primary_key,
           *attrs.sort,
           created_at,
-          updated_at,
+          updated_at
         ].compact
       end
 
@@ -116,7 +116,7 @@ module Administrate
 
       def enum_column?(attr)
         klass.respond_to?(:defined_enums) &&
-          klass.defined_enums.keys.include?(attr)
+          klass.defined_enums.key?(attr)
       end
 
       def column_types(attr)

--- a/lib/generators/administrate/field/field_generator.rb
+++ b/lib/generators/administrate/field/field_generator.rb
@@ -6,7 +6,7 @@ module Administrate
       def template_field_object
         template(
           "field_object.rb.erb",
-          "app/fields/#{file_name}_field.rb",
+          "app/fields/#{file_name}_field.rb"
         )
       end
 
@@ -23,7 +23,7 @@ module Administrate
 
         copy_file(
           partial,
-          "app/views/fields/#{file_name}_field/#{partial}",
+          "app/views/fields/#{file_name}_field/#{partial}"
         )
       end
     end

--- a/lib/generators/administrate/install/install_generator.rb
+++ b/lib/generators/administrate/install/install_generator.rb
@@ -18,7 +18,7 @@ module Administrate
         :namespace,
         type: :string,
         desc: "Namespace where the admin dashboards will live",
-        default: "admin",
+        default: "admin"
       )
 
       def run_routes_generator
@@ -31,7 +31,7 @@ module Administrate
       def create_dashboard_controller
         template(
           "application_controller.rb.erb",
-          "app/controllers/#{namespace}/application_controller.rb",
+          "app/controllers/#{namespace}/application_controller.rb"
         )
       end
 

--- a/lib/generators/administrate/routes/routes_generator.rb
+++ b/lib/generators/administrate/routes/routes_generator.rb
@@ -18,7 +18,7 @@ module Administrate
         :namespace,
         type: :string,
         desc: "Namespace where the admin dashboards live",
-        default: "admin",
+        default: "admin"
       )
 
       def insert_dashboard_routes
@@ -61,10 +61,10 @@ module Administrate
       end
 
       def database_models
-        ActiveRecord::Base.descendants.
-          reject(&:abstract_class?).
-          reject { |k| k < Administrate::Generators::TestRecord }.
-          sort_by(&:to_s)
+        ActiveRecord::Base.descendants
+          .reject(&:abstract_class?)
+          .reject { |k| k < Administrate::Generators::TestRecord }
+          .sort_by(&:to_s)
       end
 
       def invalid_dashboard_models

--- a/lib/generators/administrate/views/field_generator.rb
+++ b/lib/generators/administrate/views/field_generator.rb
@@ -7,7 +7,7 @@ module Administrate
         def self.template_source_path
           File.expand_path(
             "../../../../../app/views/fields/",
-            __FILE__,
+            __FILE__
           )
         end
 
@@ -41,7 +41,7 @@ module Administrate
 
           copy_file(
             template_file,
-            "app/views/fields/#{template_file}",
+            "app/views/fields/#{template_file}"
           )
         end
       end

--- a/lib/generators/administrate/views/layout_generator.rb
+++ b/lib/generators/administrate/views/layout_generator.rb
@@ -9,7 +9,7 @@ module Administrate
         def copy_template
           copy_file(
             "../../layouts/administrate/application.html.erb",
-            "app/views/layouts/admin/application.html.erb",
+            "app/views/layouts/admin/application.html.erb"
           )
 
           call_generator("administrate:views:navigation")

--- a/spec/administrate/views/fields/belongs_to/_index_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_index_spec.rb
@@ -10,7 +10,7 @@ describe "fields/belongs_to/_index", type: :view do
       "Administrate::Field::BelongsTo",
       associated_class: associated_class,
       display_associated_resource: product.name,
-      data: product,
+      data: product
     )
   end
 
@@ -19,7 +19,7 @@ describe "fields/belongs_to/_index", type: :view do
       instance_double(
         "Administrate::Field::BelongsTo",
         associated_class: associated_class,
-        data: nil,
+        data: nil
       )
     end
 
@@ -58,7 +58,7 @@ describe "fields/belongs_to/_index", type: :view do
   def render_belongs_to_index
     render(
       partial: "fields/belongs_to/index",
-      locals: { field: belongs_to, namespace: :admin },
+      locals: {field: belongs_to, namespace: :admin}
     )
   end
 end

--- a/spec/administrate/views/fields/belongs_to/_show_spec.rb
+++ b/spec/administrate/views/fields/belongs_to/_show_spec.rb
@@ -10,7 +10,7 @@ describe "fields/belongs_to/_show", type: :view do
       "Administrate::Field::BelongsTo",
       associated_class: associated_class,
       display_associated_resource: product.name,
-      data: product,
+      data: product
     )
   end
 
@@ -43,7 +43,7 @@ describe "fields/belongs_to/_show", type: :view do
   def render_belongs_to_show
     render(
       partial: "fields/belongs_to/show",
-      locals: { field: belongs_to, namespace: :admin },
+      locals: {field: belongs_to, namespace: :admin}
     )
   end
 end

--- a/spec/administrate/views/fields/date_time/_index_spec.rb
+++ b/spec/administrate/views/fields/date_time/_index_spec.rb
@@ -8,12 +8,12 @@ describe "fields/date_time/_index", type: :view do
         format: #{Time::DATE_FORMATS[:default]}
       )",
       data: product,
-      datetime: product.created_at,
+      datetime: product.created_at
     )
 
     render(
       partial: "fields/date_time/index",
-      locals: { field: date_time, namespace: :admin },
+      locals: {field: date_time, namespace: :admin}
     )
   end
 end

--- a/spec/administrate/views/fields/has_many/_form_spec.rb
+++ b/spec/administrate/views/fields/has_many/_form_spec.rb
@@ -5,12 +5,12 @@ describe "fields/has_many/_form", type: :view do
     it "displays the association name" do
       has_many = double(
         attribute_key: :associated_object_ids,
-        attribute: :associated_objects,
+        attribute: :associated_objects
       )
 
       render(
         partial: "fields/has_many/form",
-        locals: { f: fake_form_builder, field: has_many },
+        locals: {f: fake_form_builder, field: has_many}
       )
 
       expect(rendered).to include("Associated objects")

--- a/spec/administrate/views/fields/has_many/_index_spec.rb
+++ b/spec/administrate/views/fields/has_many/_index_spec.rb
@@ -5,14 +5,14 @@ describe "fields/has_many/_index", type: :view do
     it "displays the pluralized attribute name" do
       has_many = double(
         data: double(
-          size: 0,
+          size: 0
         ),
-        attribute: :teams,
+        attribute: :teams
       )
 
       render(
         partial: "fields/has_many/index",
-        locals: { field: has_many },
+        locals: {field: has_many}
       )
 
       expect(rendered.strip).to eq("0 teams")
@@ -23,14 +23,14 @@ describe "fields/has_many/_index", type: :view do
     it "displays the singularized attribute name" do
       has_many = double(
         data: double(
-          size: 1,
+          size: 1
         ),
-        attribute: :teams,
+        attribute: :teams
       )
 
       render(
         partial: "fields/has_many/index",
-        locals: { field: has_many },
+        locals: {field: has_many}
       )
 
       expect(rendered.strip).to eq("1 team")
@@ -41,14 +41,14 @@ describe "fields/has_many/_index", type: :view do
     it "displays the pluralized attribute name" do
       has_many = double(
         data: double(
-          size: 2,
+          size: 2
         ),
-        attribute: :teams,
+        attribute: :teams
       )
 
       render(
         partial: "fields/has_many/index",
-        locals: { field: has_many },
+        locals: {field: has_many}
       )
 
       expect(rendered.strip).to eq("2 teams")

--- a/spec/administrate/views/fields/has_many/_show_spec.rb
+++ b/spec/administrate/views/fields/has_many/_show_spec.rb
@@ -7,7 +7,7 @@ describe "fields/has_many/_show", type: :view do
 
       render(
         partial: "fields/has_many/show",
-        locals: { field: has_many },
+        locals: {field: has_many}
       )
 
       expect(rendered.strip).to eq(t("administrate.fields.has_many.none"))

--- a/spec/administrate/views/fields/has_one/_form_spec.rb
+++ b/spec/administrate/views/fields/has_one/_form_spec.rb
@@ -8,12 +8,12 @@ describe "fields/has_one/_form", type: :view do
       attribute: "Meta",
       data: nil,
       nested_form: nested_form,
-      name: "product_tag",
+      name: "product_tag"
     )
 
     render(
       partial: "fields/has_one/form",
-      locals: { field: has_one, f: form_builder },
+      locals: {field: has_one, f: form_builder}
     )
 
     expect(rendered.strip).to include("Product Tag")
@@ -32,10 +32,10 @@ describe "fields/has_one/_form", type: :view do
     instance_double(
       "Administrate::Page::Show",
       resource: double(
-        class: ProductMetaTag,
+        class: ProductMetaTag
       ),
       attributes: [],
-      resource_name: "Product Tag",
+      resource_name: "Product Tag"
     )
   end
 end

--- a/spec/administrate/views/fields/has_one/_index_spec.rb
+++ b/spec/administrate/views/fields/has_one/_index_spec.rb
@@ -9,7 +9,7 @@ describe "fields/has_one/_index", type: :view do
       "Administrate::Field::HasOne",
       data: product,
       linkable?: true,
-      display_associated_resource: product.name,
+      display_associated_resource: product.name
     )
   end
 
@@ -17,7 +17,7 @@ describe "fields/has_one/_index", type: :view do
     let(:has_one) do
       instance_double(
         "Administrate::Field::HasOne",
-        linkable?: false,
+        linkable?: false
       )
     end
 
@@ -57,7 +57,7 @@ describe "fields/has_one/_index", type: :view do
   def render_has_one_index
     render(
       partial: "fields/has_one/index",
-      locals: { field: has_one, namespace: :admin },
+      locals: {field: has_one, namespace: :admin}
     )
   end
 end

--- a/spec/administrate/views/fields/has_one/_show_spec.rb
+++ b/spec/administrate/views/fields/has_one/_show_spec.rb
@@ -13,12 +13,12 @@ describe "fields/has_one/_show", type: :view do
       has_one = Administrate::Field::HasOne.new(
         :product_meta_tag,
         build(:product_meta_tag),
-        :show,
+        :show
       )
 
       render(
         partial: "fields/has_one/show",
-        locals: { field: has_one },
+        locals: {field: has_one}
       )
 
       expect(rendered.strip).to eq("")
@@ -35,17 +35,17 @@ describe "fields/has_one/_show", type: :view do
         name: "simple_string_field",
         truncate: "string value",
         html_class: "string",
-        to_partial_path: "fields/string/index",
+        to_partial_path: "fields/string/index"
       )
 
       nested_show_page_for_has_one = instance_double(
         "Administrate::Page::Show",
         resource: double(
-          class: ProductMetaTag,
+          class: ProductMetaTag
         ),
-        attributes: { "" => [
-          nested_simple_field,
-        ] },
+        attributes: {"" => [
+          nested_simple_field
+        ]}
       )
 
       @has_one_field = instance_double(
@@ -54,7 +54,7 @@ describe "fields/has_one/_show", type: :view do
         data: field_resource,
         linkable?: true,
         nested_show: nested_show_page_for_has_one,
-        associated_class_name: "NestedHasOne",
+        associated_class_name: "NestedHasOne"
       )
 
       @page_double = instance_double("Administrate::Page::Show")
@@ -66,8 +66,8 @@ describe "fields/has_one/_show", type: :view do
         locals: {
           field: @has_one_field,
           page: @page_double,
-          resource_name: "parent_resource",
-        },
+          resource_name: "parent_resource"
+        }
       )
     end
 
@@ -76,10 +76,10 @@ describe "fields/has_one/_show", type: :view do
         helpers: {
           label: {
             nested_has_one: {
-              simple_string_field: "Just a Simple String",
-            },
-          },
-        },
+              simple_string_field: "Just a Simple String"
+            }
+          }
+        }
       )
 
       render_field
@@ -123,15 +123,15 @@ describe "fields/has_one/_show", type: :view do
         data: nested_collection,
         html_class: "has-many",
         name: "payments",
-        to_partial_path: "fields/has_many/index",
+        to_partial_path: "fields/has_many/index"
       )
 
       nested_show_page_for_nested_has_one = instance_double(
         "Administrate::Page::Show",
         resource: double(
-          class: ProductMetaTag,
+          class: ProductMetaTag
         ),
-        attributes: { "" => [] },
+        attributes: {"" => []}
       )
 
       nested_has_one = instance_double(
@@ -143,12 +143,12 @@ describe "fields/has_one/_show", type: :view do
         html_class: "has-one",
         to_partial_path: "fields/has_one/show",
         display_associated_resource: "Resource Doubly Nested with HasOne",
-        name: "page",
+        name: "page"
       )
 
       nested_show_page_for_top_has_one = instance_double(
         "Administrate::Page::Show",
-        attributes: { "" => [nested_has_one, nested_has_many] },
+        attributes: {"" => [nested_has_one, nested_has_many]}
       )
 
       has_one_field = instance_double(
@@ -157,7 +157,7 @@ describe "fields/has_one/_show", type: :view do
         data: field_resource,
         linkable?: true,
         nested_show: nested_show_page_for_top_has_one,
-        associated_class_name: "NameOfAssociatedClass",
+        associated_class_name: "NameOfAssociatedClass"
       )
 
       page_double = instance_double("Administrate::Page::Show")
@@ -167,8 +167,8 @@ describe "fields/has_one/_show", type: :view do
         locals: {
           field: has_one_field,
           page: page_double,
-          resource_name: "product_meta_tag",
-        },
+          resource_name: "product_meta_tag"
+        }
       )
 
       expect(rendered.strip).to include("Resource Nested with HasOne")

--- a/spec/administrate/views/fields/polymorphic/_form_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_form_spec.rb
@@ -6,7 +6,7 @@ describe "fields/polymorphic/_form", type: :view do
 
     render(
       partial: "fields/polymorphic/form",
-      locals: { field: polymorphic, f: fake_form_builder },
+      locals: {field: polymorphic, f: fake_form_builder}
     )
 
     expect(rendered).to include("Parent")

--- a/spec/administrate/views/fields/polymorphic/_index_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_index_spec.rb
@@ -8,7 +8,7 @@ describe "fields/polymorphic/_index", type: :view do
     instance_double(
       "Administrate::Field::Polymorphic",
       data: product,
-      display_associated_resource: product.name,
+      display_associated_resource: product.name
     )
   end
 
@@ -16,7 +16,7 @@ describe "fields/polymorphic/_index", type: :view do
     let(:polymorphic) do
       instance_double(
         "Administrate::Field::Polymorphic",
-        data: nil,
+        data: nil
       )
     end
 
@@ -55,7 +55,7 @@ describe "fields/polymorphic/_index", type: :view do
   def render_polymorphic_index
     render(
       partial: "fields/polymorphic/index",
-      locals: { field: polymorphic, namespace: :admin },
+      locals: {field: polymorphic, namespace: :admin}
     )
   end
 end

--- a/spec/administrate/views/fields/polymorphic/_show_spec.rb
+++ b/spec/administrate/views/fields/polymorphic/_show_spec.rb
@@ -8,12 +8,12 @@ describe "fields/polymorphic/_show", type: :view do
       polymorphic = instance_double(
         "Administrate::Field::Polymorphic",
         display_associated_resource: "",
-        data: nil,
+        data: nil
       )
 
       render(
         partial: "fields/polymorphic/show",
-        locals: { field: polymorphic },
+        locals: {field: polymorphic}
       )
 
       expect(rendered.strip).to eq("")
@@ -28,14 +28,14 @@ describe "fields/polymorphic/_show", type: :view do
         "Administrate::Field::Polymorphic",
         display_associated_resource: product.name,
         data: product,
-        attribute: "product",
+        attribute: "product"
       )
 
       allow(view).to receive(:accessible_action?).and_return(true)
 
       render(
         partial: "fields/polymorphic/show",
-        locals: { field: polymorphic, namespace: :admin },
+        locals: {field: polymorphic, namespace: :admin}
       )
 
       expected = "<a href=\"#{product_path}\">#{product.name}</a>"

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -9,17 +9,17 @@ describe "fields/select/_form", type: :view do
       attribute: :email_subscriber,
       data: false,
       selectable_options: [true, false, nil],
-      include_blank_option: false,
+      include_blank_option: false
     )
 
     render(
       partial: "fields/select/form",
-      locals: { field: select, f: form_builder(customer) },
+      locals: {field: select, f: form_builder(customer)}
     )
 
     expect(rendered).to have_css(
-      %{select[name="customer[email_subscriber]"]
-        option[value="false"][selected="selected"]},
+      %(select[name="customer[email_subscriber]"]
+        option[value="false"][selected="selected"])
     )
   end
 
@@ -30,17 +30,17 @@ describe "fields/select/_form", type: :view do
       attribute: :email_subscriber,
       data: "Yes",
       selectable_options: ["Yes", "No"],
-      include_blank_option: "Unknown",
+      include_blank_option: "Unknown"
     )
 
     render(
       partial: "fields/select/form",
-      locals: { field: select, f: form_builder(customer) },
+      locals: {field: select, f: form_builder(customer)}
     )
 
     expect(rendered).to have_css(
-      %{select[name="customer[email_subscriber]"] option[value=""]},
-      text: "Unknown",
+      %(select[name="customer[email_subscriber]"] option[value=""]),
+      text: "Unknown"
     )
   end
 
@@ -49,7 +49,7 @@ describe "fields/select/_form", type: :view do
       object.model_name.singular,
       object,
       build_template,
-      {},
+      {}
     )
   end
 

--- a/spec/administrate/views/fields/time/_index_spec.rb
+++ b/spec/administrate/views/fields/time/_index_spec.rb
@@ -7,7 +7,7 @@ describe "fields/time/_index", type: :view do
 
       render(
         partial: "fields/time/index",
-        locals: { field: time },
+        locals: {field: time}
       )
 
       expect(rendered.strip).to eq("")
@@ -21,11 +21,11 @@ describe "fields/time/_index", type: :view do
       time = instance_double(
         "Administrate::Field::Time",
         data: customer.example_time,
-        time: "12:34PM",
+        time: "12:34PM"
       )
       render(
         partial: "fields/time/index",
-        locals: { field: time, namespace: :admin },
+        locals: {field: time, namespace: :admin}
       )
 
       expect(rendered.strip).to eq("12:34PM")

--- a/spec/administrate/views/fields/url/_form_spec.rb
+++ b/spec/administrate/views/fields/url/_form_spec.rb
@@ -7,15 +7,15 @@ describe "fields/url/_form", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       attribute: :image_url,
-      data: nil,
+      data: nil
     )
 
     render(
       partial: "fields/url/form",
-      locals: { field: url, f: form_builder(product) },
+      locals: {field: url, f: form_builder(product)}
     )
 
-    expect(rendered).to have_css(%{input[type="url"][name="product[image_url]"]})
+    expect(rendered).to have_css(%(input[type="url"][name="product[image_url]"]))
   end
 
   def form_builder(object)
@@ -23,7 +23,7 @@ describe "fields/url/_form", type: :view do
       object.model_name.singular,
       object,
       build_template,
-      {},
+      {}
     )
   end
 

--- a/spec/administrate/views/fields/url/_index_spec.rb
+++ b/spec/administrate/views/fields/url/_index_spec.rb
@@ -9,17 +9,17 @@ describe "fields/url/_index", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
-      html_options: {},
+      html_options: {}
     )
 
     render(
       partial: "fields/url/index",
-      locals: { field: url, namespace: :admin },
+      locals: {field: url, namespace: :admin}
     )
 
     expect(rendered).to have_css(
-      %{a[href="#{product.image_url}"]},
-      text: product.image_url,
+      %(a[href="#{product.image_url}"]),
+      text: product.image_url
     )
   end
 
@@ -27,17 +27,17 @@ describe "fields/url/_index", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
-      html_options: { referrerpolicy: "no-referrer" },
+      html_options: {referrerpolicy: "no-referrer"}
     )
 
     render(
       partial: "fields/url/show",
-      locals: { field: url, namespace: :admin },
+      locals: {field: url, namespace: :admin}
     )
 
     expect(rendered).to have_css(
-      %{a[href="#{product.image_url}"][referrerpolicy="no-referrer"]},
-      text: product.image_url,
+      %(a[href="#{product.image_url}"][referrerpolicy="no-referrer"]),
+      text: product.image_url
     )
   end
 end

--- a/spec/administrate/views/fields/url/_show_spec.rb
+++ b/spec/administrate/views/fields/url/_show_spec.rb
@@ -9,17 +9,17 @@ describe "fields/url/_show", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
-      html_options: {},
+      html_options: {}
     )
 
     render(
       partial: "fields/url/show",
-      locals: { field: url, namespace: :admin },
+      locals: {field: url, namespace: :admin}
     )
 
     expect(rendered).to have_css(
-      %{a[href="#{product.image_url}"]},
-      text: product.image_url,
+      %(a[href="#{product.image_url}"]),
+      text: product.image_url
     )
   end
 
@@ -27,17 +27,17 @@ describe "fields/url/_show", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
-      html_options: { target: "_blank" },
+      html_options: {target: "_blank"}
     )
 
     render(
       partial: "fields/url/show",
-      locals: { field: url, namespace: :admin },
+      locals: {field: url, namespace: :admin}
     )
 
     expect(rendered).to have_css(
-      %{a[href="#{product.image_url}"][target="_blank"]},
-      text: product.image_url,
+      %(a[href="#{product.image_url}"][target="_blank"]),
+      text: product.image_url
     )
   end
 end

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Admin::ApplicationController, type: :controller do
   describe "redirections after actions" do
     controller(Admin::OrdersController) do
       def after_resource_destroyed_path(_requested_resource)
-        { action: :index, controller: :customers }
+        {action: :index, controller: :customers}
       end
 
       def after_resource_created_path(requested_resource)
@@ -19,7 +19,7 @@ RSpec.describe Admin::ApplicationController, type: :controller do
     it "redirect to custom route after destroy" do
       order = create(:order)
 
-      delete :destroy, params: { id: order.to_param }
+      delete :destroy, params: {id: order.to_param}
       expect(response).to redirect_to(admin_customers_path)
     end
 
@@ -30,18 +30,18 @@ RSpec.describe Admin::ApplicationController, type: :controller do
         "id",
         "created_at",
         "updated_at",
-        "shipped_at",
+        "shipped_at"
       )
 
-      post :create, params: { order: params }
+      post :create, params: {order: params}
       expect(response).to redirect_to(admin_customer_path(customer))
     end
 
     it "redirect to custom route after update" do
       order = create(:order)
-      order_params = { address_line_one: order.address_line_one }
+      order_params = {address_line_one: order.address_line_one}
 
-      put :update, params: { id: order.to_param, order: order_params }
+      put :update, params: {id: order.to_param, order: order_params}
       expect(response).to redirect_to(admin_customer_path(order.customer))
     end
   end
@@ -64,10 +64,10 @@ RSpec.describe Admin::ApplicationController, type: :controller do
         "id",
         "created_at",
         "updated_at",
-        "shipped_at",
+        "shipped_at"
       )
 
-      post :create, params: { order: params }
+      post :create, params: {order: params}
 
       expect(controller.resource).to be_a(Order)
     end
@@ -90,14 +90,14 @@ RSpec.describe Admin::ApplicationController, type: :controller do
 
     it "authorizes allowed actions" do
       resource = FactoryBot.create(:order, address_zip: "666")
-      expect { get :show, params: { id: resource.id } }.
-        not_to raise_error
+      expect { get :show, params: {id: resource.id} }
+        .not_to raise_error
     end
 
     it "does not authorize disallowed actions" do
       resource = FactoryBot.create(:order, address_zip: "667")
-      expect { get :show, params: { id: resource.id } }.
-        to raise_error(Administrate::NotAuthorizedError)
+      expect { get :show, params: {id: resource.id} }
+        .to raise_error(Administrate::NotAuthorizedError)
     end
   end
 
@@ -112,8 +112,8 @@ RSpec.describe Admin::ApplicationController, type: :controller do
       allow(Administrate.deprecator).to receive(:warn)
       get :index
       expect(Administrate.deprecator).to(
-        have_received(:warn).
-          with(/`show_action\?` is deprecated/),
+        have_received(:warn)
+          .with(/`show_action\?` is deprecated/)
       )
     end
   end
@@ -129,8 +129,8 @@ RSpec.describe Admin::ApplicationController, type: :controller do
       allow(Administrate.deprecator).to receive(:warn)
       get :index
       expect(Administrate.deprecator).to(
-        have_received(:warn).
-          with(/`valid_action\?` is deprecated/),
+        have_received(:warn)
+          .with(/`valid_action\?` is deprecated/)
       )
     end
   end

--- a/spec/controllers/admin/blog/posts_controller_spec.rb
+++ b/spec/controllers/admin/blog/posts_controller_spec.rb
@@ -11,7 +11,7 @@ describe Admin::Blog::PostsController, type: :controller do
 
     it "passes the search term to the view" do
       locals = capture_view_locals do
-        get :index, params: { search: "foo" }
+        get :index, params: {search: "foo"}
       end
 
       expect(locals[:search_term]).to eq("foo")
@@ -29,7 +29,7 @@ describe Admin::Blog::PostsController, type: :controller do
       blog_post = create(:blog_post)
 
       locals = capture_view_locals do
-        get :show, params: { id: blog_post.to_param }
+        get :show, params: {id: blog_post.to_param}
       end
 
       page = locals[:page]
@@ -51,7 +51,7 @@ describe Admin::Blog::PostsController, type: :controller do
       blog_post = create(:blog_post)
 
       locals = capture_view_locals do
-        get :edit, params: { id: blog_post.to_param }
+        get :edit, params: {id: blog_post.to_param}
       end
 
       page = locals[:page]
@@ -64,12 +64,12 @@ describe Admin::Blog::PostsController, type: :controller do
     context "with valid params" do
       it "creates a new blog post" do
         expect do
-          post :create, params: { blog_post: attributes_for(:blog_post) }
+          post :create, params: {blog_post: attributes_for(:blog_post)}
         end.to change(Blog::Post, :count).by(1)
       end
 
       it "redirects to the created blog post" do
-        post :create, params: { blog_post: attributes_for(:blog_post) }
+        post :create, params: {blog_post: attributes_for(:blog_post)}
 
         expect(response).to redirect_to([:admin, Blog::Post.last])
       end
@@ -79,10 +79,10 @@ describe Admin::Blog::PostsController, type: :controller do
       render_views
 
       it "passes a form page object to the view" do
-        invalid_attributes = { title: "" }
+        invalid_attributes = {title: ""}
 
         locals = capture_view_locals do
-          post :create, params: { blog_post: invalid_attributes }
+          post :create, params: {blog_post: invalid_attributes}
         end
 
         page = locals[:page]
@@ -91,9 +91,9 @@ describe Admin::Blog::PostsController, type: :controller do
       end
 
       it "re-renders the 'new' template" do
-        invalid_attributes = { title: "" }
+        invalid_attributes = {title: ""}
 
-        post :create, params: { blog_post: invalid_attributes }
+        post :create, params: {blog_post: invalid_attributes}
 
         expect(page.find("h1")).to have_content "New Blog Post"
       end
@@ -104,11 +104,11 @@ describe Admin::Blog::PostsController, type: :controller do
     context "with valid params" do
       it "updates the requested blog post" do
         blog_post = create(:blog_post, title: "old title")
-        new_attributes = { title: "new title" }
+        new_attributes = {title: "new title"}
 
         put(
           :update,
-          params: { id: blog_post.to_param, blog_post: new_attributes },
+          params: {id: blog_post.to_param, blog_post: new_attributes}
         )
 
         blog_post.reload
@@ -121,7 +121,7 @@ describe Admin::Blog::PostsController, type: :controller do
 
         put(
           :update,
-          params: { id: blog_post.to_param, blog_post: valid_attributes },
+          params: {id: blog_post.to_param, blog_post: valid_attributes}
         )
         blog_post.reload
 
@@ -134,14 +134,14 @@ describe Admin::Blog::PostsController, type: :controller do
 
       it "re-renders the 'edit' template" do
         blog_post = create(:blog_post)
-        invalid_attributes = { title: "" }
+        invalid_attributes = {title: ""}
 
         put(
           :update,
           params: {
             id: blog_post.to_param,
-            blog_post: invalid_attributes,
-          },
+            blog_post: invalid_attributes
+          }
         )
 
         expect(page.find("h1")).to have_content "Edit"
@@ -149,15 +149,15 @@ describe Admin::Blog::PostsController, type: :controller do
 
       it "passes a form page object to the view" do
         blog_post = create(:blog_post)
-        invalid_attributes = { title: "" }
+        invalid_attributes = {title: ""}
 
         locals = capture_view_locals do
           put(
             :update,
             params: {
               id: blog_post.to_param,
-              blog_post: invalid_attributes,
-            },
+              blog_post: invalid_attributes
+            }
           )
         end
 
@@ -173,14 +173,14 @@ describe Admin::Blog::PostsController, type: :controller do
       blog_post = create(:blog_post)
 
       expect do
-        delete :destroy, params: { id: blog_post.to_param }
+        delete :destroy, params: {id: blog_post.to_param}
       end.to change(Blog::Post, :count).by(-1)
     end
 
     it "redirects to the blog posts list" do
       blog_post = create(:blog_post)
 
-      delete :destroy, params: { id: blog_post.to_param }
+      delete :destroy, params: {id: blog_post.to_param}
 
       expect(response).to redirect_to(admin_blog_posts_path)
     end

--- a/spec/controllers/admin/customers_controller_spec.rb
+++ b/spec/controllers/admin/customers_controller_spec.rb
@@ -19,7 +19,7 @@ describe Admin::CustomersController, type: :controller do
 
     it "passes the search term to the view" do
       locals = capture_view_locals do
-        get :index, params: { search: "foo" }
+        get :index, params: {search: "foo"}
       end
 
       expect(locals[:search_term]).to eq("foo")
@@ -32,7 +32,7 @@ describe Admin::CustomersController, type: :controller do
     end
 
     it "shows the search bar" do
-      customer = create(:customer)
+      create(:customer)
 
       locals = capture_view_locals { get :index }
       expect(locals[:show_search_bar]).to be_truthy
@@ -73,7 +73,7 @@ describe Admin::CustomersController, type: :controller do
       customer = create(:customer)
 
       locals = capture_view_locals do
-        get :show, params: { id: customer.to_param }
+        get :show, params: {id: customer.to_param}
       end
 
       page = locals[:page]
@@ -95,7 +95,7 @@ describe Admin::CustomersController, type: :controller do
       customer = create(:customer)
 
       locals = capture_view_locals do
-        get :edit, params: { id: customer.to_param }
+        get :edit, params: {id: customer.to_param}
       end
 
       page = locals[:page]
@@ -108,12 +108,12 @@ describe Admin::CustomersController, type: :controller do
     describe "with valid params" do
       it "creates a new Customer" do
         expect {
-          post :create, params: { customer: attributes_for(:customer) }
+          post :create, params: {customer: attributes_for(:customer)}
         }.to change(Customer, :count).by(1)
       end
 
       it "redirects to the created customer" do
-        post :create, params: { customer: attributes_for(:customer) }
+        post :create, params: {customer: attributes_for(:customer)}
 
         expect(response).to redirect_to([:admin, Customer.last])
       end
@@ -121,10 +121,10 @@ describe Admin::CustomersController, type: :controller do
 
     describe "with invalid params" do
       it "passes a form page object to the view" do
-        invalid_attributes = { name: "" }
+        invalid_attributes = {name: ""}
 
         locals = capture_view_locals do
-          post :create, params: { customer: invalid_attributes }
+          post :create, params: {customer: invalid_attributes}
         end
 
         page = locals[:page]
@@ -135,10 +135,10 @@ describe Admin::CustomersController, type: :controller do
 
     describe "with empty string param" do
       it "sets empty string value to nil" do
-        empty_string_attributes = { country_code: "" }
+        empty_string_attributes = {country_code: ""}
 
         locals = capture_view_locals do
-          post :create, params: { customer: empty_string_attributes }
+          post :create, params: {customer: empty_string_attributes}
         end
 
         page = locals[:page]
@@ -152,9 +152,9 @@ describe Admin::CustomersController, type: :controller do
       it "updates the requested customer" do
         customer = create(:customer)
         new_name = "new name"
-        new_attributes = { name: new_name }
+        new_attributes = {name: new_name}
 
-        put :update, params: { id: customer.to_param, customer: new_attributes }
+        put :update, params: {id: customer.to_param, customer: new_attributes}
 
         customer.reload
         expect(customer.name).to eq new_name
@@ -166,7 +166,7 @@ describe Admin::CustomersController, type: :controller do
 
         put(
           :update,
-          params: { id: customer.to_param, customer: valid_attributes },
+          params: {id: customer.to_param, customer: valid_attributes}
         )
 
         expect(response).to redirect_to([:admin, customer])
@@ -176,12 +176,12 @@ describe Admin::CustomersController, type: :controller do
     describe "with invalid params" do
       it "passes a form page object to the view" do
         customer = create(:customer)
-        invalid_attributes = { name: "" }
+        invalid_attributes = {name: ""}
 
         locals = capture_view_locals do
           put(
             :update,
-            params: { id: customer.to_param, customer: invalid_attributes },
+            params: {id: customer.to_param, customer: invalid_attributes}
           )
         end
 
@@ -197,14 +197,14 @@ describe Admin::CustomersController, type: :controller do
       customer = create(:customer)
 
       expect do
-        delete :destroy, params: { id: customer.to_param }
+        delete :destroy, params: {id: customer.to_param}
       end.to change(Customer, :count).by(-1)
     end
 
     it "redirects to the customers list" do
       customer = create(:customer)
 
-      delete :destroy, params: { id: customer.to_param }
+      delete :destroy, params: {id: customer.to_param}
 
       expect(response).to redirect_to(admin_customers_url)
     end

--- a/spec/controllers/admin/log_entries_controller_spec.rb
+++ b/spec/controllers/admin/log_entries_controller_spec.rb
@@ -7,10 +7,10 @@ describe Admin::LogEntriesController, type: :controller do
         action: action,
         logeable: {
           type: "Administrate::Field::Polymorphic",
-          value: logeable.to_global_id.to_s,
-        },
+          value: logeable.to_global_id.to_s
+        }
       )
-      post :create, params: { log_entry: resource_params }
+      post :create, params: {log_entry: resource_params}
     end
 
     describe "with valid params" do
@@ -36,15 +36,15 @@ describe Admin::LogEntriesController, type: :controller do
               params: {
                 logeable: {
                   type: "Administrate::Field::Polymorphic",
-                  value: customer.to_global_id.to_s,
-                },
-              },
-            },
-          },
+                  value: customer.to_global_id.to_s
+                }
+              }
+            }
+          }
         )
 
         allow_any_instance_of(
-          LogEntryDashboard,
+          LogEntryDashboard
         ).to receive(:permitted_attributes).and_return(
           [
             arbitrarily: {
@@ -52,23 +52,23 @@ describe Admin::LogEntriesController, type: :controller do
                 params: {
                   logeable: [
                     :type,
-                    :value,
-                  ],
-                },
-              },
-            },
-          ],
+                    :value
+                  ]
+                }
+              }
+            }
+          ]
         )
 
         LogEntry.attr_accessor :arbitrarily
 
-        post :create, params: { log_entry: resource_params }
+        post :create, params: {log_entry: resource_params}
 
         logeable_in_params = subject.send(:resource_params).dig(
           :arbitrarily,
           :nested,
           :params,
-          :logeable,
+          :logeable
         )
         expect(logeable_in_params).to eq(customer)
       end
@@ -95,10 +95,10 @@ describe Admin::LogEntriesController, type: :controller do
         action: action,
         logeable: {
           type: "Administrate::Field::Polymorphic",
-          value: logeable.to_global_id.to_s,
-        },
+          value: logeable.to_global_id.to_s
+        }
       )
-      put :update, params: { id: original.to_param, log_entry: resource_params }
+      put :update, params: {id: original.to_param, log_entry: resource_params}
     end
 
     describe "with valid params" do

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 # Test Authorization by using the Pundit concern and an example policy,
 # which will test all the authorization functionality.
 
+# standard:disable Lint/ConstantDefinitionInBlock
 describe Admin::OrdersController, type: :controller do
   context "with namespaced Punditize concern" do
     controller(Admin::OrdersController) do
@@ -41,14 +42,14 @@ describe Admin::OrdersController, type: :controller do
     describe "GET edit" do
       it "allows me to edit my records" do
         order = create :order, customer: user
-        expect { get :edit, params: { id: order.id } }.not_to raise_error
+        expect { get :edit, params: {id: order.id} }.not_to raise_error
       end
 
       it "does not allow me to see other users' records" do
         other_user = create(:customer)
         order = create(:order, customer: other_user)
-        expect { get :show, params: { id: order.id } }.
-          to raise_error(ActiveRecord::RecordNotFound)
+        expect { get :show, params: {id: order.id} }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -58,8 +59,8 @@ describe Admin::OrdersController, type: :controller do
           :update,
           params: {
             id: order.id,
-            order: { address_line_one: "22 Acacia Avenue" },
-          },
+            order: {address_line_one: "22 Acacia Avenue"}
+          }
         )
       end
 
@@ -82,8 +83,8 @@ describe Admin::OrdersController, type: :controller do
     describe "DELETE destroy" do
       it "never allows me to delete a record" do
         o = create :order, customer: user, address_state: "AZ"
-        expect { delete :destroy, params: { id: o.id } }.
-          to raise_error(Pundit::NotAuthorizedError)
+        expect { delete :destroy, params: {id: o.id} }
+          .to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
@@ -147,8 +148,8 @@ describe Admin::OrdersController, type: :controller do
         locals = capture_view_locals { get :index }
 
         expect(locals[:resources]).to contain_exactly(order1, order3)
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/`resolve_admin` method is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/`resolve_admin` method is deprecated/)
       end
     end
 
@@ -161,18 +162,18 @@ describe Admin::OrdersController, type: :controller do
     describe "GET edit" do
       it "allows me to edit my records" do
         order = create :order, customer: user
-        expect { get :edit, params: { id: order.id } }.not_to raise_error
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/`resolve_admin` method is deprecated/)
+        expect { get :edit, params: {id: order.id} }.not_to raise_error
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/`resolve_admin` method is deprecated/)
       end
 
       it "does not allow me to see other users' records" do
         other_user = create(:customer)
         order = create(:order, customer: other_user)
-        expect { get :show, params: { id: order.id } }.
-          to raise_error(ActiveRecord::RecordNotFound)
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/`resolve_admin` method is deprecated/)
+        expect { get :show, params: {id: order.id} }
+          .to raise_error(ActiveRecord::RecordNotFound)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/`resolve_admin` method is deprecated/)
       end
     end
 
@@ -182,8 +183,8 @@ describe Admin::OrdersController, type: :controller do
           :update,
           params: {
             id: order.id,
-            order: { address_line_one: "22 Acacia Avenue" },
-          },
+            order: {address_line_one: "22 Acacia Avenue"}
+          }
         )
       end
 
@@ -192,8 +193,8 @@ describe Admin::OrdersController, type: :controller do
         send_request(order: order)
         expect(response).to redirect_to([:admin, order])
         expect(order.reload.address_line_one).to eq("22 Acacia Avenue")
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/`resolve_admin` method is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/`resolve_admin` method is deprecated/)
       end
 
       it "does not allow me to update other users' records" do
@@ -202,16 +203,16 @@ describe Admin::OrdersController, type: :controller do
         expect do
           send_request(order: order)
         end.to raise_error(ActiveRecord::RecordNotFound)
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/`resolve_admin` method is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/`resolve_admin` method is deprecated/)
       end
     end
 
     describe "DELETE destroy" do
       it "never allows me to delete a record" do
         o = create :order, customer: user, address_state: "AZ"
-        expect { delete :destroy, params: { id: o.id } }.
-          to raise_error(Pundit::NotAuthorizedError)
+        expect { delete :destroy, params: {id: o.id} }
+          .to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
@@ -234,3 +235,4 @@ describe Admin::OrdersController, type: :controller do
     end
   end
 end
+# standard:enable Lint/ConstantDefinitionInBlock

--- a/spec/controllers/concerns/administrate/punditize_spec.rb
+++ b/spec/controllers/concerns/administrate/punditize_spec.rb
@@ -24,7 +24,7 @@ module Administrate
 
       yield
 
-      Object.const_set("Pundit", original)
+      Object.const_set(:Pundit, original)
     end
 
     def reload_punditize
@@ -36,7 +36,7 @@ module Administrate
         "controllers",
         "concerns",
         "administrate",
-        "punditize.rb",
+        "punditize.rb"
       )
     end
 

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -12,15 +12,15 @@ describe CustomerDashboard do
 
   describe "#attribute_types" do
     it "maps each attribute to an attribute field" do
-      Field = Administrate::Field
+      stub_const("Field", Administrate::Field)
       dashboard = CustomerDashboard.new
 
       fields = dashboard.attribute_types
 
       expect(fields[:name]).to eq(Field::String)
       expect(fields[:email]).to eq(Field::Email)
-      expect(fields[:lifetime_value]).
-        to eq(Field::Number.with_options(prefix: "$", decimals: 2))
+      expect(fields[:lifetime_value])
+        .to eq(Field::Number.with_options(prefix: "$", decimals: 2))
     end
   end
 
@@ -40,8 +40,8 @@ describe CustomerDashboard do
     context "for a non-existent attribute" do
       it "raises an exception" do
         dashboard = CustomerDashboard.new
-        expect { dashboard.attribute_type_for(:foo) }.
-          to raise_error missing_attribute_message("foo", "CustomerDashboard")
+        expect { dashboard.attribute_type_for(:foo) }
+          .to raise_error missing_attribute_message("foo", "CustomerDashboard")
       end
     end
   end
@@ -53,7 +53,7 @@ describe CustomerDashboard do
         fields = dashboard.attribute_types_for([:name, :email])
         expect(fields).to match(
           name: Administrate::Field::String,
-          email: Administrate::Field::Email,
+          email: Administrate::Field::Email
         )
       end
     end
@@ -61,8 +61,8 @@ describe CustomerDashboard do
     context "for one non-existent attribute" do
       it "raises an exception" do
         dashboard = CustomerDashboard.new
-        expect { dashboard.attribute_types_for([:name, :foo]) }.
-          to raise_error missing_attribute_message("foo", "CustomerDashboard")
+        expect { dashboard.attribute_types_for([:name, :foo]) }
+          .to raise_error missing_attribute_message("foo", "CustomerDashboard")
       end
     end
   end

--- a/spec/dashboards/line_item_dashboard_spec.rb
+++ b/spec/dashboards/line_item_dashboard_spec.rb
@@ -16,7 +16,7 @@ describe LineItemDashboard do
             product
             quantity
             unit_price
-          ],
+          ]
         )
       end
     end
@@ -29,7 +29,7 @@ describe LineItemDashboard do
           %i[
             order
             product
-          ],
+          ]
         )
       end
     end
@@ -43,7 +43,7 @@ describe LineItemDashboard do
             order
             product
             quantity
-          ],
+          ]
         )
       end
     end
@@ -58,7 +58,7 @@ describe LineItemDashboard do
             product
             quantity
             unit_price
-          ],
+          ]
         )
       end
     end

--- a/spec/example_app/app/controllers/admin/log_entries_controller.rb
+++ b/spec/example_app/app/controllers/admin/log_entries_controller.rb
@@ -6,23 +6,23 @@ module Admin
       customer_ids = Customer.where(
         [
           "name ILIKE ?",
-          "%#{search_term}%",
-        ],
+          "%#{search_term}%"
+        ]
       ).pluck(:id)
       order_ids = Order.joins(:customer).where(
         [
           "customers.name ILIKE ?",
-          "%#{search_term}%",
-        ],
+          "%#{search_term}%"
+        ]
       ).pluck(:id)
 
       customers_filter = resources.where(
         logeable_type: "Customer",
-        logeable_id: customer_ids,
+        logeable_id: customer_ids
       )
       orders_filter = resources.where(
         logeable_type: "Order",
-        logeable_id: order_ids,
+        logeable_id: order_ids
       )
       customers_filter.or(orders_filter)
     end

--- a/spec/example_app/app/controllers/admin/stats_controller.rb
+++ b/spec/example_app/app/controllers/admin/stats_controller.rb
@@ -3,7 +3,7 @@ module Admin
     def index
       @stats = {
         customer_count: Customer.count,
-        order_count: Order.count,
+        order_count: Order.count
       }
     end
   end

--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -21,7 +21,7 @@ class DocsController < ApplicationController
   def render_page(name, title = nil)
     page = DocPage.find(name)
 
-    title = title || page.title
+    title ||= page.title
     @page_title = [title, "Administrate"].compact.join(" - ")
     # rubocop:disable Rails/OutputSafety
     render layout: "docs", html: page.body.html_safe
@@ -30,7 +30,7 @@ class DocsController < ApplicationController
     render(
       file: Rails.root.join("public", "404.html"),
       layout: false,
-      status: :not_found,
+      status: :not_found
     )
   end
 end

--- a/spec/example_app/app/dashboards/blog/post_dashboard.rb
+++ b/spec/example_app/app/dashboards/blog/post_dashboard.rb
@@ -9,20 +9,20 @@ module Blog
       title: Field::String,
       published_at: Field::DateTime,
       body: Field::Text,
-      tags: Field::HasMany,
+      tags: Field::HasMany
     }
 
     READ_ONLY_ATTRIBUTES = [
       :id,
       :created_at,
-      :updated_at,
+      :updated_at
     ]
 
     COLLECTION_ATTRIBUTES = [
       :id,
       :title,
       :tags,
-      :published_at,
+      :published_at
     ]
 
     FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES

--- a/spec/example_app/app/dashboards/blog/tag_dashboard.rb
+++ b/spec/example_app/app/dashboards/blog/tag_dashboard.rb
@@ -7,7 +7,7 @@ module Blog
       name: Field::String,
       created_at: Field::DateTime,
       updated_at: Field::DateTime,
-      posts: Field::HasMany,
+      posts: Field::HasMany
     }.freeze
 
     COLLECTION_ATTRIBUTES = %i[

--- a/spec/example_app/app/dashboards/country_dashboard.rb
+++ b/spec/example_app/app/dashboards/country_dashboard.rb
@@ -1,13 +1,13 @@
 require "administrate/base_dashboard"
 
 class CountryDashboard < Administrate::BaseDashboard
-  ATTRIBUTES = %i(code name).freeze
+  ATTRIBUTES = %i[code name].freeze
 
   ATTRIBUTE_TYPES = {
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     code: Field::String,
-    name: Field::String,
+    name: Field::String
   }.freeze
 
   COLLECTION_ATTRIBUTES = ATTRIBUTES

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -15,9 +15,9 @@ class CustomerDashboard < Administrate::BaseDashboard
     territory: Field::BelongsTo.with_options(
       searchable: true,
       searchable_fields: ["name"],
-      include_blank: true,
+      include_blank: true
     ),
-    password: Field::Password,
+    password: Field::Password
   }
 
   COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys - %i[created_at updated_at]
@@ -28,12 +28,12 @@ class CustomerDashboard < Administrate::BaseDashboard
     :email_subscriber,
     :kind,
     :territory,
-    :password,
+    :password
   ].freeze
 
   COLLECTION_FILTERS = {
     vip: ->(resources) { resources.where(kind: :vip) },
-    kind: ->(resources, arg) { resources.where(kind: arg) },
+    kind: ->(resources, arg) { resources.where(kind: arg) }
   }.freeze
 
   def display_resource(customer)

--- a/spec/example_app/app/dashboards/line_item_dashboard.rb
+++ b/spec/example_app/app/dashboards/line_item_dashboard.rb
@@ -5,7 +5,7 @@ class LineItemDashboard < Administrate::BaseDashboard
     :order,
     :product,
     :quantity,
-    :unit_price,
+    :unit_price
   ]
 
   ATTRIBUTE_TYPES = {
@@ -15,7 +15,7 @@ class LineItemDashboard < Administrate::BaseDashboard
     product: Field::BelongsTo,
     quantity: Field::Number,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
-    unit_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    unit_price: Field::Number.with_options(prefix: "$", decimals: 2)
   }
 
   COLLECTION_ATTRIBUTES = ATTRIBUTES + [:total_price]

--- a/spec/example_app/app/dashboards/log_entry_dashboard.rb
+++ b/spec/example_app/app/dashboards/log_entry_dashboard.rb
@@ -1,12 +1,12 @@
 require "administrate/base_dashboard"
 
 class LogEntryDashboard < Administrate::BaseDashboard
-  ATTRIBUTES = %i(action logeable).freeze
+  ATTRIBUTES = %i[action logeable].freeze
 
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     action: Field::String,
-    logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order]),
+    logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order])
   }.freeze
 
   COLLECTION_ATTRIBUTES = [:id] + ATTRIBUTES
@@ -24,9 +24,9 @@ class LogEntryDashboard < Administrate::BaseDashboard
   end
 
   def display_logeable(logeable)
-    (logeable.class.to_s + "Dashboard").
-      constantize.
-      new.
-      display_resource(logeable)
+    (logeable.class.to_s + "Dashboard")
+      .constantize
+      .new
+      .display_resource(logeable)
   end
 end

--- a/spec/example_app/app/dashboards/logged/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/logged/order_dashboard.rb
@@ -14,14 +14,14 @@ module Logged
       customer: Field::BelongsTo,
       line_items: Field::HasMany,
       total_price: Field::Number.with_options(prefix: "$", decimals: 2),
-      shipped_at: Field::DateTime,
+      shipped_at: Field::DateTime
     }
 
     READ_ONLY_ATTRIBUTES = [
       :id,
       :total_price,
       :created_at,
-      :updated_at,
+      :updated_at
     ]
 
     COLLECTION_ATTRIBUTES = [
@@ -30,7 +30,7 @@ module Logged
       :address_state,
       :total_price,
       :line_items,
-      :shipped_at,
+      :shipped_at
     ]
 
     FORM_ATTRIBUTES = ATTRIBUTE_TYPES.keys - READ_ONLY_ATTRIBUTES

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -12,18 +12,18 @@ class OrderDashboard < Administrate::BaseDashboard
     address_zip: Field::String,
     customer: Field::BelongsTo.with_options(order: "name"),
     line_items: Field::HasMany.with_options(
-      collection_attributes: %i[product quantity unit_price total_price],
+      collection_attributes: %i[product quantity unit_price total_price]
     ),
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
-    payments: Field::HasMany,
+    payments: Field::HasMany
   }
 
   READ_ONLY_ATTRIBUTES = [
     :id,
     :total_price,
     :created_at,
-    :updated_at,
+    :updated_at
   ]
 
   COLLECTION_ATTRIBUTES = [
@@ -32,7 +32,7 @@ class OrderDashboard < Administrate::BaseDashboard
     :address_state,
     :total_price,
     :line_items,
-    :shipped_at,
+    :shipped_at
   ]
 
   FORM_ATTRIBUTES = {
@@ -48,10 +48,10 @@ class OrderDashboard < Administrate::BaseDashboard
       address_city
       address_state
       address_zip
-    ],
+    ]
   }.freeze
   SHOW_PAGE_ATTRIBUTES = FORM_ATTRIBUTES.merge(
     "" => %i[customer created_at updated_at],
-    "details" => %i[line_items total_price shipped_at payments],
+    "details" => %i[line_items total_price shipped_at payments]
   ).freeze
 end

--- a/spec/example_app/app/dashboards/page_dashboard.rb
+++ b/spec/example_app/app/dashboards/page_dashboard.rb
@@ -7,7 +7,7 @@ class PageDashboard < Administrate::BaseDashboard
     title: Field::String,
     body: Field::Text,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[

--- a/spec/example_app/app/dashboards/payment_dashboard.rb
+++ b/spec/example_app/app/dashboards/payment_dashboard.rb
@@ -5,11 +5,11 @@ class PaymentDashboard < Administrate::BaseDashboard
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    order: Field::BelongsTo,
+    order: Field::BelongsTo
   }
 
   COLLECTION_ATTRIBUTES = [
-    :id,
+    :id
   ]
 
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys

--- a/spec/example_app/app/dashboards/product_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_dashboard.rb
@@ -8,7 +8,7 @@ class ProductDashboard < Administrate::BaseDashboard
     :description,
     :image_url,
     :product_meta_tag,
-    :release_year,
+    :release_year
   ]
 
   ATTRIBUTE_TYPES = {
@@ -21,8 +21,8 @@ class ProductDashboard < Administrate::BaseDashboard
     price: Field::Number.with_options(prefix: "$", decimals: 2),
     product_meta_tag: Field::HasOne.with_options(order: "meta_title"),
     release_year: Field::Select.with_options(
-      collection: -> { (Time.current.year - 10)..Time.current.year },
-    ),
+      collection: -> { (Time.current.year - 10)..Time.current.year }
+    )
   }
 
   COLLECTION_ATTRIBUTES = ATTRIBUTES

--- a/spec/example_app/app/dashboards/product_meta_tag_dashboard.rb
+++ b/spec/example_app/app/dashboards/product_meta_tag_dashboard.rb
@@ -10,7 +10,7 @@ class ProductMetaTagDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     meta_title: Field::String,
-    meta_description: Field::String,
+    meta_description: Field::String
   }.freeze
 
   COLLECTION_ATTRIBUTES = ATTRIBUTES

--- a/spec/example_app/app/dashboards/series_dashboard.rb
+++ b/spec/example_app/app/dashboards/series_dashboard.rb
@@ -3,14 +3,14 @@ require "administrate/base_dashboard"
 class SeriesDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    name: Field::String,
+    name: Field::String
   }.freeze
 
-  COLLECTION_ATTRIBUTES = %i(id name).freeze
+  COLLECTION_ATTRIBUTES = %i[id name].freeze
 
-  SHOW_PAGE_ATTRIBUTES = %i(id name).freeze
+  SHOW_PAGE_ATTRIBUTES = %i[id name].freeze
 
   FORM_ATTRIBUTES = [
-    :name,
+    :name
   ].freeze
 end

--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -4,7 +4,7 @@ class Customer < ApplicationRecord
     :territory,
     class_name: "Country",
     foreign_key: :country_code,
-    primary_key: :code,
+    primary_key: :code
   )
   has_many :log_entries, as: :logeable
 
@@ -13,7 +13,7 @@ class Customer < ApplicationRecord
 
   KINDS = {
     "standard" => "kind:std",
-    "vip" => "kind:vip",
+    "vip" => "kind:vip"
   }.freeze
   enum kind: KINDS
 

--- a/spec/example_app/app/models/doc_page.rb
+++ b/spec/example_app/app/models/doc_page.rb
@@ -32,7 +32,7 @@ class DocPage
     def doc_paths
       [
         Dir.glob(Rails.root + "../../**/*.md"),
-        Dir.glob(Rails.root + "../../*.md"),
+        Dir.glob(Rails.root + "../../*.md")
       ].join
     end
 
@@ -95,7 +95,7 @@ class DocPage
     def redcarpet_config
       {
         fenced_code_blocks: true,
-        autolink: true,
+        autolink: true
       }
     end
   end

--- a/spec/example_app/app/models/product.rb
+++ b/spec/example_app/app/models/product.rb
@@ -18,10 +18,10 @@ class Product < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true
   validates :release_year,
-            numericality: {
-              less_than_or_equal_to: ->(_product) { Time.current.year },
-            },
-            allow_blank: true
+    numericality: {
+      less_than_or_equal_to: ->(_product) { Time.current.year }
+    },
+    allow_blank: true
   validates :slug, uniqueness: true
   validates :product_meta_tag, presence: true, on: :some_unclear_situation
   validate :valid_slug

--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -24,10 +24,10 @@ module AdministratePrototype
     end
 
     config.action_controller.action_on_unpermitted_parameters = :raise
-    config.active_record.time_zone_aware_types = %i(datetime time)
+    config.active_record.time_zone_aware_types = %i[datetime time]
 
     # Opt-out of FLoC: https://amifloced.org/
-    config.action_dispatch.
-      default_headers["Permissions-Policy"] = "interest-cohort=()"
+    config.action_dispatch
+      .default_headers["Permissions-Policy"] = "interest-cohort=()"
   end
 end

--- a/spec/example_app/config/environments/production.rb
+++ b/spec/example_app/config/environments/production.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either
@@ -72,9 +72,9 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.

--- a/spec/example_app/config/environments/test.rb
+++ b/spec/example_app/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   if config.respond_to?(:public_file_server)
     config.public_file_server.enabled = true
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=3600",
+      "Cache-Control" => "public, max-age=3600"
     }
   else
     config.serve_static_files = true
@@ -23,7 +23,7 @@ Rails.application.configure do
   end
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/spec/example_app/config/initializers/assets.rb
+++ b/spec/example_app/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( docs.css )
+Rails.application.config.assets.precompile += %w[docs.css]

--- a/spec/example_app/config/initializers/inflections.rb
+++ b/spec/example_app/config/initializers/inflections.rb
@@ -4,10 +4,10 @@
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-  inflect.uncountable %w(series)
+  #   inflect.plural /^(ox)$/i, '\1en'
+  #   inflect.singular /^(ox)en/i, '\1'
+  #   inflect.irregular 'person', 'people'
+  inflect.uncountable %w[series]
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/spec/example_app/config/initializers/session_store.rb
+++ b/spec/example_app/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_administrate-prototype_session'
+Rails.application.config.session_store :cookie_store, key: "_administrate-prototype_session"

--- a/spec/example_app/db/migrate/20150914175022_add_slug_to_products.rb
+++ b/spec/example_app/db/migrate/20150914175022_add_slug_to_products.rb
@@ -6,8 +6,8 @@ class AddSlugToProducts < ActiveRecord::Migration[4.2]
     products.each do |product|
       update(<<-SQL)
         UPDATE products
-          SET slug='#{product['name'].parameterize}'
-          WHERE id=#{product['id']}
+          SET slug='#{product["name"].parameterize}'
+          WHERE id=#{product["id"]}
       SQL
     end
 

--- a/spec/example_app/db/migrate/20170510122301_create_countries.rb
+++ b/spec/example_app/db/migrate/20170510122301_create_countries.rb
@@ -1,7 +1,7 @@
 class CreateCountries < ActiveRecord::Migration[4.2]
   def change
     create_table :countries do |t|
-      t.string :code, null: false, index: { unique: true }
+      t.string :code, null: false, index: {unique: true}
       t.string :name
 
       t.timestamps null: false

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -19,11 +19,11 @@ Blog::Post.destroy_all
 Page.destroy_all
 
 countries = Country.create! [
-  { code: "US", name: "USA" },
-  { code: "CA", name: "Canada" },
-  { code: "CN", name: "China" },
-  { code: "RU", name: "Russia" },
-  { code: "AU", name: "Australia" },
+  {code: "US", name: "USA"},
+  {code: "CA", name: "Canada"},
+  {code: "CN", name: "China"},
+  {code: "RU", name: "Russia"},
+  {code: "AU", name: "Australia"}
 ]
 
 customer_attributes = Array.new(100) do
@@ -32,7 +32,7 @@ customer_attributes = Array.new(100) do
     name: name,
     email: Faker::Internet.email(name: name),
     territory: countries.sample,
-    password: Faker::Internet.password,
+    password: Faker::Internet.password
   }
 end
 
@@ -41,27 +41,27 @@ customers = Customer.create!(customer_attributes)
 log_entry_attributes = customers.map do |c|
   {
     action: "create",
-    logeable: c,
+    logeable: c
   }
 end
 
 LogEntry.create!(log_entry_attributes)
 
-product_attributes = YAML.load_file(Rails.root.join('db/seeds/products.yml'))
+product_attributes = YAML.load_file(Rails.root.join("db/seeds/products.yml"))
 
 product_attributes.each do |attributes|
   attributes = attributes.merge product_meta_tag_attributes: {
     meta_title: Faker::Movies::LordOfTheRings.character,
-    meta_description: Faker::Movies::LordOfTheRings.location,
+    meta_description: Faker::Movies::LordOfTheRings.location
   }
-  Product.create! attributes.merge(price: 20 + rand(50))
+  Product.create! attributes.merge(price: rand(20..69))
 end
 
 Product.find_each do |p|
   Page.create!(
     title: "Rules of #{p.name}",
     body: Faker::Lorem.paragraph,
-    product: p,
+    product: p
   )
 end
 
@@ -72,12 +72,12 @@ Product.find_each do |p|
   Blog::Post.create!(
     title: "The secrets of #{p.name}",
     body: Faker::Lorem.paragraph,
-    tags: [tag_secrets],
+    tags: [tag_secrets]
   )
   Blog::Post.create!(
     title: "If you liked #{p.name}, you will love these products",
     body: Faker::Lorem.paragraph,
-    tags: [tag_recommendations],
+    tags: [tag_recommendations]
   )
 end
 
@@ -89,11 +89,11 @@ def create_order(customer:, shipped_at: nil)
     address_city: Faker::Address.city,
     address_state: Faker::Address.state_abbr,
     address_zip: Faker::Address.zip,
-    shipped_at: shipped_at,
+    shipped_at: shipped_at
   )
   LogEntry.create!(
     action: "create",
-    logeable: order,
+    logeable: order
   )
 
   item_count = (1..3).to_a.sample
@@ -102,7 +102,7 @@ def create_order(customer:, shipped_at: nil)
       order: order,
       product: product,
       unit_price: product.price,
-      quantity: (1..3).to_a.sample,
+      quantity: (1..3).to_a.sample
     )
   end
 

--- a/spec/example_app/spec/models/product_spec.rb
+++ b/spec/example_app/spec/models/product_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Product do
     it "is trimmed on save" do
       product = FactoryBot.create(
         :product,
-        image_url: "\n https://example.com/foo/bar  \n",
+        image_url: "\n https://example.com/foo/bar  \n"
       )
       expect(product.image_url).to eq("https://example.com/foo/bar")
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :customer do
     association :territory, factory: :country
     sequence(:name) { |n| "Customer #{n}" }
-    email { name.downcase.gsub(" ", "_") + "@example.com" }
+    email { name.downcase.tr(" ", "_") + "@example.com" }
 
     transient do
       order_count { 3 }

--- a/spec/features/authorization_spec.rb
+++ b/spec/features/authorization_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 
+# standard:disable Lint/ConstantDefinitionInBlock
 describe "authorization" do
   before do
     class TestProductPolicy < ProductPolicy
@@ -54,3 +55,4 @@ describe "authorization" do
     expect(page).to have_css(".js-table-row", count: 1)
   end
 end
+# standard:enable Lint/ConstantDefinitionInBlock

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -12,7 +12,7 @@ describe "documentation navigation" do
 
     expect(page).to have_css("div.main h1", text: "Administrate")
     expect(page).to have_content(
-      "A framework for creating flexible, powerful admin dashboards in Rails",
+      "A framework for creating flexible, powerful admin dashboards in Rails"
     )
   end
 
@@ -21,7 +21,7 @@ describe "documentation navigation" do
 
     expect(page).to have_css("div.main h1", text: "Contributing Guide")
     expect(page).to have_content(
-      "We welcome pull requests from everyone.",
+      "We welcome pull requests from everyone."
     )
 
     visit("/CONTRIBUTING.md")
@@ -80,8 +80,8 @@ describe "documentation navigation" do
   it "links to the GitHub repo" do
     visit root_path
 
-    expect(github_link[:href]).
-      to eq "https://github.com/thoughtbot/administrate"
+    expect(github_link[:href])
+      .to eq "https://github.com/thoughtbot/administrate"
   end
 
   private
@@ -91,8 +91,8 @@ describe "documentation navigation" do
   end
 
   def internal_documentation_links
-    all(".sidebar a").
-      map { |anchor| anchor[:href] }.
-      select { |href| URI.parse(href).relative? }
+    all(".sidebar a")
+      .map { |anchor| anchor[:href] }
+      .select { |href| URI.parse(href).relative? }
   end
 end

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -52,7 +52,7 @@ describe "customer edit page" do
     visit edit_admin_customer_path(customer)
     expect(page).to have_css(
       ".selectize-input.items > [data-value]",
-      text: "vip",
+      text: "vip"
     )
   end
 
@@ -65,7 +65,7 @@ describe "customer edit page" do
 
     expect(page).to have_css(
       "#error_explanation ul li.flash-error",
-      text: "Name can't be blank",
+      text: "Name can't be blank"
     )
   end
 
@@ -77,9 +77,9 @@ describe "customer edit page" do
     translations = {
       activerecord: {
         models: {
-          customer: "Custom name",
-        },
-      },
+          customer: "Custom name"
+        }
+      }
     }
 
     with_translations(:en, translations) do

--- a/spec/features/form_spec.rb
+++ b/spec/features/form_spec.rb
@@ -16,10 +16,10 @@ describe "edit form" do
       helpers: {
         label: {
           customer: {
-            email_subscriber: custom_label,
-          },
-        },
-      },
+            email_subscriber: custom_label
+          }
+        }
+      }
     }
 
     with_translations(:en, translations) do
@@ -36,7 +36,7 @@ describe "edit form" do
       Product.human_attribute_name(:name),
       Product.human_attribute_name(:description),
       Product.human_attribute_name(:price),
-      Product.human_attribute_name(:image_url),
+      Product.human_attribute_name(:image_url)
     ]
 
     required_field_labels = find_all(".field-unit--required").map(&:text)
@@ -114,10 +114,10 @@ describe "edit form" do
         administrate: {
           field_hints: {
             customer: {
-              kind: field_hint,
-            },
-          },
-        },
+              kind: field_hint
+            }
+          }
+        }
       }
 
       with_translations(:en, translations) do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -1,7 +1,5 @@
 require "rails_helper"
 
-search_input_selector = ".search__input"
-
 describe "customer index page" do
   it "displays customers' name and email" do
     customer = create(:customer)
@@ -62,10 +60,10 @@ describe "customer index page" do
       helpers: {
         label: {
           customer: {
-            email_subscriber: custom_label,
-          },
-        },
-      },
+            email_subscriber: custom_label
+          }
+        }
+      }
     }
 
     with_translations(:en, translations) do

--- a/spec/features/log_entries_form_spec.rb
+++ b/spec/features/log_entries_form_spec.rb
@@ -11,7 +11,7 @@ describe "log entry form" do
 
     expect(page).to have_link(customer.name)
     expect(page).to have_flash(
-      t("administrate.controller.create.success", resource: "Log entry"),
+      t("administrate.controller.create.success", resource: "Log entry")
     )
   end
 

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -56,7 +56,7 @@ feature "log entries index page" do
       click_on t("administrate.actions.destroy")
     end
     expect(page).to have_flash(
-      t("administrate.controller.destroy.success", resource: "Log entry"),
+      t("administrate.controller.destroy.success", resource: "Log entry")
     )
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -32,10 +32,10 @@ describe "navigation" do
         models: {
           customer: {
             one: "User",
-            other: "Users",
-          },
-        },
-      },
+            other: "Users"
+          }
+        }
+      }
     }
 
     with_translations(:en, translations) do

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -79,10 +79,10 @@ describe "order form" do
         helpers: {
           label: {
             order: {
-              line_items: custom_label,
-            },
-          },
-        },
+              line_items: custom_label
+            }
+          }
+        }
       }
 
       with_translations(:en, translations) do

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -30,8 +30,8 @@ describe "product form has_one relationship" do
 
     travel_to(1.year.ago) do
       visit new_admin_product_path
-      expect(page).
-        not_to have_select("Release year", with_options: [current_year])
+      expect(page)
+        .not_to have_select("Release year", with_options: [current_year])
     end
   end
 
@@ -40,8 +40,8 @@ describe "product form has_one relationship" do
     new_release_year = Administrate::Field::Select.with_options(
       collection: [
         ["Last Year", 2019],
-        ["This Year", 2020],
-      ],
+        ["This Year", 2020]
+      ]
     )
     ProductDashboard::ATTRIBUTE_TYPES[:release_year] = new_release_year
 
@@ -75,10 +75,10 @@ describe "product form has_one relationship" do
         helpers: {
           label: {
             product: {
-              product_meta_tag: custom_label,
-            },
-          },
-        },
+              product_meta_tag: custom_label
+            }
+          }
+        }
       }
 
       with_translations(:en, translations) do

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -41,15 +41,15 @@ RSpec.describe "product index page" do
   scenario "product sorted by has_one association" do
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Gamma"),
+      product_meta_tag: build(:product_meta_tag, meta_title: "Gamma")
     )
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Alpha"),
+      product_meta_tag: build(:product_meta_tag, meta_title: "Alpha")
     )
     create(
       :product,
-      product_meta_tag: build(:product_meta_tag, meta_title: "Beta"),
+      product_meta_tag: build(:product_meta_tag, meta_title: "Beta")
     )
 
     visit admin_products_path

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -16,7 +16,7 @@ feature "Search" do
     it "is hidden when nothing is searchable in the current dashboard" do
       CustomerDashboard::ATTRIBUTE_TYPES.each do |_name, field_class|
         allow(field_class).to(
-          receive(:searchable?).and_return(false),
+          receive(:searchable?).and_return(false)
         )
       end
 
@@ -122,7 +122,7 @@ feature "Search" do
   scenario "admin clears search" do
     query = "foo"
     mismatch = create(:customer, name: "someone")
-    visit admin_customers_path(search: query, customer: { order: :name })
+    visit admin_customers_path(search: query, customer: {order: :name})
 
     expect(page).not_to have_content(mismatch.email)
     clear_search

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -48,15 +48,12 @@ RSpec.describe "customer show page" do
       end
     end
 
-    describe(
-      "when these are not a collection field" +
-      "and there's another paging association",
-    ) do
+    describe "when not a collection field and there's another paging association" do
       it "doesn't break" do
         orig_collection_attributes = CustomerDashboard::COLLECTION_ATTRIBUTES
         allow_any_instance_of(CustomerDashboard).to(
-          receive(:collection_attributes).
-          and_return(orig_collection_attributes - [:orders]),
+          receive(:collection_attributes)
+          .and_return(orig_collection_attributes - [:orders])
         )
 
         customer = create(:customer)
@@ -117,8 +114,8 @@ RSpec.describe "customer show page" do
     end
 
     visit admin_customer_path(customer, orders: {
-                                order: :id, direction: :desc
-                              })
+      order: :id, direction: :desc
+    })
 
     order_ids = orders.sort_by(&:id).map(&:id).reverse
 
@@ -127,8 +124,8 @@ RSpec.describe "customer show page" do
     end
 
     visit admin_customer_path(customer, orders: {
-                                order: :id, direction: :desc, page: 2
-                              })
+      order: :id, direction: :desc, page: 2
+    })
 
     within(table_for_attribute(:orders)) do
       expect(order_ids.last(2)).to eq(ids_in_table)
@@ -146,8 +143,8 @@ RSpec.describe "customer show page" do
 
     visit admin_customer_path(
       customer,
-      orders: { order: :id, direction: :desc },
-      log_entries: { order: :id, direction: :asc },
+      orders: {order: :id, direction: :desc},
+      log_entries: {order: :id, direction: :asc}
     )
 
     order_ids = orders.sort_by(&:id).map(&:id).reverse
@@ -166,8 +163,8 @@ RSpec.describe "customer show page" do
       orders: {
         order: :id,
         direction: :desc,
-        page: 2,
-      },
+        page: 2
+      }
     )
 
     within(table_for_attribute(:orders)) do
@@ -223,10 +220,10 @@ RSpec.describe "customer show page" do
       helpers: {
         label: {
           customer: {
-            email_subscriber: custom_label,
-          },
-        },
-      },
+            email_subscriber: custom_label
+          }
+        }
+      }
     }
 
     with_translations(:en, translations) do
@@ -246,16 +243,16 @@ RSpec.describe "customer show page" do
         actions: {
           edit: "Edit",
           destroy: "Destroy",
-          confirm: "Are you sure?",
-        },
+          confirm: "Are you sure?"
+        }
       },
       helpers: {
         label: {
           order: {
-            shipped_at: custom_label,
-          },
-        },
-      },
+            shipped_at: custom_label
+          }
+        }
+      }
     }
 
     with_translations(:en, translations) do
@@ -275,7 +272,7 @@ RSpec.describe "customer show page" do
         e[:class]&.split&.last&.split("--line_item_")&.last
       end
       expect(%w[product quantity unit_price total_price]).to(
-        eq(columns.first(4)),
+        eq(columns.first(4))
       )
     end
   end

--- a/spec/generators/assets_generator_spec.rb
+++ b/spec/generators/assets_generator_spec.rb
@@ -10,8 +10,8 @@ describe Administrate::Generators::AssetsGenerator, :generator do
       run_generator []
 
       %w[javascripts stylesheets].each do |asset|
-        expect(Rails::Generators).
-          to invoke_generator("administrate:assets:#{asset}")
+        expect(Rails::Generators)
+          .to invoke_generator("administrate:assets:#{asset}")
       end
     end
   end

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -21,91 +21,83 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
     describe "#attribute_types" do
       it "includes standard model attributes" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:foos) { |t| t.timestamps null: false }
-          end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          attrs = FooDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:id]).to eq(Administrate::Field::Number)
-          expect(attrs[:created_at]).to eq(Administrate::Field::DateTime)
-          expect(attrs[:updated_at]).to eq(Administrate::Field::DateTime)
-        ensure
-          remove_constants :Foo, :FooDashboard
+        ActiveRecord::Schema.define do
+          create_table(:foos) { |t| t.timestamps null: false }
         end
+
+        class Foo < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+        attrs = FooDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:id]).to eq(Administrate::Field::Number)
+        expect(attrs[:created_at]).to eq(Administrate::Field::DateTime)
+        expect(attrs[:updated_at]).to eq(Administrate::Field::DateTime)
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
 
       it "includes user-defined database columns" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:foos) { |t| t.string :name }
-          end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          attrs = FooDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:name]).to eq(Administrate::Field::String)
-        ensure
-          remove_constants :Foo, :FooDashboard
+        ActiveRecord::Schema.define do
+          create_table(:foos) { |t| t.string :name }
         end
+
+        class Foo < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+        attrs = FooDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:name]).to eq(Administrate::Field::String)
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
 
       it "sorts the attributes" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:foos, primary_key: :code) do |t|
-              t.string :col_2
-              t.string :col_1
-              t.string :col_3
-              t.timestamps
-            end
+        ActiveRecord::Schema.define do
+          create_table(:foos, primary_key: :code) do |t|
+            t.string :col_2
+            t.string :col_1
+            t.string :col_3
+            t.timestamps
           end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          attrs = FooDashboard::ATTRIBUTE_TYPES.keys
-
-          expect(attrs).to eq(%i[code col_1 col_2 col_3 created_at updated_at])
-        ensure
-          remove_constants :Foo, :FooDashboard
         end
+
+        class Foo < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+        attrs = FooDashboard::ATTRIBUTE_TYPES.keys
+
+        expect(attrs).to eq(%i[code col_1 col_2 col_3 created_at updated_at])
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
 
       it "defaults to a string column that is not searchable" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:foos) { |t| t.inet :ip_address }
-          end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          attrs = FooDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:ip_address]).
-            to eq(Administrate::Field::String.with_options(searchable: false))
-        ensure
-          remove_constants :Foo, :FooDashboard
+        ActiveRecord::Schema.define do
+          create_table(:foos) { |t| t.inet :ip_address }
         end
+
+        class Foo < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+        attrs = FooDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:ip_address])
+          .to eq(Administrate::Field::String.with_options(searchable: false))
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
 
       it "includes has_many relationships" do
@@ -117,29 +109,27 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       end
 
       it "assigns numeric fields a type of `Number`" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table :inventory_items do |t|
-              t.integer :quantity
-              t.float :price
-            end
+        ActiveRecord::Schema.define do
+          create_table :inventory_items do |t|
+            t.integer :quantity
+            t.float :price
           end
-
-          class InventoryItem < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["inventory_item"]
-          load file("app/dashboards/inventory_item_dashboard.rb")
-          attrs = InventoryItemDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:price]).
-            to eq(Administrate::Field::Number.with_options(decimals: 2))
-          expect(attrs[:quantity]).
-            to eq(Administrate::Field::Number)
-        ensure
-          remove_constants :InventoryItem, :InventoryItemDashboard
         end
+
+        class InventoryItem < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["inventory_item"]
+        load file("app/dashboards/inventory_item_dashboard.rb")
+        attrs = InventoryItemDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:price])
+          .to eq(Administrate::Field::Number.with_options(decimals: 2))
+        expect(attrs[:quantity])
+          .to eq(Administrate::Field::Number)
+      ensure
+        remove_constants :InventoryItem, :InventoryItemDashboard
       end
 
       it "detects enum field as `Select`" do
@@ -180,186 +170,172 @@ describe Administrate::Generators::DashboardGenerator, :generator do
         attrs = ShipmentDashboard::ATTRIBUTE_TYPES
         enum_collection_option = attrs[:status].options[:collection]
         select_field = Administrate::Field::Select.new(:status,
-                                                       nil,
-                                                       attrs[:status].options,
-                                                       resource: Shipment.new)
+          nil,
+          attrs[:status].options,
+          resource: Shipment.new)
 
-        expect(enum_collection_option.call(select_field)).
-          to eq(Shipment.statuses.keys)
+        expect(enum_collection_option.call(select_field))
+          .to eq(Shipment.statuses.keys)
       ensure
         remove_constants :Shipment, :ShipmentDashboard
       end
 
       it "detects boolean values" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:users) { |t| t.boolean :active }
-          end
-
-          class User < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["user"]
-          load file("app/dashboards/user_dashboard.rb")
-          attrs = UserDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:active]).to eq(Administrate::Field::Boolean)
-        ensure
-          remove_constants :User, :UserDashboard
+        ActiveRecord::Schema.define do
+          create_table(:users) { |t| t.boolean :active }
         end
+
+        class User < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["user"]
+        load file("app/dashboards/user_dashboard.rb")
+        attrs = UserDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:active]).to eq(Administrate::Field::Boolean)
+      ensure
+        remove_constants :User, :UserDashboard
       end
 
       it "assigns dates, times, and datetimes a type of `Date`, `DateTime` and
       `Time` respectively" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table :events do |t|
-              t.date :start_date
-              t.time :start_time
-              t.datetime :ends_at
-            end
+        ActiveRecord::Schema.define do
+          create_table :events do |t|
+            t.date :start_date
+            t.time :start_time
+            t.datetime :ends_at
           end
-
-          class Event < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["event"]
-          load file("app/dashboards/event_dashboard.rb")
-          attrs = EventDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:start_date]).to eq(Administrate::Field::Date)
-          expect(attrs[:start_time]).to eq(Administrate::Field::Time)
-          expect(attrs[:ends_at]).to eq(Administrate::Field::DateTime)
-        ensure
-          remove_constants :Event, :EventDashboard
         end
+
+        class Event < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["event"]
+        load file("app/dashboards/event_dashboard.rb")
+        attrs = EventDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:start_date]).to eq(Administrate::Field::Date)
+        expect(attrs[:start_time]).to eq(Administrate::Field::Time)
+        expect(attrs[:ends_at]).to eq(Administrate::Field::DateTime)
+      ensure
+        remove_constants :Event, :EventDashboard
       end
 
       it "detects belongs_to relationships" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table(:comments) { |t| t.references :post }
-          end
-          class Comment < Administrate::Generators::TestRecord
-            belongs_to :post
-          end
-
-          run_generator ["comment"]
-          load file("app/dashboards/comment_dashboard.rb")
-          attrs = CommentDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:post]).to eq(Administrate::Field::BelongsTo)
-          expect(attrs.keys).not_to include(:post_id)
-        ensure
-          remove_constants :Comment, :CommentDashboard
+        ActiveRecord::Schema.define do
+          create_table(:comments) { |t| t.references :post }
         end
+        class Comment < Administrate::Generators::TestRecord
+          belongs_to :post
+        end
+
+        run_generator ["comment"]
+        load file("app/dashboards/comment_dashboard.rb")
+        attrs = CommentDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:post]).to eq(Administrate::Field::BelongsTo)
+        expect(attrs.keys).not_to include(:post_id)
+      ensure
+        remove_constants :Comment, :CommentDashboard
       end
 
       it "detects polymorphic belongs_to relationships" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table :comments do |t|
-              t.references :commentable, polymorphic: true
-            end
+        ActiveRecord::Schema.define do
+          create_table :comments do |t|
+            t.references :commentable, polymorphic: true
           end
-          class Comment < Administrate::Generators::TestRecord
-            belongs_to :commentable, polymorphic: true
-          end
-
-          run_generator ["comment"]
-          load file("app/dashboards/comment_dashboard.rb")
-          attrs = CommentDashboard::ATTRIBUTE_TYPES
-
-          expect(attrs[:commentable]).to eq(Administrate::Field::Polymorphic)
-          expect(attrs.keys).not_to include(:commentable_id)
-          expect(attrs.keys).not_to include(:commentable_type)
-        ensure
-          remove_constants :Comment, :CommentDashboard
         end
+        class Comment < Administrate::Generators::TestRecord
+          belongs_to :commentable, polymorphic: true
+        end
+
+        run_generator ["comment"]
+        load file("app/dashboards/comment_dashboard.rb")
+        attrs = CommentDashboard::ATTRIBUTE_TYPES
+
+        expect(attrs[:commentable]).to eq(Administrate::Field::Polymorphic)
+        expect(attrs.keys).not_to include(:commentable_id)
+        expect(attrs.keys).not_to include(:commentable_type)
+      ensure
+        remove_constants :Comment, :CommentDashboard
       end
 
       it "detects has_one relationships" do
-        begin
+        ActiveRecord::Schema.define do
+          create_table :accounts
+
+          create_table :profiles do |t|
+            t.references :account
+          end
+        end
+
+        class Account < Administrate::Generators::TestRecord
+          reset_column_information
+          has_one :profile
+        end
+
+        class Ticket < Administrate::Generators::TestRecord
+          reset_column_information
+          belongs_to :account
+        end
+
+        dashboard = file("app/dashboards/account_dashboard.rb")
+
+        run_generator ["account"]
+
+        expect(dashboard).to contain("profile: Field::HasOne")
+      ensure
+        remove_constants :Account, :Ticket
+      end
+
+      if ActiveRecord.version >= Gem::Version.new(5)
+        it "skips temporary attributes" do
           ActiveRecord::Schema.define do
             create_table :accounts
-
-            create_table :profiles do |t|
-              t.references :account
-            end
           end
 
           class Account < Administrate::Generators::TestRecord
             reset_column_information
-            has_one :profile
-          end
-
-          class Ticket < Administrate::Generators::TestRecord
-            reset_column_information
-            belongs_to :account
+            attribute :tmp_attribute, :boolean
           end
 
           dashboard = file("app/dashboards/account_dashboard.rb")
 
           run_generator ["account"]
 
-          expect(dashboard).to contain("profile: Field::HasOne")
+          expect(dashboard).not_to contain("tmp_attribute")
         ensure
-          remove_constants :Account, :Ticket
-        end
-      end
-
-      if ActiveRecord.version >= Gem::Version.new(5)
-        it "skips temporary attributes" do
-          begin
-            ActiveRecord::Schema.define do
-              create_table :accounts
-            end
-
-            class Account < Administrate::Generators::TestRecord
-              reset_column_information
-              attribute :tmp_attribute, :boolean
-            end
-
-            dashboard = file("app/dashboards/account_dashboard.rb")
-
-            run_generator ["account"]
-
-            expect(dashboard).not_to contain("tmp_attribute")
-          ensure
-            remove_constants :Account
-          end
+          remove_constants :Account
         end
       end
     end
 
     describe "COLLECTION_ATTRIBUTES" do
       it "is limited to a reasonable number of items" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table :foos do |t|
-              %i(a b c d e f g).each { |attr| t.string attr }
-            end
+        ActiveRecord::Schema.define do
+          create_table :foos do |t|
+            %i[a b c d e f g].each { |attr| t.string attr }
           end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          all_attrs = FooDashboard::ATTRIBUTE_TYPES.keys.sort
-          table_attrs = FooDashboard::COLLECTION_ATTRIBUTES
-
-          expect(table_attrs).to contain_exactly(
-            :id,
-            *all_attrs.first(table_attribute_limit - 1),
-          )
-          expect(table_attrs).not_to eq(all_attrs)
-        ensure
-          remove_constants :Foo, :FooDashboard
         end
+
+        class Foo < Administrate::Generators::TestRecord
+          reset_column_information
+        end
+
+        run_generator ["foo"]
+        load file("app/dashboards/foo_dashboard.rb")
+        all_attrs = FooDashboard::ATTRIBUTE_TYPES.keys.sort
+        table_attrs = FooDashboard::COLLECTION_ATTRIBUTES
+
+        expect(table_attrs).to contain_exactly(
+          :id,
+          *all_attrs.first(table_attribute_limit - 1)
+        )
+        expect(table_attrs).not_to eq(all_attrs)
+      ensure
+        remove_constants :Foo, :FooDashboard
       end
 
       def table_attribute_limit
@@ -369,33 +345,6 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
     describe "FORM_ATTRIBUTES" do
       it "does not include read-only attributes" do
-        begin
-          ActiveRecord::Schema.define do
-            create_table :foos do |t|
-              t.string :name
-              t.timestamps null: true
-            end
-          end
-
-          class Foo < Administrate::Generators::TestRecord
-            reset_column_information
-          end
-
-          run_generator ["foo"]
-          load file("app/dashboards/foo_dashboard.rb")
-          attrs = FooDashboard::FORM_ATTRIBUTES
-
-          expect(attrs).to match_array([:name])
-        ensure
-          remove_constants :Foo, :FooDashboard
-        end
-      end
-    end
-  end
-
-  describe "SHOW_PAGE_ATTRIBUTES" do
-    it "includes all attributes" do
-      begin
         ActiveRecord::Schema.define do
           create_table :foos do |t|
             t.string :name
@@ -409,12 +358,35 @@ describe Administrate::Generators::DashboardGenerator, :generator do
 
         run_generator ["foo"]
         load file("app/dashboards/foo_dashboard.rb")
+        attrs = FooDashboard::FORM_ATTRIBUTES
 
-        attrs = FooDashboard::SHOW_PAGE_ATTRIBUTES
-        expect(attrs).to match_array([:name, :id, :created_at, :updated_at])
+        expect(attrs).to match_array([:name])
       ensure
         remove_constants :Foo, :FooDashboard
       end
+    end
+  end
+
+  describe "SHOW_PAGE_ATTRIBUTES" do
+    it "includes all attributes" do
+      ActiveRecord::Schema.define do
+        create_table :foos do |t|
+          t.string :name
+          t.timestamps null: true
+        end
+      end
+
+      class Foo < Administrate::Generators::TestRecord
+        reset_column_information
+      end
+
+      run_generator ["foo"]
+      load file("app/dashboards/foo_dashboard.rb")
+
+      attrs = FooDashboard::SHOW_PAGE_ATTRIBUTES
+      expect(attrs).to match_array([:name, :id, :created_at, :updated_at])
+    ensure
+      remove_constants :Foo, :FooDashboard
     end
   end
 
@@ -429,38 +401,35 @@ describe Administrate::Generators::DashboardGenerator, :generator do
     end
 
     it "subclasses Admin::ApplicationController by default" do
-      begin
-        ActiveRecord::Schema.define { create_table :foos }
-        class Foo < Administrate::Generators::TestRecord; end
+      ActiveRecord::Schema.define { create_table :foos }
+      class Foo < Administrate::Generators::TestRecord; end
 
-        run_generator ["foo"]
-        load file("app/controllers/admin/foos_controller.rb")
+      run_generator ["foo"]
+      load file("app/controllers/admin/foos_controller.rb")
 
-        expect(Admin::FoosController.ancestors).
-          to include(Admin::ApplicationController)
-      ensure
-        remove_constants :Foo
-        Admin.send(:remove_const, :FoosController)
-      end
+      expect(Admin::FoosController.ancestors)
+        .to include(Admin::ApplicationController)
+    ensure
+      remove_constants :Foo
+      Admin.send(:remove_const, :FoosController)
     end
 
     it "uses the given namespace to create controllers" do
-      begin
-        ActiveRecord::Schema.define { create_table :foos }
-        class Foo < Administrate::Generators::TestRecord; end
-        module Manager
-          class ApplicationController < Administrate::ApplicationController; end
-        end
+      ActiveRecord::Schema.define { create_table :foos }
+      class Foo < Administrate::Generators::TestRecord; end
 
-        run_generator ["foo", "--namespace", "manager"]
-        load file("app/controllers/manager/foos_controller.rb")
-
-        expect(Manager::FoosController.ancestors).
-          to include(Manager::ApplicationController)
-      ensure
-        remove_constants :Foo
-        Manager.send(:remove_const, :FoosController)
+      module Manager
+        class ApplicationController < Administrate::ApplicationController; end
       end
+
+      run_generator ["foo", "--namespace", "manager"]
+      load file("app/controllers/manager/foos_controller.rb")
+
+      expect(Manager::FoosController.ancestors)
+        .to include(Manager::ApplicationController)
+    ensure
+      remove_constants :Foo
+      Manager.send(:remove_const, :FoosController)
     end
   end
 end

--- a/spec/generators/field_generator_spec.rb
+++ b/spec/generators/field_generator_spec.rb
@@ -5,18 +5,16 @@ require "generators/administrate/field/field_generator"
 describe Administrate::Generators::FieldGenerator, :generator do
   describe "administrate:field field_name" do
     it "generates a field object" do
-      begin
-        run_generator ["foobar"]
+      run_generator ["foobar"]
 
-        load file("app/fields/foobar_field.rb")
-        field = FoobarField.new(:attr_name, "value", "show")
+      load file("app/fields/foobar_field.rb")
+      field = FoobarField.new(:attr_name, "value", "show")
 
-        expect(field.name).to eq("attr_name")
-        expect(field.data).to eq("value")
-        expect(field.to_s).to eq("value")
-      ensure
-        remove_constants :FoobarField
-      end
+      expect(field.name).to eq("attr_name")
+      expect(field.data).to eq("value")
+      expect(field.to_s).to eq("value")
+    ensure
+      remove_constants :FoobarField
     end
 
     it "generates a default `_index` partial" do

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -95,8 +95,8 @@ describe Administrate::Generators::InstallGenerator, :generator do
       run_generator
 
       %w[customer order product line_item].each do |resource|
-        expect(Rails::Generators).
-          to invoke_generator(
+        expect(Rails::Generators)
+          .to invoke_generator(
             "administrate:dashboard", [resource, "--namespace", "admin"]
           )
       end
@@ -107,7 +107,7 @@ describe Administrate::Generators::InstallGenerator, :generator do
     insert_into_file_after_line(
       1,
       file("config/routes.rb"),
-      File.read("lib/generators/administrate/install/templates/routes.rb"),
+      File.read("lib/generators/administrate/install/templates/routes.rb")
     )
   end
 

--- a/spec/generators/routes_generator_spec.rb
+++ b/spec/generators/routes_generator_spec.rb
@@ -51,18 +51,16 @@ describe Administrate::Generators::RoutesGenerator, :generator do
     end
 
     it "skips models that aren't backed by the database with a warning" do
-      begin
-        class ModelWithoutDBTable < ApplicationRecord; end
-        routes = file("config/routes.rb")
+      class ModelWithoutDBTable < ApplicationRecord; end
+      routes = file("config/routes.rb")
 
-        output = run_generator
+      output = run_generator
 
-        expect(routes).not_to contain("model_without_db_table")
-        expect(output).to include("WARNING: Unable to generate a dashboard " \
-          "for ModelWithoutDBTable.")
-      ensure
-        remove_constants :ModelWithoutDBTable
-      end
+      expect(routes).not_to contain("model_without_db_table")
+      expect(output).to include("WARNING: Unable to generate a dashboard " \
+        "for ModelWithoutDBTable.")
+    ensure
+      remove_constants :ModelWithoutDBTable
     end
 
     it "skips models that don't have a named constant" do
@@ -93,7 +91,7 @@ describe Administrate::Generators::RoutesGenerator, :generator do
         output = run_generator
 
         expect(routes).not_to contain("abstract_model")
-        expect(output).not_to include("WARNING: Unable to generate a "\
+        expect(output).not_to include("WARNING: Unable to generate a " \
           "dashboard for AbstractModel")
       end
     end

--- a/spec/generators/views/field_generator_spec.rb
+++ b/spec/generators/views/field_generator_spec.rb
@@ -44,7 +44,7 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :show)
           contents = File.read(
-            file("app/views/fields/#{field_type}/_show.html.erb"),
+            file("app/views/fields/#{field_type}/_show.html.erb")
           )
 
           expect(contents).to eq(expected_contents)
@@ -57,7 +57,7 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :form)
           contents = File.read(
-            file("app/views/fields/#{field_type}/_form.html.erb"),
+            file("app/views/fields/#{field_type}/_form.html.erb")
           )
 
           expect(contents).to eq(expected_contents)
@@ -70,7 +70,7 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
         field_types.each do |field_type|
           expected_contents = contents_for_field_template(field_type, :index)
           contents = File.read(
-            file("app/views/fields/#{field_type}/_index.html.erb"),
+            file("app/views/fields/#{field_type}/_index.html.erb")
           )
 
           expect(contents).to eq(expected_contents)
@@ -81,7 +81,7 @@ describe Administrate::Generators::Views::FieldGenerator, :generator do
 
   def contents_for_field_template(field_name, partial_name)
     File.read(
-      "app/views/fields/#{field_name}/_#{partial_name}.html.erb",
+      "app/views/fields/#{field_name}/_#{partial_name}.html.erb"
     )
   end
 end

--- a/spec/generators/views/layout_generator_spec.rb
+++ b/spec/generators/views/layout_generator_spec.rb
@@ -7,7 +7,7 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
     it "copies the layout template into the `admin/application` namespace" do
       allow(Rails::Generators).to receive(:invoke)
       expected_contents = File.read(
-        "app/views/layouts/administrate/application.html.erb",
+        "app/views/layouts/administrate/application.html.erb"
       )
 
       run_generator []
@@ -32,8 +32,8 @@ describe Administrate::Generators::Views::LayoutGenerator, :generator do
 
       run_generator []
 
-      expect(Rails::Generators).
-        to invoke_generator("administrate:views:navigation")
+      expect(Rails::Generators)
+        .to invoke_generator("administrate:views:navigation")
     end
 
     it "copies the javascript partial into the `admin/application` namespace" do

--- a/spec/generators/views_generator_spec.rb
+++ b/spec/generators/views_generator_spec.rb
@@ -11,10 +11,10 @@ describe Administrate::Generators::ViewsGenerator, :generator do
       run_generator [resource]
 
       %w[index show new edit].each do |generator|
-        expect(Rails::Generators).
-          to invoke_generator(
+        expect(Rails::Generators)
+          .to invoke_generator(
             "administrate:views:#{generator}",
-            [resource, "--namespace", "admin"],
+            [resource, "--namespace", "admin"]
           )
       end
     end
@@ -28,23 +28,23 @@ describe Administrate::Generators::ViewsGenerator, :generator do
       expect(Rails::Generators).to invoke_generator(
         "administrate:views:index",
         [resource, "--namespace", "admin"],
-        behavior: :revoke,
+        behavior: :revoke
       )
     end
 
     context "when run without any arguments" do
       it "calls the sub-generators without any arguments" do
         application_resource_path = instance_double("BaseResourcePath")
-        allow(Administrate::ViewGenerator::BaseResourcePath).to receive(:new).
-          and_return(application_resource_path)
+        allow(Administrate::ViewGenerator::BaseResourcePath).to receive(:new)
+          .and_return(application_resource_path)
         allow(Rails::Generators).to receive(:invoke)
 
         run_generator
 
         %w[index show new edit].each do |generator|
-          expect(Rails::Generators). to invoke_generator(
+          expect(Rails::Generators).to invoke_generator(
             "administrate:views:#{generator}",
-            [application_resource_path, "--namespace", "admin"],
+            [application_resource_path, "--namespace", "admin"]
           )
         end
       end
@@ -59,10 +59,10 @@ describe Administrate::Generators::ViewsGenerator, :generator do
         run_generator [resource, "--namespace", namespace]
 
         %w[index show new edit].each do |generator|
-          expect(Rails::Generators).
-            to invoke_generator(
+          expect(Rails::Generators)
+            .to invoke_generator(
               "administrate:views:#{generator}",
-              [resource, "--namespace", namespace],
+              [resource, "--namespace", namespace]
             )
         end
       end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe Administrate::ApplicationHelper do
             models: {
               customer: {
                 one: "User",
-                other: "Users",
-              },
-            },
-          },
+                other: "Users"
+              }
+            }
+          }
         }
       end
 
@@ -114,10 +114,10 @@ RSpec.describe Administrate::ApplicationHelper do
         ctx.accessible_action?("my_resource", "foo")
 
         expect(ctx).to(
-          have_received(:existing_action?).with(:my_resource, "foo"),
+          have_received(:existing_action?).with(:my_resource, "foo")
         )
         expect(ctx).to(
-          have_received(:authorized_action?).with(:my_resource, "foo"),
+          have_received(:authorized_action?).with(:my_resource, "foo")
         )
       ensure
         remove_constants :MyResource
@@ -133,10 +133,10 @@ RSpec.describe Administrate::ApplicationHelper do
         ctx.accessible_action?(:my_resource, "foo")
 
         expect(ctx).to(
-          have_received(:existing_action?).with(:my_resource, "foo"),
+          have_received(:existing_action?).with(:my_resource, "foo")
         )
         expect(ctx).to(
-          have_received(:authorized_action?).with(:my_resource, "foo"),
+          have_received(:authorized_action?).with(:my_resource, "foo")
         )
       ensure
         remove_constants :MyResource
@@ -153,7 +153,7 @@ RSpec.describe Administrate::ApplicationHelper do
 
         expect(ctx).to have_received(:existing_action?).with(MyResource, "foo")
         expect(ctx).to(
-          have_received(:authorized_action?).with(MyResource, "foo"),
+          have_received(:authorized_action?).with(MyResource, "foo")
         )
       ensure
         remove_constants :MyResource

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,17 +1,17 @@
-require 'spec_helper'
-require 'i18n/tasks'
+require "spec_helper"
+require "i18n/tasks"
 
-describe 'I18n' do
+describe "I18n" do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
 
-  it 'does not have missing keys' do
+  it "does not have missing keys" do
     expect(missing_keys).to be_empty,
       "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
-  it 'does not have unused keys' do
+  it "does not have unused keys" do
     expect(unused_keys).to be_empty,
       "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end

--- a/spec/lib/administrate/not_authorized_error_spec.rb
+++ b/spec/lib/administrate/not_authorized_error_spec.rb
@@ -5,10 +5,10 @@ describe Administrate::NotAuthorizedError do
     it "produces a message mentioning it directly" do
       error = described_class.new(
         resource: Administrate,
-        action: "foo",
+        action: "foo"
       )
       expect(error.message).to eq(
-        %{Not allowed to perform "foo" on Administrate},
+        %(Not allowed to perform "foo" on Administrate)
       )
     end
   end
@@ -17,9 +17,9 @@ describe Administrate::NotAuthorizedError do
     it "produces a message mentioning it directly" do
       error = described_class.new(
         resource: "User",
-        action: "foo",
+        action: "foo"
       )
-      expect(error.message).to eq(%{Not allowed to perform "foo" on "User"})
+      expect(error.message).to eq(%(Not allowed to perform "foo" on "User"))
     end
   end
 
@@ -27,9 +27,9 @@ describe Administrate::NotAuthorizedError do
     it "produces a message mentioning it directly" do
       error = described_class.new(
         resource: :user,
-        action: "foo",
+        action: "foo"
       )
-      expect(error.message).to eq(%{Not allowed to perform "foo" on :user})
+      expect(error.message).to eq(%(Not allowed to perform "foo" on :user))
     end
   end
 
@@ -39,10 +39,10 @@ describe Administrate::NotAuthorizedError do
 
       error = described_class.new(
         resource: TestStuff.new,
-        action: "foo",
+        action: "foo"
       )
       expect(error.message).to eq(
-        %{Not allowed to perform "foo" on the given TestStuff},
+        %(Not allowed to perform "foo" on the given TestStuff)
       )
     ensure
       remove_constants :TestStuff

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -38,7 +38,7 @@ describe Administrate::Order do
         ordered = order.apply(relation)
 
         expect(relation).to have_received(:reorder).with(
-          to_sql('"table_name"."name" ASC'),
+          to_sql('"table_name"."name" ASC')
         )
         expect(ordered).to eq(relation)
       end
@@ -51,7 +51,7 @@ describe Administrate::Order do
         ordered = order.apply(relation)
 
         expect(relation).to have_received(:reorder).with(
-          to_sql('"table_name"."name" DESC'),
+          to_sql('"table_name"."name" DESC')
         )
         expect(ordered).to eq(relation)
       end
@@ -64,7 +64,7 @@ describe Administrate::Order do
         ordered = order.apply(relation)
 
         expect(relation).to have_received(:reorder).with(
-          to_sql('"table_name"."name" ASC'),
+          to_sql('"table_name"."name" ASC')
         )
         expect(ordered).to eq(relation)
       end
@@ -78,8 +78,8 @@ describe Administrate::Order do
           klass: double(
             table_name: "users",
             arel_table: Arel::Table.new("users"),
-            primary_key: "uid",
-          ),
+            primary_key: "uid"
+          )
         )
         allow(relation).to receive(:reorder).and_return(relation)
         allow(relation).to receive(:left_joins).and_return(relation)
@@ -90,7 +90,7 @@ describe Administrate::Order do
         expect(relation).to have_received(:left_joins).with(:name)
         expect(relation).to have_received(:group).with(:id)
         expect(relation).to have_received(:reorder).with(
-          to_sql('COUNT("users"."uid") ASC'),
+          to_sql('COUNT("users"."uid") ASC')
         )
         expect(ordered).to eq(relation)
       end
@@ -101,14 +101,14 @@ describe Administrate::Order do
         order = Administrate::Order.new
         relation = relation_with_association(
           :belongs_to,
-          foreign_key: "some_foreign_key",
+          foreign_key: "some_foreign_key"
         )
         allow(relation).to receive(:reorder).and_return(relation)
 
         ordered = order.apply(relation)
 
         expect(relation).to have_received(:reorder).with(
-          to_sql('"table_name"."some_foreign_key" ASC'),
+          to_sql('"table_name"."some_foreign_key" ASC')
         )
         expect(ordered).to eq(relation)
       end
@@ -118,21 +118,21 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(to_sym: :user, tableize: "users"),
             nil,
-            association_attribute: "name",
+            association_attribute: "name"
           )
           relation = relation_with_association(
             :belongs_to,
             klass: double(
               table_name: "users",
-              columns_hash: { "name" => :value },
-            ),
+              columns_hash: {"name" => :value}
+            )
           )
           allow(relation).to receive(:joins).and_return(relation)
           allow(relation).to receive(:reorder).and_return(relation)
 
           ordered = order.apply(relation)
           expect(relation).to have_received(:reorder).with(
-            to_sql('"users"."name" ASC'),
+            to_sql('"users"."name" ASC')
           )
           expect(ordered).to eq(relation)
         end
@@ -143,14 +143,14 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(table_name: "users", to_sym: :user),
             nil,
-            association_attribute: "invalid_column_name",
+            association_attribute: "invalid_column_name"
           )
           relation = relation_with_association(
             :belongs_to,
             klass: double(
               table_name: "users",
-              columns_hash: { name: :value },
-            ),
+              columns_hash: {name: :value}
+            )
           )
           allow(relation).to receive(:joins).and_return(relation)
           allow(relation).to receive(:reorder).and_return(relation)
@@ -158,7 +158,7 @@ describe Administrate::Order do
           ordered = order.apply(relation)
 
           expect(relation).to have_received(:reorder).with(
-            to_sql('"table_name"."belongs_to_id" ASC'),
+            to_sql('"table_name"."belongs_to_id" ASC')
           )
           expect(ordered).to eq(relation)
         end
@@ -168,7 +168,7 @@ describe Administrate::Order do
     context "when relation has has_one association" do
       it "orders by id" do
         order = Administrate::Order.new(
-          double(to_sym: :user, tableize: "users"),
+          double(to_sym: :user, tableize: "users")
         )
         relation = relation_with_association(:has_one)
         allow(relation).to receive(:reorder).and_return(relation)
@@ -176,7 +176,7 @@ describe Administrate::Order do
         ordered = order.apply(relation)
 
         expect(relation).to have_received(:reorder).with(
-          to_sql('"users"."id" ASC'),
+          to_sql('"users"."id" ASC')
         )
         expect(ordered).to eq(relation)
       end
@@ -186,21 +186,21 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(to_sym: :user, tableize: "users"),
             nil,
-            association_attribute: "name",
+            association_attribute: "name"
           )
           relation = relation_with_association(
             :has_one,
             klass: double(
               table_name: "users",
-              columns_hash: { "name" => :value },
-            ),
+              columns_hash: {"name" => :value}
+            )
           )
           allow(relation).to receive(:joins).and_return(relation)
           allow(relation).to receive(:reorder).and_return(relation)
 
           ordered = order.apply(relation)
           expect(relation).to have_received(:reorder).with(
-            to_sql('"users"."name" ASC'),
+            to_sql('"users"."name" ASC')
           )
           expect(ordered).to eq(relation)
         end
@@ -211,14 +211,14 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             double(to_sym: :user, tableize: "users"),
             nil,
-            association_attribute: "invalid_column_name",
+            association_attribute: "invalid_column_name"
           )
           relation = relation_with_association(
             :has_one,
             klass: double(
               table_name: "users",
-              columns_hash: { name: :value },
-            ),
+              columns_hash: {name: :value}
+            )
           )
           allow(relation).to receive(:joins).and_return(relation)
           allow(relation).to receive(:reorder).and_return(relation)
@@ -226,7 +226,7 @@ describe Administrate::Order do
           ordered = order.apply(relation)
 
           expect(relation).to have_received(:reorder).with(
-            to_sql('"users"."id" ASC'),
+            to_sql('"users"."id" ASC')
           )
           expect(ordered).to eq(relation)
         end
@@ -321,9 +321,9 @@ describe Administrate::Order do
   def relation_with_column(column)
     double(
       klass: double(reflect_on_association: nil),
-      columns_hash: { column.to_s => :column_info },
+      columns_hash: {column.to_s => :column_info},
       table_name: "table_name",
-      arel_table: Arel::Table.new("table_name"),
+      arel_table: Arel::Table.new("table_name")
     )
   end
 
@@ -338,11 +338,11 @@ describe Administrate::Order do
           "#{association}_reflection",
           macro: association,
           foreign_key: foreign_key,
-          klass: klass,
-        ),
+          klass: klass
+        )
       ),
       table_name: "table_name",
-      arel_table: Arel::Table.new("table_name"),
+      arel_table: Arel::Table.new("table_name")
     )
   end
 end

--- a/spec/lib/administrate/resource_resolver_spec.rb
+++ b/spec/lib/administrate/resource_resolver_spec.rb
@@ -79,9 +79,9 @@ describe Administrate::ResourceResolver do
       translations = {
         activerecord: {
           models: {
-            "library/book": "Library Book",
-          },
-        },
+            "library/book": "Library Book"
+          }
+        }
       }
 
       with_translations(:en, translations) do

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -7,10 +7,10 @@ require "administrate/field/email"
 require "administrate/field/has_many"
 require "administrate/field/has_one"
 require "administrate/field/number"
-require "administrate/field/string"
 require "administrate/base_dashboard"
 require "administrate/search"
 
+# standard:disable Lint/ConstantDefinitionInBlock
 describe Administrate::Search do
   before :all do
     module Administrate
@@ -22,14 +22,16 @@ describe Administrate::Search do
         end
 
         class Role < MockRecord; end
+
         class Person < MockRecord; end
+
         class Address < MockRecord; end
 
         class Foo < MockRecord
           belongs_to :role
           belongs_to(
             :author,
-            class_name: "Administrate::SearchSpecMocks::Person",
+            class_name: "Administrate::SearchSpecMocks::Person"
           )
           has_one :address
         end
@@ -39,12 +41,12 @@ describe Administrate::Search do
             id: Administrate::Field::Number.with_options(searchable: true),
             name: Administrate::Field::String,
             email: Administrate::Field::Email,
-            phone: Administrate::Field::Number,
+            phone: Administrate::Field::Number
           }.freeze
 
           COLLECTION_FILTERS = {
             vip: ->(resource) { resource.where(kind: :vip) },
-            kind: ->(resource, param) { resource.where(kind: param) },
+            kind: ->(resource, param) { resource.where(kind: param) }
           }.freeze
         end
 
@@ -52,17 +54,17 @@ describe Administrate::Search do
           ATTRIBUTE_TYPES = {
             role: Administrate::Field::BelongsTo.with_options(
               searchable: true,
-              searchable_field: "name",
+              searchable_field: "name"
             ),
             author: Administrate::Field::BelongsTo.with_options(
               searchable: true,
               searchable_fields: ["first_name", "last_name"],
-              class_name: "Administrate::SearchSpecMocks::Person",
+              class_name: "Administrate::SearchSpecMocks::Person"
             ),
             address: Administrate::Field::HasOne.with_options(
               searchable: true,
-              searchable_fields: ["street"],
-            ),
+              searchable_fields: ["street"]
+            )
           }.freeze
         end
       end
@@ -83,7 +85,7 @@ describe Administrate::Search do
       search = Administrate::Search.new(
         scoped_object,
         Administrate::SearchSpecMocks::UserDashboard.new,
-        nil,
+        nil
       )
       expect(scoped_object).to receive(:all)
 
@@ -98,7 +100,7 @@ describe Administrate::Search do
       search = Administrate::Search.new(
         scoped_object,
         Administrate::SearchSpecMocks::UserDashboard.new,
-        "   ",
+        "   "
       )
       expect(scoped_object).to receive(:all)
 
@@ -113,17 +115,17 @@ describe Administrate::Search do
       search = Administrate::Search.new(
         scoped_object,
         Administrate::SearchSpecMocks::UserDashboard.new,
-        "test",
+        "test"
       )
       expected_query = [
         [
           'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
           'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?',
-          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?'
         ].join(" OR "),
         "%test%",
         "%test%",
-        "%test%",
+        "%test%"
       ]
       expect(scoped_object).to receive(:where).with(*expected_query)
 
@@ -138,17 +140,17 @@ describe Administrate::Search do
       search = Administrate::Search.new(
         scoped_object,
         Administrate::SearchSpecMocks::UserDashboard.new,
-        "Тест Test",
+        "Тест Test"
       )
       expected_query = [
         [
           'LOWER(CAST("users"."id" AS CHAR(256))) LIKE ?',
           'LOWER(CAST("users"."name" AS CHAR(256))) LIKE ?',
-          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?'
         ].join(" OR "),
         "%тест test%",
         "%тест test%",
-        "%тест test%",
+        "%тест test%"
       ]
       expect(scoped_object).to receive(:where).with(*expected_query)
 
@@ -168,20 +170,20 @@ describe Administrate::Search do
         Administrate::Search.new(
           scoped_object,
           Administrate::SearchSpecMocks::FooDashboard.new,
-          "Тест Test",
+          "Тест Test"
         )
       end
 
       let(:expected_query) do
         [
-          'LOWER(CAST("roles"."name" AS CHAR(256))) LIKE ?'\
-          ' OR LOWER(CAST("people"."first_name" AS CHAR(256))) LIKE ?'\
-          ' OR LOWER(CAST("people"."last_name" AS CHAR(256))) LIKE ?'\
+          'LOWER(CAST("roles"."name" AS CHAR(256))) LIKE ?' \
+          ' OR LOWER(CAST("people"."first_name" AS CHAR(256))) LIKE ?' \
+          ' OR LOWER(CAST("people"."last_name" AS CHAR(256))) LIKE ?' \
           ' OR LOWER(CAST("addresses"."street" AS CHAR(256))) LIKE ?',
           "%тест test%",
           "%тест test%",
           "%тест test%",
-          "%тест test%",
+          "%тест test%"
         ]
       end
 
@@ -192,7 +194,7 @@ describe Administrate::Search do
         search.run
 
         expect(scoped_object).to(
-          have_received(:left_joins).with(%i(role author address)),
+          have_received(:left_joins).with(%i[role author address])
         )
       end
 
@@ -203,22 +205,22 @@ describe Administrate::Search do
         search.run
 
         expect(scoped_object).to(
-          have_received(:where).with(*expected_query),
+          have_received(:where).with(*expected_query)
         )
       end
 
       it "triggers a deprecation warning" do
         allow(scoped_object).to receive(:where)
         allow(scoped_object).to(
-          receive(:left_joins).
-            with(%i(role author address)).
-            and_return(scoped_object),
+          receive(:left_joins)
+            .with(%i[role author address])
+            .and_return(scoped_object)
         )
 
         search.run
 
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/:class_name is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/:class_name is deprecated/)
       end
     end
 
@@ -230,12 +232,12 @@ describe Administrate::Search do
       search = Administrate::Search.new(
         scoped_object,
         Administrate::SearchSpecMocks::UserDashboard.new,
-        "vip:",
+        "vip:"
       )
       expect(scoped_object).to \
-        receive(:where).
-        with(kind: :vip).
-        and_return(scoped_object)
+        receive(:where)
+        .with(kind: :vip)
+        .and_return(scoped_object)
       expect(scoped_object).to receive(:where).and_return(scoped_object)
 
       search.run
@@ -244,3 +246,4 @@ describe Administrate::Search do
     end
   end
 end
+# standard:enable Lint/ConstantDefinitionInBlock

--- a/spec/lib/fields/base_spec.rb
+++ b/spec/lib/fields/base_spec.rb
@@ -8,11 +8,11 @@ describe Administrate::Field::Base do
     it "is false by default" do
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [],
+        validators_on: []
       )
       resource = instance_double(
         "ActiveRecord::Base",
-        class: resource_class,
+        class: resource_class
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -22,15 +22,15 @@ describe Administrate::Field::Base do
     it "is true on an unconditional requirement for a value" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        options: {},
+        options: {}
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
-        class: resource_class,
+        class: resource_class
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -40,15 +40,15 @@ describe Administrate::Field::Base do
     it "is false on a conditional requirement for a value (with :if)" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        if: -> { true },
+        if: -> { true }
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
-        class: resource_class,
+        class: resource_class
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -58,15 +58,15 @@ describe Administrate::Field::Base do
     it "is false on a conditional requirement for a value (with :unless)" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        unless: -> { true },
+        unless: -> { true }
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
-        class: resource_class,
+        class: resource_class
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -76,16 +76,16 @@ describe Administrate::Field::Base do
     it "is true for an unpersisted record in only required on create" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        on: :create,
+        on: :create
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
         class: resource_class,
-        persisted?: false,
+        persisted?: false
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -95,16 +95,16 @@ describe Administrate::Field::Base do
     it "is false for a persisted record if only required on create" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        on: :create,
+        on: :create
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
         class: resource_class,
-        persisted?: true,
+        persisted?: true
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -114,16 +114,16 @@ describe Administrate::Field::Base do
     it "is true for a persisted record in only required on update" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        on: :update,
+        on: :update
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
         class: resource_class,
-        persisted?: true,
+        persisted?: true
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -133,16 +133,16 @@ describe Administrate::Field::Base do
     it "is false for a persisted record in only required on update" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        on: :update,
+        on: :update
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
         class: resource_class,
-        persisted?: false,
+        persisted?: false
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 
@@ -152,15 +152,15 @@ describe Administrate::Field::Base do
     it "is false when required only on unstandard situations" do
       validator = ActiveRecord::Validations::PresenceValidator.new(
         attributes: [:foo],
-        on: :some_situation_or_the_other,
+        on: :some_situation_or_the_other
       )
       resource_class = class_double(
         "ActiveRecord::Base",
-        validators_on: [validator],
+        validators_on: [validator]
       )
       resource = instance_double(
         "ActiveRecord::Base",
-        class: resource_class,
+        class: resource_class
       )
       field = field_class.new(:attribute, :date, :page, resource: resource)
 

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -10,7 +10,7 @@ describe Administrate::Field::BelongsTo do
     should_permit_param(
       "country_code",
       on_model: Customer,
-      for_attribute: :territory,
+      for_attribute: :territory
     )
   end
 
@@ -33,7 +33,7 @@ describe Administrate::Field::BelongsTo do
         :product,
         nil,
         :show,
-        resource: line_item,
+        resource: line_item
       )
       expect(field.associated_class).to eq(Product)
     end
@@ -44,7 +44,7 @@ describe Administrate::Field::BelongsTo do
         :territory,
         nil,
         :show,
-        resource: customer,
+        resource: customer
       )
       expect(field.associated_class).to eq(Country)
     end
@@ -58,12 +58,12 @@ describe Administrate::Field::BelongsTo do
         :product,
         line_item.product,
         :show,
-        resource: line_item,
+        resource: line_item
       )
       allow_any_instance_of(ProductDashboard).to(
         receive(:display_resource) do |_, resource|
           "Mock #{resource.name}"
-        end,
+        end
       )
       expect(field.display_associated_resource).to eq("Mock Associated Product")
     end
@@ -75,12 +75,12 @@ describe Administrate::Field::BelongsTo do
         :territory,
         country,
         :show,
-        resource: customer,
+        resource: customer
       )
       allow_any_instance_of(CountryDashboard).to(
         receive(:display_resource) do |_, resource|
           "Mock #{resource.name}"
-        end,
+        end
       )
       expect(field.display_associated_resource).to eq("Mock Associated Country")
     end
@@ -94,13 +94,13 @@ describe Administrate::Field::BelongsTo do
     it "determines the associated_class" do
       line_item = create(:line_item)
       field_class = Administrate::Field::BelongsTo.with_options(
-        class_name: "Customer",
+        class_name: "Customer"
       )
       field = field_class.new(
         :product,
         line_item.product,
         :show,
-        resource: line_item,
+        resource: line_item
       )
       expect(field.associated_class).to eq(Customer)
     end
@@ -109,33 +109,33 @@ describe Administrate::Field::BelongsTo do
       product = create(:product, name: "Associated Product")
       line_item = create(:line_item, product: product)
       field_class = Administrate::Field::BelongsTo.with_options(
-        class_name: "LineItem",
+        class_name: "LineItem"
       )
       field = field_class.new(
         :product,
         line_item.product,
         :show,
-        resource: line_item,
+        resource: line_item
       )
       expect(field.display_associated_resource).to match(
-        /^Line Item \#\d\d\d\d$/,
+        /^Line Item \#\d\d\d\d$/
       )
     end
 
     it "triggers a deprecation warning" do
       line_item = create(:line_item)
       field_class = Administrate::Field::BelongsTo.with_options(
-        class_name: "Customer",
+        class_name: "Customer"
       )
       field = field_class.new(
         :product,
         line_item.product,
         :show,
-        resource: line_item,
+        resource: line_item
       )
       field.associated_class
-      expect(Administrate.deprecator).to have_received(:warn).
-        with(/:class_name is deprecated/)
+      expect(Administrate.deprecator).to have_received(:warn)
+        .with(/:class_name is deprecated/)
     end
   end
 
@@ -148,11 +148,11 @@ describe Administrate::Field::BelongsTo do
           :territory,
           [],
           :edit,
-          resource: customer,
+          resource: customer
         )
         candidates = field.associated_resource_options
 
-        expect(field.include_blank_option). to eq(true)
+        expect(field.include_blank_option).to eq(true)
         expect(candidates).to eq([])
       end
     end
@@ -161,17 +161,17 @@ describe Administrate::Field::BelongsTo do
       it "determines if choices has blank option or not" do
         customer = create(:customer, territory: nil)
         association = Administrate::Field::BelongsTo.with_options(
-          include_blank: false,
+          include_blank: false
         )
         field = association.new(
           :territory,
           [],
           :edit,
-          resource: customer,
+          resource: customer
         )
         candidates = field.associated_resource_options
 
-        expect(field.include_blank_option). to eq(false)
+        expect(field.include_blank_option).to eq(false)
         expect(candidates).to eq([])
       end
     end
@@ -181,25 +181,21 @@ describe Administrate::Field::BelongsTo do
     before do
       allow(Administrate.deprecator).to receive(:warn)
 
-      Foo = Class.new
-      FooDashboard = Class.new
+      stub_const("Foo", Class.new)
+      stub_const("FooDashboard", Class.new)
       uuid = SecureRandom.uuid
       allow(Foo).to receive(:all).and_return([Foo])
       allow(Foo).to receive(:uuid).and_return(uuid)
       allow(Foo).to receive(:id).and_return(1)
       allow_any_instance_of(FooDashboard).to(
-        receive(:display_resource).and_return(uuid),
+        receive(:display_resource).and_return(uuid)
       )
-    end
-
-    after do
-      remove_constants :Foo, :FooDashboard
     end
 
     it "is the associated table key that matches our foreign key" do
       association =
         Administrate::Field::BelongsTo.with_options(
-          primary_key: "uuid", class_name: "Foo",
+          primary_key: "uuid", class_name: "Foo"
         )
       field = association.new(:customers, [], :show)
       field.associated_resource_options
@@ -212,13 +208,13 @@ describe Administrate::Field::BelongsTo do
     it "triggers a deprecation warning" do
       association =
         Administrate::Field::BelongsTo.with_options(
-          primary_key: "uuid",
+          primary_key: "uuid"
         )
       field = association.new(:foo, double(uuid: nil), :baz)
       field.selected_option
 
-      expect(Administrate.deprecator).to have_received(:warn).
-        with(/:primary_key is deprecated/)
+      expect(Administrate.deprecator).to have_received(:warn)
+        .with(/:primary_key is deprecated/)
     end
   end
 
@@ -229,7 +225,7 @@ describe Administrate::Field::BelongsTo do
 
     it "determines what foreign key is used on the relationship for the form" do
       association = Administrate::Field::BelongsTo.with_options(
-        foreign_key: "foo_uuid", class_name: "Foo",
+        foreign_key: "foo_uuid", class_name: "Foo"
       )
       field = association.new(:customers, [], :show)
       permitted_attribute = field.permitted_attribute
@@ -238,14 +234,14 @@ describe Administrate::Field::BelongsTo do
 
     it "triggers a deprecation warning" do
       association = Administrate::Field::BelongsTo.with_options(
-        foreign_key: "foo_uuid", class_name: "Foo",
+        foreign_key: "foo_uuid", class_name: "Foo"
       )
       field = association.new(:customers, [], :show)
 
       field.permitted_attribute
 
-      expect(Administrate.deprecator).to have_received(:warn).
-        with(/:foreign_key is deprecated/)
+      expect(Administrate.deprecator).to have_received(:warn)
+        .with(/:foreign_key is deprecated/)
     end
   end
 
@@ -254,7 +250,7 @@ describe Administrate::Field::BelongsTo do
       it "returns the resources in correct order" do
         order = create(:order)
         create_list(:customer, 5)
-        options = { order: "name" }
+        options = {order: "name"}
         association = Administrate::Field::BelongsTo.with_options(options)
 
         field = association.new(:customer, [], :show, resource: order)
@@ -270,7 +266,7 @@ describe Administrate::Field::BelongsTo do
         create_list(:customer, 3)
         options = {
           order: "name",
-          scope: -> { Customer.order(name: :desc) },
+          scope: -> { Customer.order(name: :desc) }
         }
         association = Administrate::Field::BelongsTo.with_options(options)
 

--- a/spec/lib/fields/boolean_spec.rb
+++ b/spec/lib/fields/boolean_spec.rb
@@ -21,7 +21,7 @@ describe Administrate::Field::Boolean do
     should_permit_param(
       "foo",
       on_model: Customer,
-      for_attribute: :foo,
+      for_attribute: :foo
     )
   end
 

--- a/spec/lib/fields/date_spec.rb
+++ b/spec/lib/fields/date_spec.rb
@@ -6,29 +6,29 @@ describe Administrate::Field::Date do
   let(:formats) do
     {
       date: {
-        formats: { default: "%m/%d/%Y", short: "%b %d" },
+        formats: {default: "%m/%d/%Y", short: "%b %d"},
         abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
-        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
       },
       time: {
-        formats: { default: "%a, %b %-d, %Y", short: "%d %b" },
-      },
+        formats: {default: "%a, %b %-d, %Y", short: "%d %b"}
+      }
     }
   end
 
   describe "#date" do
     it "displays the date" do
       with_translations(:en, formats) do
-        field = Administrate::Field::Date.
-          new(:start_date, start_date, :show)
+        field = Administrate::Field::Date
+          .new(:start_date, start_date, :show)
         expect(field.date).to eq("12/25/2015")
       end
     end
 
     context "with `prefix` option" do
       it "displays the date in the requested format" do
-        options_field = Administrate::Field::Date.
-          with_options(format: :short)
+        options_field = Administrate::Field::Date
+          .with_options(format: :short)
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -37,8 +37,8 @@ describe Administrate::Field::Date do
       end
 
       it "displays the date using a format string" do
-        options_field = Administrate::Field::Date.
-          with_options(format: "%Y")
+        options_field = Administrate::Field::Date
+          .with_options(format: "%Y")
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -6,29 +6,29 @@ describe Administrate::Field::DateTime do
   let(:formats) do
     {
       date: {
-        formats: { default: "%m/%d/%Y", short: "%b %d" },
+        formats: {default: "%m/%d/%Y", short: "%b %d"},
         abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
-        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
       },
       time: {
-        formats: { default: "%a, %b %-d, %Y at %r", short: "%d %b %H:%M" },
-      },
+        formats: {default: "%a, %b %-d, %Y at %r", short: "%d %b %H:%M"}
+      }
     }
   end
 
   describe "#date" do
     it "displays the date" do
       with_translations(:en, formats) do
-        field = Administrate::Field::DateTime.
-          new(:start_date, start_date, :show)
+        field = Administrate::Field::DateTime
+          .new(:start_date, start_date, :show)
         expect(field.date).to eq("12/25/2015")
       end
     end
 
     context "with `prefix` option" do
       it "displays the date in the requested format" do
-        options_field = Administrate::Field::DateTime.
-          with_options(format: :short)
+        options_field = Administrate::Field::DateTime
+          .with_options(format: :short)
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -37,8 +37,8 @@ describe Administrate::Field::DateTime do
       end
 
       it "displays the date using a format string" do
-        options_field = Administrate::Field::DateTime.
-          with_options(format: "%Y")
+        options_field = Administrate::Field::DateTime
+          .with_options(format: "%Y")
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -50,8 +50,8 @@ describe Administrate::Field::DateTime do
     context "with `timezone` option set to New York & early DateTime" do
       it "displays previous day because of the time difference" do
         start_date = DateTime.parse("2015-12-25 02:15:45")
-        options_field = Administrate::Field::DateTime.
-          with_options(format: :short, timezone: "America/New_York")
+        options_field = Administrate::Field::DateTime
+          .with_options(format: :short, timezone: "America/New_York")
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -63,8 +63,8 @@ describe Administrate::Field::DateTime do
     context "with default `timezone` set to New York & early DateTime" do
       it "displays previous day because of the time difference" do
         start_date = Time.zone.parse("2015-12-25 02:15:45")
-        options_field = Administrate::Field::DateTime.
-          with_options(format: :short)
+        options_field = Administrate::Field::DateTime
+          .with_options(format: :short)
         field = options_field.new(:start_date, start_date, :show)
 
         Time.use_zone("America/New_York") do
@@ -76,8 +76,8 @@ describe Administrate::Field::DateTime do
 
       it "displays the date with the timezone which is specified by options" do
         start_date = Time.zone.parse("2015-12-25 02:15:45")
-        options_field = Administrate::Field::DateTime.
-          with_options(format: :short, timezone: "Paris")
+        options_field = Administrate::Field::DateTime
+          .with_options(format: :short, timezone: "Paris")
         field = options_field.new(:start_date, start_date, :show)
 
         Time.use_zone("America/New_York") do
@@ -100,8 +100,8 @@ describe Administrate::Field::DateTime do
 
     context "with `prefix` option" do
       it "displays the datetime in the requested format" do
-        options_field = Administrate::Field::DateTime.
-          with_options(format: :short)
+        options_field = Administrate::Field::DateTime
+          .with_options(format: :short)
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -110,8 +110,8 @@ describe Administrate::Field::DateTime do
       end
 
       it "displays the datetime format string" do
-        options_field = Administrate::Field::DateTime.
-          with_options(format: "%H:%M")
+        options_field = Administrate::Field::DateTime
+          .with_options(format: "%H:%M")
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do
@@ -122,8 +122,8 @@ describe Administrate::Field::DateTime do
 
     context "with `timezone` option" do
       it "displays the datetime for the specified timezone" do
-        options_field = Administrate::Field::DateTime.
-          with_options(format: "%H:%M", timezone: "America/New_York")
+        options_field = Administrate::Field::DateTime
+          .with_options(format: "%H:%M", timezone: "America/New_York")
         field = options_field.new(:start_date, start_date, :show)
 
         with_translations(:en, formats) do

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -14,35 +14,35 @@ describe Administrate::Field::Deferred do
       it "returns the value given" do
         deferred = Administrate::Field::Deferred.new(
           Administrate::Field::BelongsTo,
-          foreign_key: :bar,
+          foreign_key: :bar
         )
-        expect(deferred.permitted_attribute(:foo, resource_class: LineItem)).
-          to eq(:bar)
+        expect(deferred.permitted_attribute(:foo, resource_class: LineItem))
+          .to eq(:bar)
       end
 
       it "triggers a deprecation warning" do
         deferred = Administrate::Field::Deferred.new(
           Administrate::Field::BelongsTo,
-          foreign_key: :bar,
+          foreign_key: :bar
         )
         deferred.permitted_attribute(:foo, resource_class: LineItem)
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/:foreign_key is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/:foreign_key is deprecated/)
       end
     end
 
     context "when not given a `foreign_key` option" do
       it "delegates to the backing class" do
         deferred = Administrate::Field::Deferred.new(
-          Administrate::Field::String,
+          Administrate::Field::String
         )
         allow(Administrate::Field::String).to receive(:permitted_attribute)
 
         deferred.permitted_attribute(:foo, resource_class: LineItem)
 
         expect(Administrate::Field::String).to(
-          have_received(:permitted_attribute).
-            with(:foo, resource_class: LineItem),
+          have_received(:permitted_attribute)
+            .with(:foo, resource_class: LineItem)
         )
       end
     end
@@ -53,14 +53,14 @@ describe Administrate::Field::Deferred do
         allow(field).to receive(:permitted_attribute)
         deferred = Administrate::Field::Deferred.new(
           field,
-          class_name: "Foo::Bar",
+          class_name: "Foo::Bar"
         )
 
         deferred.permitted_attribute(:bars)
 
         expect(field).to(
-          have_received(:permitted_attribute).
-            with(:bars, class_name: "Foo::Bar"),
+          have_received(:permitted_attribute)
+            .with(:bars, class_name: "Foo::Bar")
         )
       end
     end
@@ -71,11 +71,11 @@ describe Administrate::Field::Deferred do
       it "returns the value given" do
         searchable_deferred = Administrate::Field::Deferred.new(
           double(searchable?: false),
-          searchable: true,
+          searchable: true
         )
         unsearchable_deferred = Administrate::Field::Deferred.new(
           double(searchable?: true),
-          searchable: false,
+          searchable: false
         )
 
         expect(searchable_deferred.searchable?).to eq(true)
@@ -86,10 +86,10 @@ describe Administrate::Field::Deferred do
     context "when not given a `searchable` option" do
       it "falls back to the default of the deferred class" do
         searchable_deferred = Administrate::Field::Deferred.new(
-          double(searchable?: true),
+          double(searchable?: true)
         )
         unsearchable_deferred = Administrate::Field::Deferred.new(
-          double(searchable?: false),
+          double(searchable?: false)
         )
 
         expect(searchable_deferred.searchable?).to eq(true)

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -23,7 +23,7 @@ describe Administrate::Field::HasMany do
         :orders,
         Order.all,
         :show,
-        resource: customer,
+        resource: customer
       )
 
       page = field.associated_collection
@@ -38,17 +38,13 @@ describe Administrate::Field::HasMany do
     before do
       allow(Administrate.deprecator).to receive(:warn)
 
-      FooDashboard = Class.new
+      stub_const("FooDashboard", Class.new)
       allow(FooDashboard).to receive(:new).and_return(dashboard_double)
     end
 
-    after do
-      remove_constants :FooDashboard
-    end
-
     it "determines what dashboard is used to present the association" do
-      association = Administrate::Field::HasMany.
-        with_options(class_name: "Foo")
+      association = Administrate::Field::HasMany
+        .with_options(class_name: "Foo")
       field = association.new(:customers, [], :show)
       collection = field.associated_collection
       attributes = collection.attribute_names
@@ -58,13 +54,13 @@ describe Administrate::Field::HasMany do
     end
 
     it "triggers a deprecation warning" do
-      association = Administrate::Field::HasMany.
-        with_options(class_name: "Foo")
+      association = Administrate::Field::HasMany
+        .with_options(class_name: "Foo")
       field = association.new(:customers, [], :show)
       field.associated_collection
 
-      expect(Administrate.deprecator).to have_received(:warn).
-        with(/:class_name is deprecated/)
+      expect(Administrate.deprecator).to have_received(:warn)
+        .with(/:class_name is deprecated/)
     end
   end
 
@@ -72,25 +68,21 @@ describe Administrate::Field::HasMany do
     before do
       allow(Administrate.deprecator).to receive(:warn)
 
-      Foo = Class.new
-      FooDashboard = Class.new
+      stub_const("Foo", Class.new)
+      stub_const("FooDashboard", Class.new)
       uuid = SecureRandom.uuid
       allow(Foo).to receive(:all).and_return([Foo])
       allow(Foo).to receive(:uuid).and_return(uuid)
       allow(Foo).to receive(:id).and_return(1)
       allow_any_instance_of(FooDashboard).to(
-        receive(:display_resource).and_return(uuid),
+        receive(:display_resource).and_return(uuid)
       )
-    end
-
-    after do
-      remove_constants :Foo, :FooDashboard
     end
 
     it "is the key matching the associated foreign key" do
       association =
         Administrate::Field::HasMany.with_options(
-          primary_key: "uuid", class_name: "Foo",
+          primary_key: "uuid", class_name: "Foo"
         )
       field = association.new(:customers, [], :show)
       field.associated_resource_options
@@ -103,13 +95,13 @@ describe Administrate::Field::HasMany do
     it "triggers a deprecation warning" do
       association =
         Administrate::Field::HasMany.with_options(
-          primary_key: "uuid", class_name: "Foo",
+          primary_key: "uuid", class_name: "Foo"
         )
       field = association.new(:customers, [], :show)
       field.associated_resource_options
 
-      expect(Administrate.deprecator).to have_received(:warn).
-        with(/:primary_key is deprecated/)
+      expect(Administrate.deprecator).to have_received(:warn)
+        .with(/:primary_key is deprecated/)
     end
   end
 
@@ -143,7 +135,7 @@ describe Administrate::Field::HasMany do
           :orders,
           value,
           :show,
-          resource: customer,
+          resource: customer
         )
 
         expect(field.more_than_limit?).to eq(false)
@@ -161,7 +153,7 @@ describe Administrate::Field::HasMany do
         :orders,
         value,
         :show,
-        resource: customer,
+        resource: customer
       )
 
       expect(field.resources.size).to eq(limit)
@@ -176,7 +168,7 @@ describe Administrate::Field::HasMany do
           :orders,
           value,
           :show,
-          resource: customer,
+          resource: customer
         )
 
         expect(field.resources).to eq([])
@@ -198,13 +190,13 @@ describe Administrate::Field::HasMany do
     context "with `sort_by` option" do
       it "returns the resources in correct order" do
         customer = create(:customer, :with_orders)
-        options = { sort_by: :address_line_two }
+        options = {sort_by: :address_line_two}
         association = Administrate::Field::HasMany.with_options(options)
         field = association.new(
           :orders,
           customer.orders,
           :show,
-          resource: customer,
+          resource: customer
         )
 
         correct_order = customer.orders.sort_by(&:address_line_two).map(&:id)
@@ -220,13 +212,13 @@ describe Administrate::Field::HasMany do
     context "with `direction` option" do
       it "returns the resources in correct order" do
         customer = create(:customer, :with_orders)
-        options = { sort_by: :address_line_two, direction: :desc }
+        options = {sort_by: :address_line_two, direction: :desc}
         association = Administrate::Field::HasMany.with_options(options)
         field = association.new(
           :orders,
           customer.orders,
           :show,
-          resource: customer,
+          resource: customer
         )
 
         reversed_order = customer.orders.sort_by(&:address_line_two).map(&:id)
@@ -244,17 +236,17 @@ describe Administrate::Field::HasMany do
     it "returns a collection of keys to use for the association" do
       associated_resource1 = double(
         "AssociatedResource1",
-        associated_resource_key: "associated-1",
+        associated_resource_key: "associated-1"
       )
       associated_resource2 = double(
         "AssociatedResource2",
-        associated_resource_key: "associated-2",
+        associated_resource_key: "associated-2"
       )
       attribute_value = MockRelation.new(
         [
           associated_resource1,
-          associated_resource2,
-        ],
+          associated_resource2
+        ]
       )
 
       primary_resource = double(
@@ -263,9 +255,9 @@ describe Administrate::Field::HasMany do
           "ResourceClass",
           reflect_on_association: double(
             "ResourceReflection",
-            association_primary_key: "associated_resource_key",
-          ),
-        ),
+            association_primary_key: "associated_resource_key"
+          )
+        )
       )
 
       association = Administrate::Field::HasMany
@@ -273,7 +265,7 @@ describe Administrate::Field::HasMany do
         :customers,
         attribute_value,
         :show,
-        resource: primary_resource,
+        resource: primary_resource
       )
 
       expect(field.selected_options).to eq(["associated-1", "associated-2"])
@@ -288,7 +280,7 @@ describe Administrate::Field::HasMany do
           :orders,
           value,
           :show,
-          resource: customer,
+          resource: customer
         )
 
         expect(field.selected_options).to be_nil

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -14,7 +14,7 @@ describe Administrate::Field::HasOne do
         :product_meta_tag,
         value,
         :show,
-        resource: resource,
+        resource: resource
       )
 
       form = field.nested_form
@@ -31,7 +31,7 @@ describe Administrate::Field::HasOne do
         :product_meta_tag,
         product_meta_tag,
         :show,
-        resource: product,
+        resource: product
       )
 
       show = field.nested_show
@@ -49,30 +49,30 @@ describe Administrate::Field::HasOne do
       it "returns attributes from correct dashboard" do
         field = Administrate::Field::Deferred.new(
           Administrate::Field::HasOne,
-          class_name: :product_meta_tag,
+          class_name: :product_meta_tag
         )
 
         field_name = "product_meta_tag"
         attributes = field.permitted_attribute(
           field_name,
-          resource_class: Product,
+          resource_class: Product
         )
-        expect(attributes[:"#{field_name}_attributes"]).
-          to eq(%i(meta_title meta_description id))
+        expect(attributes[:"#{field_name}_attributes"])
+          .to eq(%i[meta_title meta_description id])
       end
 
       it "triggers a deprecation warning" do
         field = Administrate::Field::Deferred.new(
           Administrate::Field::HasOne,
-          class_name: :product_meta_tag,
+          class_name: :product_meta_tag
         )
         field_name = "product_meta_tag"
         field.permitted_attribute(
           field_name,
-          resource_class: Product,
+          resource_class: Product
         )
-        expect(Administrate.deprecator).to have_received(:warn).
-          with(/:class_name is deprecated/)
+        expect(Administrate.deprecator).to have_received(:warn)
+          .with(/:class_name is deprecated/)
       end
     end
   end
@@ -86,7 +86,7 @@ describe Administrate::Field::HasOne do
         :product_meta_tag,
         value,
         page,
-        resource: resource,
+        resource: resource
       )
 
       path = field.to_partial_path
@@ -102,7 +102,7 @@ describe Administrate::Field::HasOne do
         field = described_class.new(
           :product_meta_tag,
           product_meta_tag,
-          :show,
+          :show
         )
 
         expect(field).to be_linkable
@@ -115,7 +115,7 @@ describe Administrate::Field::HasOne do
         field = described_class.new(
           :product_meta_tag,
           product_meta_tag,
-          :show,
+          :show
         )
 
         expect(field).to_not be_linkable
@@ -128,7 +128,7 @@ describe Administrate::Field::HasOne do
         field = described_class.new(
           :product_meta_tag,
           product_meta_tag,
-          :show,
+          :show
         )
 
         expect(field).not_to be_linkable

--- a/spec/lib/fields/number_spec.rb
+++ b/spec/lib/fields/number_spec.rb
@@ -21,7 +21,7 @@ describe Administrate::Field::Number do
     should_permit_param(
       "foo",
       on_model: Customer,
-      for_attribute: :foo,
+      for_attribute: :foo
     )
   end
 
@@ -87,21 +87,21 @@ describe Administrate::Field::Number do
       context "when `formatter: :number_to_delimited`" do
         it "includes the delimiter for numbers greater than 999" do
           ninety_nine = number_with_options(
-            999, format: { formatter: :number_to_delimited }
+            999, format: {formatter: :number_to_delimited}
           )
           thousand_default = number_with_options(
-            1_000, format: { formatter: :number_to_delimited }
+            1_000, format: {formatter: :number_to_delimited}
           )
           thousand_explicit_comma = number_with_options(
             1_000, format: {
               formatter: :number_to_delimited,
-              formatter_options: { delimiter: "," },
+              formatter_options: {delimiter: ","}
             }
           )
           million_explicit_space = number_with_options(
             1_000_000, format: {
               formatter: :number_to_delimited,
-              formatter_options: { delimiter: " " },
+              formatter_options: {delimiter: " "}
             }
           )
 
@@ -115,7 +115,7 @@ describe Administrate::Field::Number do
       context "when `formatter: :number_to_currency`" do
         it "includes the currency" do
           with_currency = number_with_options(
-            100, format: { formatter: :number_to_currency }
+            100, format: {formatter: :number_to_currency}
           )
           expect(with_currency.to_s).to eq("$100.00")
         end
@@ -123,7 +123,7 @@ describe Administrate::Field::Number do
 
       context "when passed incorrect `formatter`" do
         it "works" do
-          thousand = number_with_options(1_000, format: { formatter: :rubbish })
+          thousand = number_with_options(1_000, format: {formatter: :rubbish})
 
           expect(thousand.to_s).to eq("1000")
         end
@@ -141,9 +141,9 @@ describe Administrate::Field::Number do
             formatter: :number_to_delimited,
             formatter_options: {
               delimiter: " ",
-              separator: ",",
-            },
-          },
+              separator: ","
+            }
+          }
         }
         number = number_with_options(100, **options)
 

--- a/spec/lib/fields/password_spec.rb
+++ b/spec/lib/fields/password_spec.rb
@@ -20,7 +20,7 @@ describe Administrate::Field::Password do
     should_permit_param(
       "foo",
       on_model: Customer,
-      for_attribute: :foo,
+      for_attribute: :foo
     )
   end
 
@@ -54,8 +54,8 @@ describe Administrate::Field::Password do
 
       it "shortens to the given length & different to default character" do
         password = password_with_options(lorem(30),
-                                         truncate: 10,
-                                         character: "-")
+          truncate: 10,
+          character: "-")
 
         expect(password.truncate).to eq(lorem(10, "-"))
       end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -20,29 +20,27 @@ describe Administrate::Field::Polymorphic do
 
   it do
     should_permit_param(
-      { "foo" => %i{type value} },
+      {"foo" => %i[type value]},
       on_model: Customer,
-      for_attribute: :foo,
+      for_attribute: :foo
     )
   end
 
   describe "#display_associated_resource" do
     it "displays through the dashboard based on the polymorphic class name" do
-      begin
-        Thing = Class.new
-        ThingDashboard = Class.new do
-          def display_resource(*)
-            :success
-          end
+      Thing = Class.new
+      ThingDashboard = Class.new do
+        def display_resource(*)
+          :success
         end
-
-        field = Administrate::Field::Polymorphic.new(:foo, Thing.new, :show)
-        display = field.display_associated_resource
-
-        expect(display).to eq :success
-      ensure
-        remove_constants :Thing, :ThingDashboard
       end
+
+      field = Administrate::Field::Polymorphic.new(:foo, Thing.new, :show)
+      display = field.display_associated_resource
+
+      expect(display).to eq :success
+    ensure
+      remove_constants :Thing, :ThingDashboard
     end
   end
 

--- a/spec/lib/fields/select_spec.rb
+++ b/spec/lib/fields/select_spec.rb
@@ -10,11 +10,11 @@ describe Administrate::Field::Select do
         "yes",
         :_page_,
         resource: customer,
-        collection: ["no", "yes", "absolutely"],
+        collection: ["no", "yes", "absolutely"]
       )
 
       expect(field.selectable_options).to eq(
-        ["no", "yes", "absolutely"],
+        ["no", "yes", "absolutely"]
       )
     end
 
@@ -28,14 +28,14 @@ describe Administrate::Field::Select do
         collection: {
           "no" => "opt0",
           "yes" => "opt1",
-          "absolutely" => "opt2",
-        },
+          "absolutely" => "opt2"
+        }
       )
 
       expect(field.selectable_options).to eq(
         "no" => "opt0",
         "yes" => "opt1",
-        "absolutely" => "opt2",
+        "absolutely" => "opt2"
       )
     end
 
@@ -50,15 +50,15 @@ describe Administrate::Field::Select do
           {
             "no" => "opt0",
             "yes" => "opt1",
-            "absolutely" => "opt2",
+            "absolutely" => "opt2"
           }
-        },
+        }
       )
 
       expect(field.selectable_options).to eq(
         "no" => "opt0",
         "yes" => "opt1",
-        "absolutely" => "opt2",
+        "absolutely" => "opt2"
       )
     end
 
@@ -74,15 +74,15 @@ describe Administrate::Field::Select do
           {
             "no, #{person.name}" => "opt0",
             "yes, #{person.name}" => "opt1",
-            "absolutely, #{person.name}" => "opt2",
+            "absolutely, #{person.name}" => "opt2"
           }
-        },
+        }
       )
 
       expect(field.selectable_options).to eq(
         "no, Dave" => "opt0",
         "yes, Dave" => "opt1",
-        "absolutely, Dave" => "opt2",
+        "absolutely, Dave" => "opt2"
       )
     end
 
@@ -92,7 +92,7 @@ describe Administrate::Field::Select do
         :kind,
         "vip",
         :_page_,
-        resource: customer,
+        resource: customer
       )
 
       expect(field.selectable_options).to eq(["standard", "vip"])
@@ -105,7 +105,7 @@ describe Administrate::Field::Select do
         "platinum",
         :_page_,
         resource: customer,
-        collection: ["gold", "platinum"],
+        collection: ["gold", "platinum"]
       )
 
       expect(field.selectable_options).to eq(["gold", "platinum"])
@@ -117,7 +117,7 @@ describe Administrate::Field::Select do
         :email_subscriber,
         "opt1",
         :_page_,
-        resource: customer,
+        resource: customer
       )
 
       expect(field.selectable_options).to eq([])

--- a/spec/lib/fields/string_spec.rb
+++ b/spec/lib/fields/string_spec.rb
@@ -20,7 +20,7 @@ describe Administrate::Field::String do
     should_permit_param(
       "foo",
       on_model: Customer,
-      for_attribute: :foo,
+      for_attribute: :foo
     )
   end
 

--- a/spec/lib/fields/time_spec.rb
+++ b/spec/lib/fields/time_spec.rb
@@ -19,8 +19,8 @@ describe Administrate::Field::Time do
       time = DateTime.new(2021, 3, 26, 16, 38)
       formats = {
         time: {
-          formats: { short: "%H:%M" },
-        },
+          formats: {short: "%H:%M"}
+        }
       }
 
       options_field = Administrate::Field::Time.with_options(format: :short)

--- a/spec/lib/fields/url_spec.rb
+++ b/spec/lib/fields/url_spec.rb
@@ -43,7 +43,7 @@ describe Administrate::Field::Url do
           :url,
           base_url + "a",
           :page,
-          truncate: base_url.length,
+          truncate: base_url.length
         )
 
         truncated = url.truncate

--- a/spec/lib/pages/form_spec.rb
+++ b/spec/lib/pages/form_spec.rb
@@ -27,7 +27,7 @@ describe Administrate::Page::Form do
           "" => %i[
             order
             product
-          ],
+          ]
         )
       end
     end
@@ -40,7 +40,7 @@ describe Administrate::Page::Form do
           "" => %i[
             order
             product
-          ],
+          ]
         )
       end
     end
@@ -54,7 +54,7 @@ describe Administrate::Page::Form do
             order
             product
             quantity
-          ],
+          ]
         )
       end
     end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,6 +1,6 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe Customer, :type => :model do
+RSpec.describe Customer, type: :model do
   it { should have_many :orders }
 
   it { should validate_presence_of(:name) }
@@ -25,7 +25,7 @@ RSpec.describe Customer, :type => :model do
     it "sums the total_price of all orders" do
       customer = Customer.new orders: [
         order_stub(total_price: 20),
-        order_stub(total_price: 30),
+        order_stub(total_price: 30)
       ]
 
       expect(customer.lifetime_value).to eq 50

--- a/spec/models/doc_page_spec.rb
+++ b/spec/models/doc_page_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe DocPage do
       expect(page).to have_attributes(
         title: nil,
         body: a_string_matching(
-          /A framework for creating flexible, powerful admin dashboards/,
-        ),
+          /A framework for creating flexible, powerful admin dashboards/
+        )
       )
     end
 
@@ -32,8 +32,8 @@ RSpec.describe DocPage do
         title: "Getting Started",
         body: a_string_starting_with(
           "<h1>Getting Started</h1>\n\n<p>Administrate is " \
-          "released as a Ruby gem",
-        ),
+          "released as a Ruby gem"
+        )
       )
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Order do
     order.destroy
 
     expect(order.errors[:base]).to eq(
-      ["Cannot delete record because dependent payments exist"],
+      ["Cannot delete record because dependent payments exist"]
     )
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Order do
       order = build(:order)
       order.line_items = [
         line_item_stub(total_price: 20),
-        line_item_stub(total_price: 30),
+        line_item_stub(total_price: 30)
       ]
 
       expect(order.total_price).to eq 50

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Product do
     it { should validate_presence_of(:price) }
 
     it do
-      should validate_numericality_of(:release_year).
-        is_less_than_or_equal_to(Time.now.year)
+      should validate_numericality_of(:release_year)
+        .is_less_than_or_equal_to(Time.now.year)
     end
 
     it "should not allow names that produce empty slugs" do
@@ -17,8 +17,8 @@ RSpec.describe Product do
 
       product.validate
 
-      expect(product.errors[:name]).
-        to include("must have letters or numbers for the URL")
+      expect(product.errors[:name])
+        .to include("must have letters or numbers for the URL")
     end
 
     context "with other products in the database" do
@@ -38,5 +38,4 @@ RSpec.describe Product do
 
     expect(Product.all).to be_empty
   end
-
 end

--- a/spec/support/constant_helpers.rb
+++ b/spec/support/constant_helpers.rb
@@ -2,7 +2,7 @@ module ConstantHelpers
   def remove_constants(*constants)
     constants.each { |const| Object.send(:remove_const, const) }
   rescue NameError => e
-    $stderr.puts "Warning from ConstantHelpers::remove_constants:\n\t#{e}"
+    warn "Warning from ConstantHelpers::remove_constants:\n\t#{e}"
   end
 end
 

--- a/spec/support/dashboard_helpers.rb
+++ b/spec/support/dashboard_helpers.rb
@@ -1,8 +1,8 @@
 module DashboardHelpers
   def displayed(resource)
-    (resource.class.to_s + "Dashboard").
-      constantize.
-      new.
-      display_resource(resource)
+    (resource.class.to_s + "Dashboard")
+      .constantize
+      .new
+      .display_resource(resource)
   end
 end

--- a/spec/support/field_matchers.rb
+++ b/spec/support/field_matchers.rb
@@ -2,7 +2,7 @@ module FieldMatchers
   def should_permit_param(expected_param, for_attribute:, on_model:)
     permitted_param = described_class.permitted_attribute(
       for_attribute,
-      resource_class: on_model,
+      resource_class: on_model
     )
 
     permitted_param =

--- a/spec/support/generator_spec_helpers.rb
+++ b/spec/support/generator_spec_helpers.rb
@@ -17,11 +17,11 @@ module GeneratorSpecHelpers
 
   def contents_for_application_template(view_name)
     File.read(
-      "app/views/administrate/application/#{view_name}.html.erb",
+      "app/views/administrate/application/#{view_name}.html.erb"
     )
   end
 
-  def invoke_generator(generator, args = [], options = { behavior: :invoke })
+  def invoke_generator(generator, args = [], options = {behavior: :invoke})
     have_received(:invoke).with(generator, args, options)
   end
 

--- a/spec/support/table.rb
+++ b/spec/support/table.rb
@@ -29,7 +29,7 @@ module Features
     "/" + [
       :admin,
       model.class.to_s.underscore.pluralize,
-      model.to_param,
+      model.to_param
     ].join("/")
   end
 end


### PR DESCRIPTION
Some time ago, we at thoughtbot stopped using our custom Rubocop rules and replaced it with standard. This adds Standard, sets up support for it in GitHub Actions and runs it against the code base.

We ignore `Lint/ConstantDefinitionInBlock` in a few specs, as this is related to the Pundit integration. It'd be good to come back to this in future and adjust the specs to avoid defining/overriding classes in specs, but honestly it was too difficult to make it work in a reasonable time.

Finally, we need to use `main` of the standard Action as, currently, that's the only one which is working (`0.0.5` fails silently).

https://github.com/standardrb/standard
https://github.com/thoughtbot/guides/pull/606