### PR TITLE
Reliable way to check a path with Capybara

### DIFF
--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -43,14 +43,14 @@ describe "customer index page" do
     visit admin_customers_path
     click_on "Edit"
 
-    expect(current_path).to eq(edit_admin_customer_path(customer))
+    expect(page).to have_current_path(edit_admin_customer_path(customer))
   end
 
   it "links to the new page" do
     visit admin_customers_path
     click_on("New customer")
 
-    expect(current_path).to eq(new_admin_customer_path)
+    expect(page).to have_current_path(new_admin_customer_path)
   end
 
   it "displays translated labels" do

--- a/spec/features/log_entries_index_spec.rb
+++ b/spec/features/log_entries_index_spec.rb
@@ -38,14 +38,14 @@ feature "log entries index page" do
     visit admin_log_entries_path
     click_on t("administrate.actions.edit")
 
-    expect(current_path).to eq(edit_admin_log_entry_path(log_entry))
+    expect(page).to have_current_path(edit_admin_log_entry_path(log_entry))
   end
 
   scenario "user clicks through to the new page" do
     visit admin_log_entries_path
     click_on("New log entry")
 
-    expect(current_path).to eq(new_admin_log_entry_path)
+    expect(page).to have_current_path(new_admin_log_entry_path)
   end
 
   scenario "user deletes record", js: true do

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -35,14 +35,14 @@ feature "order index page" do
     visit admin_orders_path
     click_on t("administrate.actions.edit")
 
-    expect(current_path).to eq(edit_admin_order_path(order))
+    expect(page).to have_current_path(edit_admin_order_path(order))
   end
 
   scenario "user clicks through to the new page" do
     visit admin_orders_path
     click_on("New order")
 
-    expect(current_path).to eq(new_admin_order_path)
+    expect(page).to have_current_path(new_admin_order_path)
   end
 
   scenario "user deletes record", js: true do

--- a/spec/features/products_index_spec.rb
+++ b/spec/features/products_index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "product index page" do
 
     expect(page).to have_content(product.name)
     expect(page).to have_content(product.description)
-    expect(current_path).to eq(admin_product_path(product))
+    expect(page).to have_current_path(admin_product_path(product))
   end
 
   it "links to the edit page" do
@@ -28,14 +28,14 @@ RSpec.describe "product index page" do
     visit admin_products_path
     click_on "Edit"
 
-    expect(current_path).to eq(edit_admin_product_path(product))
+    expect(page).to have_current_path(edit_admin_product_path(product))
   end
 
   it "links to the new page" do
     visit admin_products_path
     click_on("New product")
 
-    expect(current_path).to eq(new_admin_product_path)
+    expect(page).to have_current_path(new_admin_product_path)
   end
 
   scenario "product sorted by has_one association" do


### PR DESCRIPTION
I just saw a random failure at `./spec/features/products_index_spec.rb:22`. It's a JS-enabled example with an expectation on `current_path`. This is one of those cases where the previous action (in this case clicking on a link) does not necessarily happen immediately, requiring a slight wait, and therefore failing randomly.

I have changed all instances of this type of expectation to use `have_current_path`, which is provided by Capybara and applies its [waiting behaviour](https://github.com/teamcapybara/capybara?tab=readme-ov-file#asynchronous-javascript-ajax-and-friends) where appropriate.

Note that not all cases actually need it, as this is only a problem in JS-enabled examples, but it's good to be consistent so I changed all.