### PR TITLE
Allow configuring text field input options

### DIFF
--- a/app/views/fields/text/_form.html.erb
+++ b/app/views/fields/text/_form.html.erb
@@ -18,5 +18,5 @@ This partial renders a textarea element for a text attribute.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_area field.attribute %>
+  <%= f.text_area field.attribute, field.options.fetch(:input_options, {}) %>
 </div>

--- a/spec/administrate/views/fields/text/_form_spec.rb
+++ b/spec/administrate/views/fields/text/_form_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require "administrate/field/text"
+
+describe "fields/text/_form", type: :view do
+  it "allows configuring input options" do
+    textarea = instance_double(
+      "Administrate::Field::Text",
+      attribute: :name,
+      data: nil,
+      options: { input_options: { rows: 50 } }
+    )
+
+    render_partial(textarea)
+
+    expect(rendered).to have_css(%(textarea[rows=50]))
+  end
+
+  it "doesn't require input options" do
+    textarea = instance_double(
+      "Administrate::Field::Text",
+      attribute: :name,
+      data: nil,
+      options: {}
+    )
+
+    render_partial(textarea)
+
+    expect(rendered).to have_css(%(textarea))
+  end
+
+  def render_partial(field)
+    product = build(:product)
+
+    render(
+      partial: "fields/text/form",
+      locals: {field: field, f: form_builder(product)}
+    )
+  end
+
+  def form_builder(object)
+    ActionView::Helpers::FormBuilder.new(
+      object.model_name.singular,
+      object,
+      build_template,
+      {}
+    )
+  end
+
+  def build_template
+    Object.new.tap do |template|
+      template.extend ActionView::Helpers::FormHelper
+      template.extend ActionView::Helpers::FormOptionsHelper
+      template.extend ActionView::Helpers::FormTagHelper
+    end
+  end
+end


### PR DESCRIPTION
## What

Allows configuring the rendered `<textarea>` for `Field::Text` fields, e.g.:

```rb
ATTRIBUTE_TYPES = {
  body: Field::Text.with_options(input_options: { rows: 20 }),
}.freeze
```

Result in:

```html
<textarea rows="20" name="post[body]" id="post_body">...</textarea>
```

## Why

The main use case for this was being able to scale up text areas when needed, f.ex:
|Before|After|
|-|-|
|![Edit CoachingContent #3 - Moment Web2024-09-27 at 11 53 31@2x](https://github.com/user-attachments/assets/dde29d9c-d7f9-4033-bb2b-16b699e53680)|![Edit CoachingContent #3 - Moment Web2024-09-27 at 11 53 12@2x](https://github.com/user-attachments/assets/789eb428-2107-4501-91b0-96b20ef7d656)|

## How

This provides a generic `input_options` to access all the options provided by `text_area`, but if that feels like overkill, it could also be hardcoded to only support `rows`?

