### PR TITLE
Fix "search with a filter with arguments" spec

### DIFF
--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -102,8 +102,8 @@ feature "Search" do
     fill_in :search, with: "kind:vip"
     submit_search
 
-    expect(page).not_to have_content(standard_match.email)
     expect(page).to have_content(kind_match.email)
+    expect(page).not_to have_content(standard_match.email)
   end
 
   scenario "admin searches with an a term similiar to a filter", :js do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -101,6 +101,7 @@ feature "Search" do
     clear_search
     fill_in :search, with: "kind:vip"
     submit_search
+    sleep 1
 
     expect(page).to have_content(kind_match.email)
     expect(page).not_to have_content(standard_match.email)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -101,7 +101,7 @@ feature "Search" do
     clear_search
     fill_in :search, with: "kind:vip"
     submit_search
-    sleep 1
+    sleep 10
 
     expect(page).to have_content(kind_match.email)
     expect(page).not_to have_content(standard_match.email)


### PR DESCRIPTION
Since we merged in #2448, this has been repeatedly failing on CI. It doesn't fail locally, which makes it hard to debug.

Fixes #2523