### PR TITLE
Run diff-check on JS/CSS to catch updates

### DIFF
--- a/.github/workflows/diff-check.yml
+++ b/.github/workflows/diff-check.yml
@@ -14,3 +14,18 @@ jobs:
       - uses: nickcharlton/diff-check@main
         with:
           command: bundle exec appraisal
+
+  builds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JS
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - uses: nickcharlton/diff-check@main
+        with:
+          command: |
+            yarn build
+            yarn build:css


### PR DESCRIPTION
In #2673, we discussed catching changes in the `builds` directory as being quite annoying in development. This can happen when people contribute changes (and should probably also commit their build changes to make future development easier), plus also when dependencies change.

Catching this with `diff-check` should mean that we see this at the point of introduction, rather than later on.