### PR TITLE
Add sorting_column to Field

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -141,16 +141,18 @@ module Administrate
       @order ||= Administrate::Order.new(
         sorting_attribute,
         sorting_direction,
-        association_attribute: order_by_field(
+        sorting_column: sorting_column(
           dashboard_attribute(sorting_attribute)
         )
       )
     end
 
-    def order_by_field(dashboard)
-      return unless dashboard.try(:options)
+    def sorting_column(dashboard_attribute)
+      return unless dashboard_attribute.try(:options)
 
-      dashboard.options.fetch(:order, nil)
+      dashboard_attribute.options.fetch(:sorting_column) {
+        dashboard_attribute.options.fetch(:order, nil)
+      }
     end
 
     def dashboard_attribute(attribute)

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -23,25 +23,35 @@ to display a collection of resources in an HTML table.
     <tr>
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
         <th class="cell-label
-        cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
-        cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
-        scope="col"
-        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
-          collection_presenter.order_params_for(attr_name, key: collection_field_name)
-        )) do %>
-        <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: resource_class.human_attribute_name(attr_name).titleize,
-        ) %>
-            <% if collection_presenter.ordered_by?(attr_name) %>
-              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
-                <svg aria-hidden="true">
-                  <use xlink:href="#icon-up-caret" />
-                </svg>
-              </span>
+          cell-label--<%= attr_type.html_class %>
+          cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+          cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
+          scope="col"
+          <% if attr_type.sortable? %>
+            aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>"
+          <% end %>
+        >
+          <% if attr_type.sortable? %>
+            <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+              collection_presenter.order_params_for(attr_name, key: collection_field_name)
+            )) do %>
+              <%= t(
+                "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+                default: resource_class.human_attribute_name(attr_name).titleize,
+              ) %>
+              <% if collection_presenter.ordered_by?(attr_name) %>
+                <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                  <svg aria-hidden="true">
+                    <use xlink:href="#icon-up-caret" />
+                  </svg>
+                </span>
+              <% end %>
             <% end %>
+          <% else %>
+            <%= t(
+              "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+              default: resource_class.human_attribute_name(attr_name).titleize,
+            ) %>
           <% end %>
         </th>
       <% end %>

--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -106,6 +106,13 @@ For example:
 with this, you will be able to search through the column `name` from the
 association `belongs_to :country`, from your model.
 
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column of the associated model to be used for sorting in the table views and dropdown menu.  
+If `sorting_column` is omitted and `order` is specified, the value of `order` will be used.  
+If neither is specified, sorting will be done using the foreign key.  
+
 `:class_name` - Specifies the name of the associated class.
 
 `:primary_key` (deprecated) - Specifies the association's primary_key.
@@ -123,6 +130,14 @@ set this to `0` or `false`. Default is `5`.
 `:sort_by` - What to sort the association by in the show view.
 
 `:direction` - What direction the sort should be in, `:asc` (default) or `:desc`.
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column of the associated model to be used for sorting in the dropdown menu.  
+If `sorting_column` is omitted and `sort_by` is specified, the value of `sort_by` will be used.  
+If neither is specified, sorting will be done using the foreign key.  
+For `HasMany` associations, sorting is based on the count, so this option is not referenced in the table views.  
 
 `:class_name` - Specifies the name of the associated class.
 
@@ -154,6 +169,13 @@ For example:
 with this, you will be able to search through the column `name` from the
 association `has_one :city`, from your model.
 
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column of the associated model to be used for sorting in the table views and dropdown menu.  
+If `sorting_column` is omitted and `order` is specified, the value of `order` will be used.  
+If neither is specified, sorting will be done using the foreign key.  
+
 `:class_name` - Specifies the name of the associated class.
 
 **Field::Number**
@@ -161,6 +183,13 @@ association `has_one :city`, from your model.
 `:searchable` - Specify if the attribute should be considered when searching.
 Note that currently number fields are searched like text, which may yield
 more results than expected. Default is `false`.
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
 
 `:decimals` - Set the number of decimals to display. Defaults to `0`.
 
