### PR TITLE
Fix BUNDLE_GEMFILE path for demo deployments

### DIFF
--- a/spec/example_app/config/boot.rb
+++ b/spec/example_app/config/boot.rb
@@ -1,3 +1,3 @@
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.


### PR DESCRIPTION
In #2705, we upgraded Rails but didn't notice that we'd changed the path on where `BUNDLE_GEMFILE` is overridden in `config/boot.rb`.

This was causing deployments to fail for the prerelease (which had also been broken for some time for other reasons), and blocking us releasing v1.

Fixes #2715.