### PR TITLE
Add administrate default format

### DIFF
--- a/lib/administrate/field/date.rb
+++ b/lib/administrate/field/date.rb
@@ -6,14 +6,23 @@ module Administrate
       def date
         I18n.localize(
           data.in_time_zone(timezone).to_date,
-          format: format
+          format: format,
+          default: fallback_format
         )
       end
 
       private
 
       def format
-        options.fetch(:format, :default)
+        options.fetch(:format, default_format)
+      end
+
+      def default_format
+        :administrate_date_default
+      end
+
+      def fallback_format
+        I18n.t("date.formats.default", default: "%Y-%m-%d")
       end
 
       def timezone

--- a/lib/administrate/field/date_time.rb
+++ b/lib/administrate/field/date_time.rb
@@ -6,21 +6,35 @@ module Administrate
       def date
         I18n.localize(
           data.in_time_zone(timezone).to_date,
-          format: format
+          format: format(type: :date),
+          default: fallback_format(type: :date)
         )
       end
 
       def datetime
         I18n.localize(
           data.in_time_zone(timezone),
-          format: format
+          format: format(type: :datetime),
+          default: fallback_format(type: :datetime)
         )
       end
 
       private
 
-      def format
-        options.fetch(:format, :default)
+      def format(type: :date)
+        options.fetch(:format, default_format(type: type))
+      end
+
+      def default_format(type: :date)
+        :"administrate_#{type}_default"
+      end
+
+      def fallback_format(type: :date)
+        if type == :date
+          I18n.t("date.formats.default", default: "%Y-%m-%d")
+        else
+          I18n.t("time.formats.default", default: "%Y-%m-%d %H:%M")
+        end
       end
 
       def timezone

--- a/lib/administrate/field/time.rb
+++ b/lib/administrate/field/time.rb
@@ -6,14 +6,23 @@ module Administrate
       def time
         I18n.localize(
           data,
-          format: format
+          format: format,
+          default: fallback_format
         )
       end
 
       private
 
       def format
-        options.fetch(:format, "%I:%M%p")
+        options.fetch(:format, default_format)
+      end
+
+      def default_format
+        :administrate_time_default
+      end
+
+      def fallback_format
+        "%I:%M%p"
       end
     end
   end

--- a/spec/example_app/config/locales/en.yml
+++ b/spec/example_app/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
         "%m/%d/%Y"
       with_weekday:
         "%a %m/%d/%y"
+      administrate_date_default:
+        "%m/%d/%Y"
 
   helpers:
     label:
@@ -20,6 +22,10 @@ en:
         "%b %-d, %Y"
       short:
         "%B %d"
+      administrate_datetime_default:
+        "%a, %b %-d, %Y at %r"
+      administrate_time_default:
+        "%I:%M%p"
 
   titles:
     application: Administrate-prototype

--- a/spec/lib/fields/date_spec.rb
+++ b/spec/lib/fields/date_spec.rb
@@ -6,12 +6,39 @@ describe Administrate::Field::Date do
   let(:formats) do
     {
       date: {
-        formats: {default: "%m/%d/%Y", short: "%b %d"},
+        formats: {
+          default: "%m/%d/%Y",
+          short: "%b %d",
+          administrate_date_default: "%m/%d, %Y"
+        },
         abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
         abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
       },
       time: {
-        formats: {default: "%a, %b %-d, %Y", short: "%d %b"}
+        formats: {
+          default: "%a, %b %-d, %Y at %r",
+          short: "%d %b %H:%M",
+          administrate_datetime_default: "%a, %b %-d, %Y, %r",
+          administrate_time_default: "%I:%M%p"
+        }
+      }
+    }
+  end
+  let(:formats_without_administrate_default) do
+    {
+      date: {
+        formats: {
+          default: "%m/%d/%Y",
+          short: "%b %d"
+        },
+        abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
+      },
+      time: {
+        formats: {
+          default: "%a, %b %-d, %Y at %r",
+          short: "%d %b %H:%M"
+        }
       }
     }
   end
