### PR TITLE
Add docker compose for services

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,3 +2,9 @@
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 PORT=3000
+
+# for docker compose usage
+# PGUSER=postgres
+# PGPASSWORD=postgres
+# PGHOST=127.0.0.1
+# PGPORT=5432

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,14 @@ bin/dev
 This will start the application defined in `spec/example_app`.
 You can view the `example_app` in the browser by navigating to `/admin`.
 
+### Docker compose services
+
+If you want to use `docker compose` in order to start needed services (eg: postgres) you can run:
+
+```sh
+docker compose up
+```
+
 ## Repository Structure
 
 * The gem's source code lives in the `app` and `lib` subdirectories.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db:/var/lib/postgresql/data
+    ports:
+      - ${PGPORT}:5432
+volumes:
+  db:

--- a/spec/example_app/config/database.yml.sample
+++ b/spec/example_app/config/database.yml.sample
@@ -5,6 +5,10 @@ development: &default
   min_messages: warning
   pool: 2
   timeout: 5000
+  username: <%= ENV['PGUSER'] %>
+  password: <%= ENV['PGPASSWORD'] %>
+  host: <%= ENV['PGHOST'] %>
+  port: <%= ENV['PGPORT'] %>
 
 test:
   <<: *default


### PR DESCRIPTION
Forcing developers to use services on them local machine is imho a bad practice

this enable bot the usage of a local postgres or a docker one, for the peace of mind of everyone XD