### PR TITLE
Add feature-test coverage for Rich Text Field

### DIFF
--- a/spec/support/features/action_text.rb
+++ b/spec/support/features/action_text.rb
@@ -1,0 +1,23 @@
+module Features
+  if Rails.version >= "6.1"
+    require "action_text/system_test_helper"
+
+    include ActionText::SystemTestHelper
+  else
+    def fill_in_rich_text_area(locator = nil, with:)
+      find(:rich_text_area, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
+    end
+
+    Capybara.add_selector :rich_text_area do
+      xpath do |label|
+        trix_editor = XPath.descendant(:"trix-editor")
+
+        if label.nil?
+          trix_editor
+        else
+          trix_editor.where XPath.attr(:"aria-label").equals(label)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to [#2411][]

Add Capybara-driven feature test coverage for filling in and rendering the contents of a `<trix-editor>` element.

[#2411]: https://github.com/thoughtbot/administrate/pull/2411