@@ -210,7 +239,17 @@ Default is `[]`.
 `:order` - What to sort the association by in the form select.
 Default is `nil`.
 
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
 **Field::DateTime**
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
 
 `:format` - Specify what format, using `strftime` you would like `DateTime`
 objects to display as.
@@ -219,6 +258,13 @@ objects to display as.
 in.
 
 **Field::Date**
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
 
 `:format` - Specify what format, using `strftime` you would like `Date`
 objects to display as.
@@ -249,12 +295,26 @@ If no collection is provided and no enum can be detected, the list of options wi
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `true`.
 
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
+
 `:include_blank` - Similar to [the option of the same name accepted by Rails helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html). If provided, a "blank" option will be added first to the list of options, with the value of `include_blank` as label.
 
 **Field::String**
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `true`.
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
 
 `:truncate` - Set the number of characters to display in the index view.
 Defaults to `50`.
@@ -263,6 +323,13 @@ Defaults to `50`.
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `false`.
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
 
 `:truncate` - Set the number of characters to display in the index view.
 Defaults to `50`.
@@ -275,6 +342,13 @@ Example: `.with_options(input_options: { rows: 20 })`
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `true`.
 
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `true`.  
+
+`:sorting_column` - Specifies the column to be used for sorting in the table view.  
+By default, the column itself is used, but when used as a virtual column,  
+a custom sorting column can be specified.  
+
 `:truncate` - Set the number of characters to display in the index view.
 Defaults to `50`.
 
@@ -285,6 +359,9 @@ Defaults is `{}`.
 
 `:searchable` - Specify if the attribute should be considered when searching.
 Default is `false`.
+
+`:sortable` - Specifies if sorting should be enabled in the table views.  
+Default is `false`.  
 
 `:truncate` - Set the number of characters to display in the views.
 Defaults to `50`.

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -24,6 +24,10 @@ module Administrate
         false
       end
 
+      def self.sortable?
+        true
+      end
+
       def self.field_type
         to_s.split("::").last.underscore
       end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -56,6 +56,10 @@ module Administrate
         end
       end
 
+      def sortable?
+        options.fetch(:sortable, deferred_class.sortable?)
+      end
+
       def permitted_attribute(attr, opts = {})
         if options.key?(:foreign_key)
           Administrate.warn_of_deprecated_option(:foreign_key)

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -82,12 +82,21 @@ module Administrate
       def order_from_params(params)
         Administrate::Order.new(
           params.fetch(:order, sort_by),
-          params.fetch(:direction, direction)
+          params.fetch(:direction, direction),
+          sorting_column: sorting_column(
+            associated_dashboard_attribute(params.fetch(:order, sort_by))
+          )
         )
       end
 
       def order
-        @order ||= Administrate::Order.new(sort_by, direction)
+        @order ||= Administrate::Order.new(
+          sort_by,
+          direction,
+          sorting_column: sorting_column(
+            associated_dashboard_attribute(sort_by)
+          )
+        )
       end
 
       private
@@ -107,6 +116,16 @@ module Administrate
 
       def display_candidate_resource(resource)
         associated_dashboard.display_resource(resource)
+      end
+
+      def sorting_column(dashboard_attribute)
+        return unless dashboard_attribute.try(:options)
+
+        dashboard_attribute.options.fetch(:sorting_column, nil)
+      end
+
+      def associated_dashboard_attribute(attribute)
+        associated_dashboard.attribute_types[attribute.to_sym] if attribute
       end
 
       def sort_by

--- a/lib/administrate/field/password.rb
+++ b/lib/administrate/field/password.rb
@@ -7,6 +7,10 @@ module Administrate
         false
       end
 
+      def self.sortable?
+        false
+      end
+
       def truncate
         data.to_s.gsub(/./, character)[0...truncation_length]
       end

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -20,7 +20,7 @@ describe CustomerDashboard do
       expect(fields[:name]).to eq(Field::String)
       expect(fields[:email]).to eq(Field::Email)
       expect(fields[:lifetime_value])
