### PR TITLE
Generate `fields/rich_text/form` with documentation

### DIFF
--- a/app/views/fields/rich_text/_form.html.erb
+++ b/app/views/fields/rich_text/_form.html.erb
@@ -1,3 +1,19 @@
+<%#
+# Rich Text Form Partial
+
+This partial renders a trix-editor element for ActionText::RichText attributes.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate trix-editor fields.
+- `field`:
+  An instance of [Administrate::Field::RichText][1].
+  A wrapper around the tmie attributes pulled from the model.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/RichText
+%>
+
 <div class="field-unit__label">
   <%= f.label field.attribute %>
 </div>

--- a/spec/administrate/views/fields/rich_text/_form_spec.rb
+++ b/spec/administrate/views/fields/rich_text/_form_spec.rb
@@ -17,37 +17,24 @@ describe "fields/rich_text/_form", type: :view do
       "ProductDashbard::ATTRIBUTE_TYPES",
       banner: Administrate::Field::RichText
     )
-    product = build(:product, name: nil)
+    product = build(:product, banner: "<div>Rich text</div>")
     banner = instance_double(
       "Administrate::Field::RichText",
       attribute: :banner,
-      data: nil
+      data: product.banner
     )
 
-    render(
-      partial: "fields/rich_text/form",
-      locals: {field: banner, f: form_builder(product)}
-    )
+    fields model: product do |f|
+      render(
+        partial: "fields/rich_text/form",
+        locals: {field: banner, f: f}
+      )
+    end
 
     expect(rendered).to have_field(
-      "product_banner_trix_input_product", type: "hidden"
-    )
-  end
-
-  def form_builder(object)
-    ActionView::Helpers::FormBuilder.new(
-      object.model_name.singular,
-      object,
-      build_template,
-      {}
-    )
-  end
-
-  def build_template
-    Object.new.tap do |template|
-      template.extend ActionView::Helpers::FormHelper
-      template.extend ActionView::Helpers::FormOptionsHelper
-      template.extend ActionView::Helpers::FormTagHelper
-    end
+      "trix_input_product", type: "hidden", with: product.banner.body.to_trix_html
+    ).and(have_element(
+      "trix-editor", input: "trix_input_product"
+    ))
   end
 end

--- a/spec/administrate/views/fields/select/_edit_spec.rb
+++ b/spec/administrate/views/fields/select/_edit_spec.rb
@@ -13,10 +13,12 @@ describe "fields/select/_form", type: :view do
       html_controller: "select"
     )
 
-    render(
-      partial: "fields/select/form",
-      locals: {field: select, f: form_builder(customer)}
-    )
+    fields model: customer do |f|
+      render(
+        partial: "fields/select/form",
+        locals: {field: select, f: f}
+      )
+    end
 
     expect(rendered).to have_css(
       %(select[name="customer[email_subscriber]"][data-controller~=select]
@@ -35,31 +37,16 @@ describe "fields/select/_form", type: :view do
       html_controller: "select"
     )
 
-    render(
-      partial: "fields/select/form",
-      locals: {field: select, f: form_builder(customer)}
-    )
+    fields model: customer do |f|
+      render(
+        partial: "fields/select/form",
+        locals: {field: select, f: f}
+      )
+    end
 
     expect(rendered).to have_css(
       %(select[name="customer[email_subscriber]"][data-controller~="select"] option[value=""]),
       text: "Unknown"
     )
-  end
-
-  def form_builder(object)
-    ActionView::Helpers::FormBuilder.new(
-      object.model_name.singular,
-      object,
-      build_template,
-      {}
-    )
-  end
-
-  def build_template
-    Object.new.tap do |template|
-      template.extend ActionView::Helpers::FormHelper
-      template.extend ActionView::Helpers::FormOptionsHelper
-      template.extend ActionView::Helpers::FormTagHelper
-    end
   end
 end

--- a/spec/administrate/views/fields/text/_form_spec.rb
+++ b/spec/administrate/views/fields/text/_form_spec.rb
@@ -31,26 +31,11 @@ RSpec.describe "fields/text/_form", type: :view do
   def render_partial(field)
     product = build(:product)
 
-    render(
-      partial: "fields/text/form",
-      locals: {field: field, f: form_builder(product)}
-    )
-  end
-
-  def form_builder(object)
-    ActionView::Helpers::FormBuilder.new(
-      object.model_name.singular,
-      object,
-      build_template,
-      {}
-    )
-  end
-
-  def build_template
-    Object.new.tap do |template|
-      template.extend ActionView::Helpers::FormHelper
-      template.extend ActionView::Helpers::FormOptionsHelper
-      template.extend ActionView::Helpers::FormTagHelper
+    fields model: product do |f|
+      render(
+        partial: "fields/text/form",
+        locals: {field: field, f: f}
+      )
     end
   end
 end

--- a/spec/administrate/views/fields/url/_form_spec.rb
+++ b/spec/administrate/views/fields/url/_form_spec.rb
@@ -10,28 +10,13 @@ describe "fields/url/_form", type: :view do
       data: nil
     )
 
-    render(
-      partial: "fields/url/form",
-      locals: {field: url, f: form_builder(product)}
-    )
+    fields model: product do |f|
+      render(
+        partial: "fields/url/form",
+        locals: {field: url, f: f}
+      )
+    end
 
     expect(rendered).to have_css(%(input[type="url"][name="product[image_url]"]))
-  end
-
-  def form_builder(object)
-    ActionView::Helpers::FormBuilder.new(
-      object.model_name.singular,
-      object,
-      build_template,
-      {}
-    )
-  end
-
-  def build_template
-    Object.new.tap do |template|
-      template.extend ActionView::Helpers::FormHelper
-      template.extend ActionView::Helpers::FormOptionsHelper
-      template.extend ActionView::Helpers::FormTagHelper
-    end
   end
 end


### PR DESCRIPTION
All form partials include guiding documentation atop the template files. Those comments are valuable additions, since view template overrides installed via generators will include them.

This commit updates the new `fields/rich_text/form` partial to include documentation.

On the test side, this commit also includes changes to view specs to generate Form Builders using *real* Action View form builders and view helpers.

Removing code that mimicked that builder instantiation uncovered an error in a how the Rich Text form partial coverage expected the `<trix-editor>` element's corresponding `<input type="hidden">` element generated its `[id]`.