### PR TITLE
Add diff-check to catch missing Appraisal runs

### DIFF
--- a/.github/workflows/diff-check.yml
+++ b/.github/workflows/diff-check.yml
@@ -1,0 +1,16 @@
+---
+name: diff-check
+on: [push]
+
+jobs:
+  appraisal:
+    runs-on: ubuntu-latest
+    env:
+      DIFF_CHECK_APPRAISAL: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+      - run: bundle install
+      - uses: nickcharlton/diff-check@main
+        with:
+          command: bundle exec appraisal

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "3.2.2" unless ENV["CI"]
+ruby "3.2.2" unless ENV["CI"] && !ENV["DIFF_CHECK_APPRAISAL"]
 
 gemspec
 


### PR DESCRIPTION
If we forget to run `bundle exec appraisal`, which is not uncommon, it means we miss when the appraisal files change. This should catch it and fail the build, reporting back that they changed and hinting at what should be done.

https://github.com/nickcharlton/diff-check
https://nickcharlton.net/posts/diff-check-github-action