@@ -21,11 +48,11 @@ describe Administrate::Field::Date do
       with_translations(:en, formats) do
         field = Administrate::Field::Date
           .new(:start_date, start_date, :show)
-        expect(field.date).to eq("12/25/2015")
+        expect(field.date).to eq("12/25, 2015")
       end
     end
 
-    context "with `prefix` option" do
+    context "with `format` option" do
       it "displays the date in the requested format" do
         options_field = Administrate::Field::Date
           .with_options(format: :short)
@@ -43,6 +70,35 @@ describe Administrate::Field::Date do
 
         with_translations(:en, formats) do
           expect(field.date).to eq("2015")
+        end
+      end
+    end
+
+    context "without `format` option" do
+      it "falls back to default format if administrate_date_default is missing" do
+        options_field = Administrate::Field::Date
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:en, formats_without_administrate_default) do
+          expect(field.date).to eq("12/25/2015")
+        end
+      end
+
+      it "falls back to static format (%Y-%m-%d) if locale formats are missing" do
+        options_field = Administrate::Field::Date
+        field = options_field.new(:start_date, start_date, :show)
+
+        with_translations(:unformatted_locale, {}) do
+          available_locales = I18n.available_locales
+          locale = I18n.locale
+          begin
+            I18n.available_locales = [:unformatted_locale]
+            I18n.locale = :unformatted_locale
+            expect(field.date).to eq("2015-12-25")
+          ensure
+            I18n.available_locales = available_locales
+            I18n.locale = locale
+          end
         end
       end
     end

--- a/spec/lib/fields/date_time_spec.rb
+++ b/spec/lib/fields/date_time_spec.rb
@@ -6,26 +6,78 @@ describe Administrate::Field::DateTime do
   let(:formats) do
     {
       date: {
-        formats: {default: "%m/%d/%Y", short: "%b %d"},
+        formats: {
+          default: "%m/%d/%Y",
+          short: "%b %d",
+          administrate_date_default: "%m/%d, %Y"
+        },
         abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
         abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
       },
       time: {
-        formats: {default: "%a, %b %-d, %Y at %r", short: "%d %b %H:%M"}
+        formats: {
+          default: "%a, %b %-d, %Y at %r",
+          short: "%d %b %H:%M",
+          administrate_datetime_default: "%a, %b %-d, %Y, %r",
+          administrate_time_default: "%I:%M%p"
+        }
+      }
+    }
+  end
+  let(:formats_without_administrate_default) do
+    {
+      date: {
+        formats: {
+          default: "%m/%d/%Y",
+          short: "%b %d"
+        },
+        abbr_month_names: Array.new(13) { |i| "Dec" if i == 12 },
+        abbr_day_names: Array.new(7) { |i| "Fri" if i == 5 }
+      },
+      time: {
+        formats: {
+          default: "%a, %b %-d, %Y at %r",
+          short: "%d %b %H:%M"
+        }
       }
     }
   end
 
   describe "#date" do
-    it "displays the date" do
-      with_translations(:en, formats) do
-        field = Administrate::Field::DateTime
-          .new(:start_date, start_date, :show)
-        expect(field.date).to eq("12/25/2015")
+    context "without `format` option" do
+      it "displays the date in the administrate default format" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+        with_translations(:en, formats) do
+          expect(field.date).to eq("12/25, 2015")
+        end
+      end
+
+      it "falls back to default format if administrate_date_default is missing" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+        with_translations(:en, formats_without_administrate_default) do
+          expect(field.date).to eq("12/25/2015")
+        end
+      end
+
+      it "falls back to static format (%Y-%m-%d) if locale formats are missing" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+
+        with_translations(:unformatted_locale, {}) do
+          available_locales = I18n.available_locales
+          locale = I18n.locale
+          begin
+            I18n.available_locales = [:unformatted_locale]
+            I18n.locale = :unformatted_locale
+            expect(field.date).to eq("2015-12-25")
+          ensure
+            I18n.available_locales = available_locales
+            I18n.locale = locale
+          end
+        end
       end
     end
 
