### PR TITLE
Fix Become button on demo app

### DIFF
--- a/spec/example_app/app/views/admin/customers/_collection_header_actions.html.erb
+++ b/spec/example_app/app/views/admin/customers/_collection_header_actions.html.erb
@@ -2,7 +2,7 @@
   [
     existing_action?(collection_presenter.resource_name, :edit),
     existing_action?(collection_presenter.resource_name, :destroy),
-    true, # "Become" action
+    resources.class == Customer, # "Become" action
   ].count(true).times do %>
   <th scope="col"></th>
 <% end %>

--- a/spec/example_app/app/views/admin/customers/_collection_item_actions.html.erb
+++ b/spec/example_app/app/views/admin/customers/_collection_item_actions.html.erb
@@ -1,21 +1,7 @@
-<% if existing_action?(collection_presenter.resource_name, :edit) %>
-  <td><%= link_to(
-    t("administrate.actions.edit"),
-    [:edit, namespace, resource],
-    class: "action-edit",
-  ) if authorized_action?(resource, :edit) %></td>
-<% end %>
+<%= render template: 'administrate/application/_collection_item_actions', locals: local_assigns %>
 
-<% if existing_action?(collection_presenter.resource_name, :destroy) %>
-  <td><%= button_to(
-    t("administrate.actions.destroy"),
-    [namespace, resource],
-    class: "link link--danger",
-    method: :delete,
-    data: { turbo_confirm: t("administrate.actions.confirm") }
-  ) if authorized_action?(resource, :destroy) %></td>
+<% if resource.class == Customer %>
+  <td>
+    <%= link_to("Become", become_admin_customer_path(resource), class: "identity__become-action") %>
+  </td>
 <% end %>
-
-<td>
-  <%= link_to("Become", become_admin_customer_path(resource), class: "identity__become-action") %>
-</td>


### PR DESCRIPTION
Fix Become button appearing in `HasMany` Field on `customers.show` demo app.

Before:

![image](https://github.com/user-attachments/assets/840ba79b-6172-46cb-ac8d-e6b596954f49)

After:

![image](https://github.com/user-attachments/assets/3474524d-3961-4c5f-ad0c-3496c499a0b3)
