### PR TITLE
Pin psych below 4 for Rails 6.0 support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,4 +1,5 @@
 appraise "rails60" do
+  gem "psych", "< 4"
   gem "rails", "~> 6.0.3.4"
   gem "sprockets-rails", "~> 3.4"
 end

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -19,6 +19,7 @@ gem "unicorn"
 gem "cssbundling-rails", "~> 1.4"
 gem "jsbundling-rails", "~> 1.3"
 gem "sprockets-rails", "~> 3.4"
+gem "psych", "< 4"
 gem "rails", "~> 6.0.3.4"
 
 group :development, :test do


### PR DESCRIPTION
See: #2736

https://stackoverflow.com/questions/74725359/ruby-on-rails-legacy-application-update-generates-gem-psych-alias-error-psychb