### PR TITLE
Start running Appraisals in the build matrix

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,38 @@
+---
+name: Setup
+description: Shared setup steps
+inputs:
+  ruby-version:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby ${{ inputs.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: true
+    - name: Set up JS
+      uses: actions/setup-node@v4
+      with:
+        cache: yarn
+    - name: Install Ruby dependencies
+      run: bundle install
+      shell: bash
+    - name: Install Appraisal dependencies
+      run: bundle exec appraisal install
+      shell: bash
+    - name: Install JS dependencies
+      run: yarn install
+      shell: bash
+    - name: Setup the environment
+      run: cp .sample.env .env
+      shell: bash
+    - run: cp spec/example_app/config/database.yml.sample spec/example_app/config/database.yml
+      shell: bash
+    - name: Setup the database
+      run: bundle exec rake db:setup
+      shell: bash
+    - name: Build assets
+      run: yarn run build && yarn run build:css
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', 3.1, 3.2, 3.3]
+        ruby: [3.1, 3.2, 3.3]
     env:
       PGHOST: localhost
       PGUSER: administrate
@@ -33,35 +33,45 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Set up JS
-        uses: actions/setup-node@v4
-        with:
-          cache: yarn
-      - name: Install Ruby dependencies
-        run: bundle install
-      - name: Install Appraisal dependencies
-        run: bundle exec appraisal install
-      - name: Install JS dependencies
-        run: yarn install
-      - name: Setup the environment
-        run: cp .sample.env .env
-      - run: cp spec/example_app/config/database.yml.sample spec/example_app/config/database.yml
-      - name: Setup the database
-        run: bundle exec rake db:setup
-      - name: Build assets
-        run: yarn run build && yarn run build:css
       - name: Run tests
         run: bundle exec rspec
-      - name: Appraise Rails 6.0
-        run: bundle exec appraisal rails60 rspec
-        if: ${{ matrix.ruby <= '3.0' }}
-      - name: Appraise Rails 6.1
-        run: bundle exec appraisal rails61 rspec
-      - name: Appraisal Rails 7.0
-        run: bundle exec appraisal rails70 rspec
+
+  appraisal:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [3.1, 3.2, 3.3]
+        appraisal: [rails61, rails70, pundit21]
+        include:
+          - ruby: '3.0'
+            appraisal: rails60
+    env:
+      PGHOST: localhost
+      PGUSER: administrate
+      PGPASSWORD: administrate
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: administrate
+          POSTGRES_DB: administrate_test
+          POSTGRES_PASSWORD: administrate
+        ports:
+           - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Appraise Rails ${{ matrix.appraisal }}
+        run: bundle exec appraisal ${{ matrix.appraisal }} rspec


### PR DESCRIPTION
This goes further with splitting out different jobs, by listing the Appraisals in the matrix. The hope is that this will provide better feedback when parts of the build fails, as if we've got something like a flakey test, it should run against every combination.

In addition to this, it extracts a "composite" action which allows for some reuse between different jobs. It's not possible to reuse the services section, unfortunately (YAML anchors aren't supported, which would be the ideal solution).

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
https://docs.github.com/en/actions/creating-actions/creating-a-composite-action 
https://github.com/actions/runner/issues/1182