### PR TITLE
Add localized time formatting and update customer dashboard example

### DIFF
--- a/lib/administrate/field/time.rb
+++ b/lib/administrate/field/time.rb
@@ -4,15 +4,16 @@ module Administrate
   module Field
     class Time < Base
       def time
-        return I18n.localize(data, format: format) if options[:format]
-
-        data.strftime("%I:%M%p")
+        I18n.localize(
+          data,
+          format: format
+        )
       end
 
       private
 
       def format
-        options[:format]
+        options.fetch(:format, "%I:%M%p")
       end
     end
   end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -17,6 +17,7 @@ class CustomerDashboard < Administrate::BaseDashboard
       searchable_fields: ["name"],
       include_blank: true
     ),
+    example_time: Field::Time,
     password: Field::Password
   }
 
@@ -28,6 +29,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     :email_subscriber,
     :kind,
     :territory,
+    :example_time,
     :password
   ].freeze
 

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -32,6 +32,7 @@ customer_attributes = Array.new(100) do
     name: name,
     email: Faker::Internet.email(name: name),
     territory: countries.sample,
+    example_time: Faker::Time.between(from: "00:00:00", to: "23:59:59"),
     password: Faker::Internet.password
   }
 end

--- a/spec/lib/fields/time_spec.rb
+++ b/spec/lib/fields/time_spec.rb
@@ -38,4 +38,34 @@ describe Administrate::Field::Time do
       expect(field.time).to eq("04:38PM")
     end
   end
+
+  it "formats the time with localized AM/PM markers" do
+    time = DateTime.new(2021, 3, 26, 16, 38)
+    formats = {
+      time: {
+        am: "午前",
+        pm: "午後"
+      }
+    }
+
+    field = Administrate::Field::Time.new(:time, time, :index)
+
+    I18n.with_locale(:ja) do
+      with_translations(:ja, formats) do
+        expect(field.time).to eq("04:38午後")
+      end
+    end
+  end
+
+  it "returns a missing translation message if the translation is not available" do
+    time = DateTime.new(2021, 3, 26, 16, 38)
+    field = Administrate::Field::Time.new(:time, time, :index)
+    formats = {}
+
+    I18n.with_locale(:ja) do
+      with_translations(:ja, formats) do
+        expect(field.time).to eq("Translation missing: ja.time.pm")
+      end
+    end
+  end
 end


### PR DESCRIPTION
- refs #2702
- Ensured consistency across public methods for DateTime, Date, and Time, which each had slight differences.
- Updated `Field::Time#time` to always go through `I18n.localize`:
  - Previously, if the `format` option wasn’t specified, it bypassed `translate_localization_format`, so AM/PM was not localized.
  - https://www.rubydoc.info/gems/i18n/I18n/Backend/Base:localize
- Added `Customer.example_time` to the Dashboard in the example app to check the behavior of the `Field::Time` .
- Added tests
  - Added a test to confirm that the existing behavior remains intact.
  - Also added a test for cases where the am/pm translations are undefined.
    - Since our application operates in non-English locales and always includes the `rails-i18n` gem, we don’t have to worry about am/pm translations being undefined.