### PR TITLE
Consistent translation for BelongsTo Fields across pages

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -17,7 +17,7 @@ that displays all possible records to associate with.
 %>
 
 <div class="field-unit__label">
-  <%= f.label field.permitted_attribute %>
+  <%= f.label field.attribute, for: "#{f.object_name}_#{field.permitted_attribute}" %>
 </div>
 <div class="field-unit__field">
   <%= f.select(field.permitted_attribute,

--- a/spec/features/orders_form_spec.rb
+++ b/spec/features/orders_form_spec.rb
@@ -28,6 +28,26 @@ describe "order form" do
       expected = order.customer.id.to_s
       expect(find_field("Customer").value).to eq expected
     end
+
+    it "displays translated label when translation for the attribute is available" do
+      order = create(:order)
+      custom_attribute_name = "Client"
+      translations = {
+        activerecord: {
+          attributes: {
+            order: {
+              customer: custom_attribute_name
+            }
+          }
+        }
+      }
+
+      with_translations(:en, translations) do
+        visit edit_admin_order_path(order)
+
+        expect(page).to have_css("label", text: custom_attribute_name)
+      end
+    end
   end
 
   describe "has_many relationships" do
@@ -89,6 +109,26 @@ describe "order form" do
         visit edit_admin_order_path(order)
 
         expect(page).to have_css("label", text: custom_label)
+      end
+    end
+
+    it "displays translated label when translation for the attribute is available" do
+      order = create(:order)
+      custom_attribute_name = "Lines"
+      translations = {
+        activerecord: {
+          attributes: {
+            order: {
+              line_items: custom_attribute_name
+            }
+          }
+        }
+      }
+
+      with_translations(:en, translations) do
+        visit edit_admin_order_path(order)
+
+        expect(page).to have_css("label", text: custom_attribute_name)
       end
     end
 


### PR DESCRIPTION
This PR addresses an inconsistency in the display of translated labels for `BelongsTo` fields across different pages in the application.

Currently, if a model (e.g., `Customer`) has a translation (e.g., `Client`), the translated label is correctly displayed on the `Show` page. However, on the `Edit` and `New` pages, the original label (e.g., `Customer`) is displayed instead of the translated one.

This PR ensures that the translated label for `BelongsTo` fields is consistently displayed across all pages. Specifically, it modifies the `belongs_to/_form` partial to display the translated label (if available) instead of the original one.

This change enhances the user experience by providing consistent and localized labels across the application.