### PR TITLE
Required for `nil.try` to be available

### DIFF
--- a/spec/lib/fields/url_spec.rb
+++ b/spec/lib/fields/url_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 require "administrate/field/url"
 
 describe Administrate::Field::Url do


### PR DESCRIPTION
The spec `spec/lib/fields/url_spec.rb` is failing when run on its own:

```
$ rspec spec/lib/fields/url_spec.rb:22
Run options: include {locations: {"./spec/lib/fields/url_spec.rb" => [22]}}

Randomized with seed 23913
F

Failures:

  1) Administrate::Field::Url#truncate renders an empty string for nil
     Failure/Error: resource.try(attribute)
     
     NoMethodError:
       undefined method 'try' for nil
     # ./lib/administrate/field/base.rb:67:in 'Administrate::Field::Base#read_value'
     # ./lib/administrate/field/base.rb:44:in 'Administrate::Field::Base#initialize'
     # ./spec/lib/fields/url_spec.rb:23:in 'Class#new'
     # ./spec/lib/fields/url_spec.rb:23:in 'block (3 levels) in <top (required)>'

Finished in 0.00103 seconds (files took 0.15639 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/fields/url_spec.rb:22 # Administrate::Field::Url#truncate renders an empty string for nil

Randomized with seed 23913
```

This is due to `nil.try` not being available unless Rails has been loaded. Requiring `rails_helper` fixes this.