### PR TITLE
Add a guide for Migrating to v1

### DIFF
--- a/docs/migrating-to-v1.md
+++ b/docs/migrating-to-v1.md
@@ -1,0 +1,23 @@
+---
+title: Migrating to v1
+---
+
+In the release of v1.0.0, we [began bundling assets in the gem itself][2397].
+In future, this should mean that changes to the way you, or Administrate
+manages assets should not have an effect on you. However, this is quite a big
+change and so you might find some problems.
+
+[2397]: https://github.com/thoughtbot/administrate/pull/2397
+
+## Reported Issues
+
+### Removal of the `sprockets-rails` transitive dependency
+
+[Issue][2514]
+
+Previously, Administrate depended on [`sprockets-rails`][], if you have a
+dependency which requires this, you may now need to add a direct dependency on
+your application.
+
+[2514]: https://github.com/thoughtbot/administrate/issues/2514
+[`sprockets-rails`]: https://rubygems.org/gems/sprockets-rails

--- a/spec/example_app/app/views/layouts/docs.html.erb
+++ b/spec/example_app/app/views/layouts/docs.html.erb
@@ -25,6 +25,7 @@
 
       <ul class="sidebar-links">
         <li><a href="/getting_started">Getting Started</a></li>
+        <li><a href="/migrating-to-v1">Migrating to v1</a></li>
         <li><a href="/customizing_dashboards">Customizing Dashboards</a></li>
         <li><a href="/customizing_page_views">Customizing Page Views</a></li>
         <li><a href="/customizing_attribute_partials">Customizing Attribute Partials</a></li>


### PR DESCRIPTION
This intends to document everything we've heard as reported issues, to try and help users migrate as easily as possible.

It will collect a few issues before being merged, but this started with documenting the transitive dependency on `sprockets-rails`.

Closes #2514