-        .to eq(Field::Number.with_options(prefix: "$", decimals: 2))
+        .to eq(Field::Number.with_options(prefix: "$", decimals: 2, sortable: false))
     end
   end
 

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -6,7 +6,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     email: Field::Email,
     email_subscriber: Field::Boolean,
-    lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2),
+    lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2, sortable: false),
     name: Field::String,
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
     log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),

--- a/spec/example_app/app/dashboards/line_item_dashboard.rb
+++ b/spec/example_app/app/dashboards/line_item_dashboard.rb
@@ -12,7 +12,7 @@ class LineItemDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     order: Field::BelongsTo,
-    product: Field::BelongsTo,
+    product: Field::BelongsTo.with_options(sorting_column: :name),
     quantity: Field::Number,
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     unit_price: Field::Number.with_options(prefix: "$", decimals: 2)

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -20,13 +20,14 @@ class OrderDashboard < Administrate::BaseDashboard
           r.address_state,
           r.address_zip
         ].compact.join("\n")
-      }
+      },
+      sorting_column: :address_zip
     ),
     customer: Field::BelongsTo.with_options(order: "name"),
     line_items: Field::HasMany.with_options(
       collection_attributes: %i[product quantity unit_price total_price]
     ),
-    total_price: Field::Number.with_options(prefix: "$", decimals: 2),
+    total_price: Field::Number.with_options(prefix: "$", decimals: 2, sortable: false),
     shipped_at: Field::DateTime,
     payments: Field::HasMany
   }

--- a/spec/features/sort_spec.rb
+++ b/spec/features/sort_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+feature "Sort" do
+  describe "sortable" do
+    context "when the field is sortable" do
+      it "is a link to sort by that field" do
+        visit admin_customers_path
+        expect(page).to have_link("Name")
+      end
+    end
+
+    context "when the field is NOT sortable" do
+      it "is not a link" do
+        visit admin_customers_path
+        expect(page).not_to have_link("Password")
+      end
+    end
+  end
+
+  scenario "admin sorts customers by name" do
+    dan = create(:customer, name: "Dan Croak")
+    bob = create(:customer, name: "Bob")
+    alice = create(:customer, name: "Alice")
+
+    visit admin_customers_path
+    click_on "Name"
+
+    expect(page).to have_css("table tr:nth-child(1)", text: alice.name)
+    expect(page).to have_css("table tr:nth-child(2)", text: bob.name)
+    expect(page).to have_css("table tr:nth-child(3)", text: dan.name)
+  end
+
+  scenario "admin sorts orders by full_address (virtual field)" do
+    create(:order, address_zip: "651", address_state: "UT")
+    create(:order, address_zip: "7", address_state: "WV")
+    create(:order, address_zip: "59543-0366", address_state: "NJ")
+
+    visit admin_orders_path
+    click_on "Full Address"
+
+    expect(page).to have_css("table tr:nth-child(1)", text: "NJ 59543-0366")
+    expect(page).to have_css("table tr:nth-child(2)", text: "UT 651")
+    expect(page).to have_css("table tr:nth-child(3)", text: "WV 7")
+  end
+
+  scenario "admin sorts customer's orders by full_address (virtual field)" do
+    customer = create(:customer, name: "Alice")
+    customer.orders << create(:order, address_zip: "651", address_state: "UT")
+    customer.orders << create(:order, address_zip: "7", address_state: "WV")
+    customer.orders << create(:order, address_zip: "59543-0366", address_state: "NJ")
+
+    visit admin_customer_path(customer)
+    click_on "Full Address"
+
+    within(table_for_attribute(:orders)) do
+      expect(page).to have_css("tr:nth-child(1)", text: "NJ 59543-0366")
+    end
+  end
+
+  scenario "admin sorts order's list_items by product name" do
+    product_1 = create(:product, name: "Monopoly 2")
+    product_2 = create(:product, name: "Monopoly 3")
+    product_3 = create(:product, name: "Monopoly 1")
+    customer = create(:customer)
+    order = create(:order, customer: customer)
+    order.line_items << create(:line_item, product: product_1)
+    order.line_items << create(:line_item, product: product_2)
+    order.line_items << create(:line_item, product: product_3)
+
+    visit admin_order_path(order)
+    click_on "Product"
+
+    within(table_for_attribute(:line_items)) do
+      expect(page).to have_css("tr:nth-child(1)", text: "Monopoly 1")
+      expect(page).to have_css("tr:nth-child(2)", text: "Monopoly 2")
+      expect(page).to have_css("tr:nth-child(3)", text: "Monopoly 3")
+    end
+  end
+
+  def table_for_attribute(attr_name)
+    find("table[aria-labelledby=#{attr_name}]")
+  end
+end

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -118,7 +118,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             :user,
             nil,
