### PR TITLE
Fix "search with a filter with arguments" spec

### DIFF
--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -86,24 +86,17 @@ feature "Search" do
   end
 
   scenario "admin searches with a filter with arguments", :js do
-    kind_match = create(:customer, kind: "vip", email: "vip@kind.com")
-    standard_match = create(:customer, kind: "standard", email: "me@kind.com")
-    no_match = create(:customer, kind: "vip", email: "standard@kind.com")
+    kind_match = create(:customer, kind: "vip", email: "standard@kind.com")
+    total_mismatch = create(:customer, kind: "standard", email: "me@kind.com")
+    kind_mismatch = create(:customer, kind: "standard", email: "vip@kind.com")
 
     visit admin_customers_path
-    fill_in :search, with: "kind:standard"
-    submit_search
-
-    expect(page).to have_content(standard_match.email)
-    expect(page).not_to have_content(kind_match.email)
-    expect(page).not_to have_content(no_match.email)
-
-    clear_search
     fill_in :search, with: "kind:vip"
     submit_search
 
-    expect(page).not_to have_content(standard_match.email)
     expect(page).to have_content(kind_match.email)
+    expect(page).not_to have_content(total_mismatch.email)
+    expect(page).not_to have_content(kind_mismatch.email)
   end
 
   scenario "admin searches with an a term similiar to a filter", :js do


### PR DESCRIPTION
Hi. This PR will solve the failing flakey test listed in https://github.com/thoughtbot/administrate/issues/2523. While debugging the issue I found a few things. 

The flake would happen when the second search of `"kind:vip"` was not applied to the url. I was able to run the test in headed chrome and see the failure happen. The url param was never set and was therefore blank. Adding a `sleep(0.1)` after the `clear_search` seemed to work as one pathway. Capybara

I went down the path of modifying the existing test to pass with a single param by the suggestions of a few at the RailsConf hackathon. Happy to add an additional scenario testing `"kind:standard"` if that would be preferred.

Thanks!