### PR TITLE
Fix datetime formatting and update timezone default handling

### DIFF
--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -13,8 +13,7 @@ module Administrate
       def datetime
         I18n.localize(
           data.in_time_zone(timezone),
-          format: format,
-          default: data
+          format: format
         )
       end
 
@@ -25,7 +24,7 @@ module Administrate
       end
 
       def timezone
-        options.fetch(:timezone, ::Time.zone.name || "UTC")
+        options.fetch(:timezone, ::Time.zone)
       end
     end
   end


### PR DESCRIPTION
- refs #2702
- Ensured consistency across public methods for DateTime, Date, and Time, which each had slight differences.
- Removed the `default` option from `I18n.localize`:
  - Since an exception is thrown with `data.in_time_zone` when `data` is `nil`, the `default` option was not meaningful.
- Removed the default value for timezone and removed string conversion with `.name`:
  - Time.zone is always defined, so a default value is unnecessary.
  - `in_time_zone` can accept `Time.zone` objects directly, so string conversion is also unnecessary.