### PR TITLE
Fixes problem in table controller

### DIFF
--- a/app/assets/javascripts/administrate/controllers/table_controller.js
+++ b/app/assets/javascripts/administrate/controllers/table_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
         event.keyCode == keycodes.space ||
         event.keyCode == keycodes.enter) {
 
-      if (event.target.href) {
+      if (event.target.closest("[href]")) {
         return;
       }
 


### PR DESCRIPTION
If there was any tag inside the link to edit or delete like a strong tag or an icon tag, the link would not take you to the correct page.