### PR TITLE
Embed sources in CSS sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "esbuild app/assets/javascripts/administrate/application.js --bundle --sourcemap --outdir=app/assets/builds/administrate --public-path=/assets/administrate",
-    "build:css": "sass ./app/assets/stylesheets/administrate/application.scss:./app/assets/builds/administrate/application.css ./app/assets/stylesheets/administrate-internal/docs.scss:./app/assets/builds/administrate-internal/docs.css --source-map --load-path=node_modules",
+    "build:css": "sass ./app/assets/stylesheets/administrate/application.scss:./app/assets/builds/administrate/application.css ./app/assets/stylesheets/administrate-internal/docs.scss:./app/assets/builds/administrate-internal/docs.css --source-map --embed-sources --load-path=node_modules",
     "lint:css": "stylelint app/assets/stylesheets/administrate/**/*.scss"
   },
   "dependencies": {


### PR DESCRIPTION
* What were you trying to do?
Trying to debug UI issues with the new Administrate beta version (turns out they are resolved in `main`?).

* What did you end up with (logs, or, even better, example apps are great!)?
Whenever I open Firefox/Chrome dev tools, they try to load the SCSS source files from the Rails server, which fails, as expected, with 404.

* What versions are you running?
  - Rails 8.0.0.beta1
  - administrate 1.0.0.beta1

I suggest you add the `--embed-sources` switch to the `build:css` `yarn` incantation.

Tested locally:
![image](https://github.com/user-attachments/assets/6bc3ede5-065d-4be1-b414-d7f9a9cc0b15)
