### PR TITLE
Documentation says Field::URL accepts option for truncate but code is different

### DIFF
--- a/app/views/fields/url/_index.html.erb
+++ b/app/views/fields/url/_index.html.erb
@@ -16,5 +16,5 @@ By default, the value is rendered as an `a` element.
 %>
 
 <%= content_tag :a, href: field.data, **field.html_options do %>
-  <%= field.data %>
+  <%= field.truncate %>
 <% end %>

--- a/spec/administrate/views/fields/url/_index_spec.rb
+++ b/spec/administrate/views/fields/url/_index_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 describe "fields/url/_index", type: :view do
   let(:product) do
-    build(:product, image_url: "https://thoughtbot.com/image.jpg")
+    build(:product, image_url: "https://thoughtbot.com/image-but-extremely-long-and-should-be-truncated.jpg")
   end
 
   it "renders url" do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
+      truncate: product.image_url[0..50],
       html_options: {}
     )
 
@@ -19,7 +20,7 @@ describe "fields/url/_index", type: :view do
 
     expect(rendered).to have_css(
       %(a[href="#{product.image_url}"]),
-      text: product.image_url
+      text: product.image_url[0..50]
     )
   end
 
@@ -27,6 +28,7 @@ describe "fields/url/_index", type: :view do
     url = instance_double(
       "Administrate::Field::Url",
       data: product.image_url,
+      truncate: product.image_url,
       html_options: {referrerpolicy: "no-referrer"}
     )
 


### PR DESCRIPTION
Documentation at https://administrate-demo.herokuapp.com/customizing_dashboards 
Code was not calling truncate.
With current change truncate is called.

This is a clean PR along with a spec. Original PR is at 
https://github.com/thoughtbot/administrate/pull/2544
but it was mostly to get some feedback.