-            association_attribute: "name"
+            sorting_column: "name"
           )
           relation = relation_with_association(
             :belongs_to,
@@ -144,7 +144,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             :user,
             nil,
-            association_attribute: "invalid_column_name"
+            sorting_column: "invalid_column_name"
           )
           relation = relation_with_association(
             :belongs_to,
@@ -192,7 +192,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             :user,
             nil,
-            association_attribute: "name"
+            sorting_column: "name"
           )
           relation = relation_with_association(
             :has_one,
@@ -218,7 +218,7 @@ describe Administrate::Order do
           order = Administrate::Order.new(
             :user,
             nil,
-            association_attribute: "invalid_column_name"
+            sorting_column: "invalid_column_name"
           )
           relation = relation_with_association(
             :has_one,

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -98,6 +98,38 @@ describe Administrate::Field::Deferred do
     end
   end
 
+  describe "#sortable?" do
+    context "when given a `sortable` option" do
+      it "returns the value given" do
+        sortable_deferred = Administrate::Field::Deferred.new(
+          double(sortable?: false),
+          sortable: true
+        )
+        unsortable_deferred = Administrate::Field::Deferred.new(
+          double(sortable?: true),
+          sortable: false
+        )
+
+        expect(sortable_deferred.sortable?).to eq(true)
+        expect(unsortable_deferred.sortable?).to eq(false)
+      end
+    end
+
+    context "when not given a `sortable` option" do
+      it "falls back to the default of the deferred class" do
+        sortable_deferred = Administrate::Field::Deferred.new(
+          double(sortable?: true)
+        )
+        unsortable_deferred = Administrate::Field::Deferred.new(
+          double(sortable?: false)
+        )
+
+        expect(sortable_deferred.sortable?).to eq(true)
+        expect(unsortable_deferred.sortable?).to eq(false)
+      end
+    end
+  end
+
   describe "#==" do
     it "returns false for different deferred classes" do
       one = Administrate::Field::Deferred.new(String)


### PR DESCRIPTION
I've split the Sortable from #2658.

# Usage

- It is possible to use a name as attribute_name that doesn't exist in the DB column but is defined in the model.

![image](https://github.com/user-attachments/assets/463c5525-2c7a-476c-b17a-f48a9a2888c6)

```ruby

class OrderDashboard < Administrate::BaseDashboard
  ATTRIBUTE_TYPES = {
    full_address: Field::String.with_options(
      getter: ->(field) {
        r = field.resource
        [
          r.address_line_one,
          r.address_line_two,
          r.address_city,
          r.address_state,
          r.address_zip
        ].compact.join("\n")
      },
      sorting_column: :address_zip
    ),
```

- Attributes that cannot be sorted will not have a sort link in the table header.

```ruby
module Administrate
  module Field
    class Password < Field::Base
      def self.sortable?
        false
      end
```

```ruby
class CustomerDashboard < Administrate::BaseDashboard
  ATTRIBUTE_TYPES = {
    # Since the aggregation is done on the Ruby side and sorting is not possible, it is set to not be sortable.
    lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2, sortable: false),
```
