### PR TITLE
Manually resolve broken net-smtp dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,7 @@ GEM
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.1)
       mini_portile2 (~> 2.8.2)


### PR DESCRIPTION
After merging https://github.com/thoughtbot/administrate/pull/2440, I saw strange CI failures. Looking into it, they don't appear to be related to the PR, but I can't really explain them.

One is related to Ruby 3.3. For some reason, a transitive dependency that wasn't necessary before is needed now? And running `bundle update net-smtp` simply added it? Beats me.

The other was an issue with Rails 6.x. Looking it up, I found [this discussion at StackOverflow](https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror). Requiring `logger` at the right place appears to fix it...?

Additionally, Appraisal seems to be doing something wrong in my computer (tested in macOS) and as a result I can't run some appraisals. See:

```
$ irb
irb(main):001> require 'mutex_m'
=> true
irb(main):002>

$ bundle exec appraisal rails80 irb
>> BUNDLE_GEMFILE=/Users/pablobm/Documents/personal/administrate/gem/gemfiles/rails80.gemfile bundle exec irb
irb(main):001> require 'mutex_m'
<internal:/Users/pablobm/Documents/personal/laptop/repos/asdf/installs/ruby/3.4.1/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require': cannot load such file -- mutex_m (LoadError)
...
```

Any ideas of what that could be?