### PR TITLE
Update linting references

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
----
-ruby:
-  config_file: .rubocop.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ This project uses:
 * Sass
 * [BEM]-style CSS selectors, with [namespaces]
 * Autoprefixer
-* SCSS-Lint, with [Hound] ([configuration](.scss-lint.yml))
+* SCSS-Lint, with [stylelint] ([configuration](stylelint-config))
 * A variety of CSS units:
   - `em` for typographical-related elements
   - `rem` for lengths related to components
@@ -79,7 +79,8 @@ This project uses:
 
 [BEM]: http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/
 [namespaces]: http://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/
-[Hound]: https://houndci.com/
+[stylelint]: https://stylelint.io
+[stylelint-config]: https://github.com/thoughtbot/stylelint-config
 
 ## Labels
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![CircleCI](https://img.shields.io/circleci/project/github/thoughtbot/administrate.svg)](https://circleci.com/gh/thoughtbot/administrate/tree/main)
 [![Gem Version](https://badge.fury.io/rb/administrate.svg)](https://badge.fury.io/rb/administrate)
-[![Code Climate](https://codeclimate.com/github/thoughtbot/administrate/badges/gpa.svg)](https://codeclimate.com/github/thoughtbot/administrate)
-[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 A framework for creating flexible, powerful admin dashboards in Rails.
 [Try the demo][demo].


### PR DESCRIPTION
Since #2508 and #2492, we no longer use Hound, this removes the last reference of it and it's configuration.

We also haven't had a working Code Climate configuration for a while, so this removes that too.