### PR TITLE
Copy the index_header partial when generating index views to customize

### DIFF
--- a/lib/generators/administrate/views/index_generator.rb
+++ b/lib/generators/administrate/views/index_generator.rb
@@ -9,6 +9,7 @@ module Administrate
         def copy_template
           copy_resource_template("index")
           copy_resource_template("_collection")
+          copy_resource_template("_index_header")
         end
       end
     end

--- a/spec/generators/views/index_generator_spec.rb
+++ b/spec/generators/views/index_generator_spec.rb
@@ -21,6 +21,16 @@ describe Administrate::Generators::Views::IndexGenerator, :generator do
 
       expect(contents).to eq(expected_contents)
     end
+
+    it "copies the index_header partial into the `admin/application` namespace" do
+      expected_contents = contents_for_application_template("_index_header")
+      generated_file = file("app/views/admin/application/_index_header.html.erb")
+
+      run_generator []
+      contents = File.read(generated_file)
+
+      expect(contents).to eq(expected_contents)
+    end
   end
 
   describe "administrate:views:index resource" do
@@ -41,6 +51,15 @@ describe Administrate::Generators::Views::IndexGenerator, :generator do
 
       expect(contents).to eq(expected_contents)
     end
+
+    it "copies the index_header partial into the `admin/resource` namespace" do
+      expected_contents = contents_for_application_template("_index_header")
+
+      run_generator ["users"]
+      contents = File.read(file("app/views/admin/users/_index_header.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
   end
 
   describe "administrate:views:index resource --namespace=<namespace>" do
@@ -58,6 +77,15 @@ describe Administrate::Generators::Views::IndexGenerator, :generator do
 
       run_generator ["users", "--namespace", "console"]
       contents = File.read(file("app/views/console/users/_collection.html.erb"))
+
+      expect(contents).to eq(expected_contents)
+    end
+
+    it "copies the index_header partial into the `namespace/resource` namespace" do
+      expected_contents = contents_for_application_template("_index_header")
+
+      run_generator ["users", "--namespace", "console"]
+      contents = File.read(file("app/views/console/users/_index_header.html.erb"))
 
       expect(contents).to eq(expected_contents)
     end


### PR DESCRIPTION
When customizing the index page of a resource, currently
the `index_header` partial is not copied for the user to
customize. The `index_header` partial contains the search
bar and the New resource button, either of which may need
to be customized. Currently this file must be manually 
created if someone wishes to edit it. 

This change adds the `index_header` file to the list of generated
`index` files.