### PR TITLE
Remove pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,6 @@ GEM
       xpath (~> 3.2)
     childprocess (5.1.0)
       logger (~> 1.5)
-    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -207,7 +206,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    method_source (1.1.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
@@ -230,9 +228,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    pry (0.15.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     psych (5.2.2)
       date
       stringio
@@ -416,7 +411,6 @@ DEPENDENCIES
   kaminari-i18n
   launchy
   pg
-  pry
   pundit
   rack-timeout
   redcarpet

--- a/gemfiles/pundit21.gemfile
+++ b/gemfiles/pundit21.gemfile
@@ -27,7 +27,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "i18n-tasks", "1.0.14"
-  gem "pry"
   gem "standard"
   gem "yard"
 end


### PR DESCRIPTION
For years, `pry` has been incredibly useful for debugging. But it's another dependency and `irb` has gotten so much more powerful and bought over so many of `pry`'s great features that it's a good enough default now.