### PR TITLE
Rephrase the Administrate pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,22 @@ A framework for creating flexible, powerful admin dashboards in Rails.
 
 ![administrate](https://user-images.githubusercontent.com/11917/72203824-ec10f980-3468-11ea-9ac1-51cd28ff88b7.png)
 
-## What Is Administrate?
+## What's Administrate?
 
-Administrate is a library for Rails apps
-that automatically generates admin dashboards.
-Administrate's admin dashboards give non-technical users clean interfaces
-that allow them to create, edit, search, and delete records
-for any model in the application.
-
-Administrate solves the same problem as [Rails Admin] and [ActiveAdmin],
-but aims to provide a better user experience for site admins,
-and to be easier for developers to customize.
+Administrate is a library for Rails that generates admin dashboards. These give
+users clean interfaces that allow them to create, edit, search, and delete
+records for any model in the application. Administrate aims to provide the best
+user experience, and doing as much work as possible for you, whilst also being
+flexible to customise.
 
 To accomplish these goals, Administrate follows a few guiding principles:
 
-- Stay as close to standard Rails as possible, keeping the
+* Stay as close to standard Rails as possible, keeping the
   Administrate-specific code as small as practical,
-- Support the simplest use cases, and let the user override defaults with
+* Support the simplest use cases, and let the user override defaults with
   standard tools such as plain Rails controllers and views,
-- Break up the library into core components and plugins,
-  so each component stays small and easy to maintain.
-
-[Rails Admin]: https://github.com/sferik/rails_admin
-[ActiveAdmin]: http://activeadmin.info/
+* Break up the library into core components and plugins, so each component
+  stays small and pleasant to maintain.
 
 ## Documentation
 

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -5,8 +5,8 @@ require "administrate/version"
 Gem::Specification.new do |s|
   s.name = "administrate"
   s.version = Administrate::VERSION
-  s.authors = ["Nick Charlton", "Grayson Wright"]
-  s.email = ["nick@nickcharlton.net", "grayson@thoughtbot.com"]
+  s.authors = ["Nick Charlton"]
+  s.email = ["nick@nickcharlton.net"]
   s.homepage = "https://administrate-demo.herokuapp.com/"
   s.summary = "A Rails engine for creating super-flexible admin dashboards"
   s.license = "MIT"
@@ -19,18 +19,10 @@ Gem::Specification.new do |s|
   s.add_dependency "kaminari", "~> 1.2.2"
 
   s.description = <<~DESCRIPTION
-    Administrate is heavily inspired by projects like Rails Admin and ActiveAdmin,
-    but aims to provide a better user experience for site admins,
-    and to be easier for developers to customize.
-    
-    To do that, we're following a few simple rules:
-    
-    - Stay as close to standard Rails as possible, keeping the
-      Administrate-specific code as small as practical,
-    - Support the simplest use cases,
-      and let the user override defaults with standard tools
-      such as plain Rails controllers and views.
-    - Break up the library into core components and plugins,
-      so each component stays small and easy to maintain.
+    Administrate is a library for Rails that generates admin dashboards. These
+    give users clean interfaces that allow them to create, edit, search, and
+    delete records for any model in the application. Administrate aims to
+    provide the best user experience, and doing as much work as possible for
+    you, whilst also being flexible to customise.
   DESCRIPTION
 end


### PR DESCRIPTION
In #2505, we stopped saying that Administrate doesn't have a DSL, but that pointed to some other things which are outdated in the README and Gemspec.

This goes further with the rephrasing to remove some weasle words, comparisons to other frameworks (which made more sense when it was first released) and try to improve the vision we're pitching for Administrate now and into the future.