### PR TITLE
Re-introduce bundle install to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,6 +13,7 @@ if [ ! -e "$DB_CONFIG_PATH" ]; then
 fi
 
 gem install bundler --conservative
+bundle install
 bundle exec appraisal install
 yarn install
 


### PR DESCRIPTION
In #2748, we tidied up some parts of `bin/setup`, but went too far and also remove the `bundle install` command. Once we made a change to bundle, this then failed.

So add that back in.