### PR TITLE
Singularize object creation form resource name.

### DIFF
--- a/app/views/administrate/application/new.html.erb
+++ b/app/views/administrate/application/new.html.erb
@@ -18,7 +18,7 @@ to do the heavy lifting.
 <% content_for(:title) do %>
   <%= t(
     "administrate.actions.new_resource",
-    name: display_resource_name(page.resource_name).titleize
+    name: display_resource_name(page.resource_name, singular: true)
   ) %>
 <% end %>
 


### PR DESCRIPTION
Currently, the resource name on the object creation form is pluralized

This commit adds a `singular: true' parameter
to the display_resource_name method in the
object creation view to explicitly show the
resource name in singular form.

Before:

![318019918-cbd11936-a1dd-470a-b945-efcd0ba28d17](https://github.com/user-attachments/assets/0b4e89f5-4da4-4dc9-b3f9-0a5dc80aa121)

After:
<img width="765" alt="Screenshot 2024-10-15 at 16 14 45" src="https://github.com/user-attachments/assets/af7789a7-b6ff-4086-928e-74cfc16c7741">

issue #2561