### PR TITLE
Fix missing logger require for Rails 6.x

### DIFF
--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -1,5 +1,6 @@
 require_relative "boot"
 
+require "logger"
 require "active_model/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"


### PR DESCRIPTION
We were getting:

    uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger

On Rails 6.x builds, it seems like adding a require for `logger` fixes it.

https://stackoverflow.com/q/79360526