### PR TITLE
Potential solution to handling arrays

### DIFF
--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -19,5 +19,9 @@ By default, the input is a text field.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute %>
+  <% if field.resource.class.columns_hash[field.attribute.to_s].array? %>
+    <%= f.text_field field.attribute, value: JSON.dump(field.data) %>
+  <% else %>
+    <%= f.text_field field.attribute, value: field.data %>
+  <% end %>
 </div>


### PR DESCRIPTION
Before I proceed with this further I need to know if this is the right approach, and also I'd like advice on how to handle errors in cases like this.

This has the potential to be a big change reason why I just showcase a small sample.

The idea is: if we have an array column we should treat it as a string containing JSON data that people can edit as is. It's the simplest thing I could think of.

Right now, if you have an array column in the DB, the value is neither displayed nor saved correctly in the form, which leads to corrupting the data if the form is submitted with that field.

What do you think? Is this approach OK? Should I continue with this for other fields types?