-    context "with `prefix` option" do
+    context "with `format` option" do
       it "displays the date in the requested format" do
         options_field = Administrate::Field::DateTime
           .with_options(format: :short)
@@ -90,15 +142,40 @@ describe Administrate::Field::DateTime do
   end
 
   describe "#datetime" do
-    it "displays the datetime" do
-      field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+    context "without `format` option" do
+      it "displays the datetime in the administrate default format" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+        with_translations(:en, formats) do
+          expect(field.datetime).to eq("Fri, Dec 25, 2015, 10:15:45 AM")
+        end
+      end
 
-      with_translations(:en, formats) do
-        expect(field.datetime).to eq("Fri, Dec 25, 2015 at 10:15:45 AM")
+      it "falls back to default format if administrate_datetime_default is missing" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+        with_translations(:en, formats_without_administrate_default) do
+          expect(field.datetime).to eq("Fri, Dec 25, 2015 at 10:15:45 AM")
+        end
+      end
+
+      it "falls back to static format (%Y-%m-%d %H:%M) if locale formats are missing" do
+        field = Administrate::Field::DateTime.new(:start_date, start_date, :show)
+
+        with_translations(:unformatted_locale, {}) do
+          available_locales = I18n.available_locales
+          locale = I18n.locale
+          begin
+            I18n.available_locales = [:unformatted_locale]
+            I18n.locale = :unformatted_locale
+            expect(field.datetime).to eq("2015-12-25 10:15")
+          ensure
+            I18n.available_locales = available_locales
+            I18n.locale = locale
+          end
+        end
       end
     end
 
-    context "with `prefix` option" do
+    context "with `format` option" do
       it "displays the datetime in the requested format" do
         options_field = Administrate::Field::DateTime
           .with_options(format: :short)

--- a/spec/lib/fields/time_spec.rb
+++ b/spec/lib/fields/time_spec.rb
@@ -40,22 +40,23 @@ describe Administrate::Field::Time do
 
       expect(field.time).to eq("04:38PM")
     end
-  end
 
-  it "formats the time with localized AM/PM markers" do
-    time = DateTime.new(2021, 3, 26, 16, 38)
-    formats = {
-      time: {
-        am: "午前",
-        pm: "午後"
+    it "formats the time with localized AM/PM markers" do
+      time = DateTime.new(2021, 3, 26, 16, 38)
+      formats = {
+        time: {
+          am: "午前",
+          pm: "午後",
+          formats: {administrate_time_default: "%p%I:%M"}
+        }
       }
-    }
 
-    field = Administrate::Field::Time.new(:time, time, :index)
+      field = Administrate::Field::Time.new(:time, time, :index)
 
-    I18n.with_locale(:ja) do
-      with_translations(:ja, formats) do
-        expect(field.time).to eq("04:38午後")
+      I18n.with_locale(:ja) do
+        with_translations(:ja, formats) do
+          expect(field.time).to eq("午後04:38")
+        end
       end
     end
   end
@@ -63,7 +64,9 @@ describe Administrate::Field::Time do
   it "returns a missing translation message if the translation is not available" do
     time = DateTime.new(2021, 3, 26, 16, 38)
     field = Administrate::Field::Time.new(:time, time, :index)
-    formats = {}
+    formats = {
+      time: {formats: {administrate_time_default: "%I:%M%p"}}
+    }
 
     I18n.with_locale(:ja) do
       with_translations(:ja, formats) do


### PR DESCRIPTION
- refs #2702 
- The only way to change the time format was to modify the Rails default setting. However, changing it would also affect other parts of the application outside the admin panel. Therefore, I added a dedicated format specifically for Administrate.
  - `administrate_date_default` `administrate_datetime_default` `administrate_time_default`
- Currently, the Time format is fixed as `"%I:%M%p"`, but in Japanese, we would prefer the order `"%p %I:%M"`. I believe other languages may also have their own preferred orders. I have made it possible to change this for each language using `administrate_time_default` .
