### PR TITLE
Fix deprecation warning regarding to_time

### DIFF
--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -28,6 +28,7 @@ module AdministratePrototype
 
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.active_record.time_zone_aware_types = %i[datetime time]
+    config.active_support.to_time_preserves_timezone = :zone
 
     # Opt-out of FLoC: https://amifloced.org/
     config.action_dispatch


### PR DESCRIPTION
We had a deprecation warning: to_time will always preserve the receive timezone rather than system local time in Rails 8.1 which gets fixed by setting "to_time_preserves_timezone" to "zone" in the application configuration.

Fixes #2747 