### PR TITLE
Undeprecate :class_name

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -106,11 +106,11 @@ For example:
 with this, you will be able to search through the column `name` from the
 association `belongs_to :country`, from your model.
 
+`:class_name` - Specifies the name of the associated class.
+
 `:primary_key` (deprecated) - Specifies the association's primary_key.
 
 `:foreign_key` (deprecated) - Specifies the name of the foreign key directly.
-
-`:class_name` (deprecated) - Specifies the name of the associated class.
 
 **Field::HasMany**
 
@@ -124,11 +124,11 @@ set this to `0` or `false`. Default is `5`.
 
 `:direction` - What direction the sort should be in, `:asc` (default) or `:desc`.
 
+`:class_name` - Specifies the name of the associated class.
+
 `:primary_key` (deprecated) - Specifies object's primary_key.
 
 `:foreign_key` (deprecated) - Specifies the name of the foreign key directly.
-
-`:class_name` (deprecated) - Specifies the name of the associated class.
 
 **Field::HasOne**
 
@@ -154,7 +154,7 @@ For example:
 with this, you will be able to search through the column `name` from the
 association `has_one :city`, from your model.
 
-`:class_name` (deprecated) - Specifies the name of the associated class.
+`:class_name` - Specifies the name of the associated class.
 
 **Field::Number**
 

--- a/docs/guides/scoping_has_many_relations.md
+++ b/docs/guides/scoping_has_many_relations.md
@@ -18,10 +18,10 @@ Since ActiveRecord infers the class name from the first argument, the new `has_m
 
 ## Add new relationship to dashboard
 
-Your new scoped relation can be used in the dashboard just like the original `HasMany`. Notice the new field needs to specifiy the class name as an option like you did in the model.
+Your new scoped relation can be used in the dashboard just like the original `HasMany`.
 
 ```ruby
 ATTRIBUTE_TYPES = {
   orders: Field::HasMany,
-  processed_orders: Field::HasMany.with_options(class_name: 'Order')
+  processed_orders: Field::HasMany
 ```

--- a/lib/administrate/field/associative.rb
+++ b/lib/administrate/field/associative.rb
@@ -37,7 +37,7 @@ module Administrate
 
       def associated_class_name
         if option_given?(:class_name)
-          deprecated_option(:class_name)
+          options.fetch(:class_name)
         else
           self.class.associated_class_name(
             resource.class,

--- a/spec/lib/fields/belongs_to_spec.rb
+++ b/spec/lib/fields/belongs_to_spec.rb
@@ -133,22 +133,6 @@ describe Administrate::Field::BelongsTo do
         /^Line Item \#\d\d\d\d$/
       )
     end
-
-    it "triggers a deprecation warning" do
-      line_item = create(:line_item)
-      field_class = Administrate::Field::BelongsTo.with_options(
-        class_name: "Customer"
-      )
-      field = field_class.new(
-        :product,
-        line_item.product,
-        :show,
-        resource: line_item
-      )
-      field.associated_class
-      expect(Administrate.deprecator).to have_received(:warn)
-        .with(/:class_name is deprecated/)
-    end
   end
 
   describe ":include_blank option" do

--- a/spec/lib/fields/has_many_spec.rb
+++ b/spec/lib/fields/has_many_spec.rb
@@ -64,16 +64,6 @@ describe Administrate::Field::HasMany do
       expect(dashboard_double).to have_received(:collection_attributes)
       expect(attributes).to eq([])
     end
-
-    it "triggers a deprecation warning" do
-      association = Administrate::Field::HasMany
-        .with_options(class_name: "Foo")
-      field = association.new(:customers, [], :show)
-      field.associated_collection
-
-      expect(Administrate.deprecator).to have_received(:warn)
-        .with(/:class_name is deprecated/)
-    end
   end
 
   describe "primary_key option" do


### PR DESCRIPTION
If we are going towards v1.0.0, perhaps we should undeprecate `:class_name` :smile:

At https://github.com/thoughtbot/administrate/issues/2384 and https://github.com/thoughtbot/administrate/issues/2546, we have seen legitimate use cases for this option, so perhaps it should be back on the menu after all.

I'm not clear yet about the other deprecations that came with it though: `:foreign_key` and `:primary_key`. I think those might be ok? Has anyone come across use cases for them? Perhaps @littleforest?

While updating the documentation, I realised there's an example that uses `:class_name` and doesn't need it, so I have addressed it.