### PR TITLE
Fix Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+web: bundle exec puma -C config/puma.rb
 js: yarn build --watch
 css: yarn build:css --watch


### PR DESCRIPTION
In #2744, we switched from Unicorn to puma. While Procfile got updated, Procfile.dev did not.