### PR TITLE
Bump yard version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.35)
+    yard (0.9.36)
     zeitwerk (2.6.13)
 
 PLATFORMS


### PR DESCRIPTION
CI is failing due to this CVE:

```
ruby-advisory-db:
  advisories:	878 advisories
  last updated:	2024-03-13 17:35:01 -0700
  commit:	ff710b9dff3b17cabad830a8011f49b9fa14ec81
Name: yard
Version: 0.9.35
CVE: CVE-2024-27285
GHSA: GHSA-8mq4-9jjh-9xrc
Criticality: Medium
URL: https://github.com/advisories/GHSA-8mq4-9jjh-9xrc
Title: YARD's default template vulnerable to Cross-site Scripting in generated frames.html
Solution: upgrade to '>= 0.9.36'
```