### PR TITLE
Allow translations of active record model names in polymorphic dashboard

### DIFF
--- a/lib/administrate/field/polymorphic.rb
+++ b/lib/administrate/field/polymorphic.rb
@@ -9,7 +9,7 @@ module Administrate
 
       def associated_resource_grouped_options
         classes.map do |klass|
-          [klass.to_s, candidate_resources_for(klass).map do |resource|
+          [klass.model_name.human, candidate_resources_for(klass).map do |resource|
             [display_candidate_resource(resource), resource.to_global_id]
           end]
         end

--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -3,6 +3,7 @@ require "administrate/field/belongs_to"
 require "administrate/field/polymorphic"
 require "support/constant_helpers"
 require "support/field_matchers"
+require "ostruct"
 
 describe Administrate::Field::Polymorphic do
   include FieldMatchers
@@ -97,6 +98,65 @@ describe Administrate::Field::Polymorphic do
 
         expect(field.send(:classes)).to eq(classes.call)
       end
+    end
+  end
+
+  describe "#associated_resource_grouped_options" do
+    it "returns grouped options with display names and global IDs" do
+      Comment = Class.new
+      instance = described_class.new(:comment, Comment.new, :show, resource: {})
+
+      Article = Class.new do
+        def self.model_name
+          OpenStruct.new(human: "Article")
+        end
+      end
+
+      Recipe = Class.new do
+        def self.model_name
+          OpenStruct.new(human: "Recipe")
+        end
+      end
+
+      resource1 = double("Hello World", to_global_id: "gid://app/Article/1")
+      resource2 = double("Today's journal", to_global_id: "gid://app/Article/2")
+      resource3 = double("Lasagna", to_global_id: "gid://app/Recipe/3")
+
+      allow(instance).to receive(:classes)
+        .and_return([Article, Recipe])
+      allow(instance).to receive(:candidate_resources_for)
+        .with(Article)
+        .and_return([resource1, resource2])
+      allow(instance).to receive(:candidate_resources_for)
+        .with(Recipe)
+        .and_return([resource3])
+      allow(instance).to receive(:display_candidate_resource)
+        .with(resource1)
+        .and_return("Hello World")
+      allow(instance).to receive(:display_candidate_resource)
+        .with(resource2)
+        .and_return("Today's journal")
+      allow(instance).to receive(:display_candidate_resource)
+        .with(resource3)
+        .and_return("Lasagna")
+
+      result = instance.associated_resource_grouped_options
+
+      expected_result = [
+        ["Article",
+          [
+            ["Hello World", "gid://app/Article/1"],
+            ["Today's journal", "gid://app/Article/2"]
+          ]],
+        ["Recipe",
+          [
+            ["Lasagna", "gid://app/Recipe/3"]
+          ]]
+      ]
+
+      expect(result).to eq(expected_result)
+    ensure
+      remove_constants :Comment, :Artcile, :Recipe
     end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/thoughtbot/administrate/issues/1994

In polymorphic associations we were not displaying the translations even when present.
By replacing `to_s` with `model_name.human` we preserve the reference to the activerecord objects, and we are able to show the translated values.

### Screenshots
![model_name-human](https://github.com/user-attachments/assets/43e69315-bf8b-45d5-93f3-44c094277fe5)
![en-yml](https://github.com/user-attachments/assets/7940a9d9-4e0f-46bc-829c-6052bf8d2549)

If I remove translations for recipe, we get the model name `Recipe` where above you can see `Ricetta`
![no-translation](https://github.com/user-attachments/assets/752fd773-d610-4f91-a358-ccebc0ac1312)

I'm gonna see if I can add a spec.

Thanks @pablobm for the recommendation on the method to apply.