### PR TITLE
Display field hints on nested forms

### DIFF
--- a/app/views/fields/has_one/_form.html.erb
+++ b/app/views/fields/has_one/_form.html.erb
@@ -30,6 +30,12 @@ The form will be rendered as nested_from to parent relationship.
           <div class="field-unit field-unit--<%= attribute.html_class %>">
             <%= render_field attribute, f: has_one_f %>
           </div>
+          <% hint_key = "administrate.field_hints.#{field.name}.#{attribute.name}" %>
+          <% if I18n.exists?(hint_key) -%>
+            <div class="field-unit__hint">
+              <%= I18n.t(hint_key) %>
+            </div>
+          <% end -%>
         <% end %>
       </fieldset>
 

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -107,5 +107,25 @@ describe "product form has_one relationship" do
         expect(page).to have_css("legend", text: custom_label)
       end
     end
+
+    it "displays hints on the has_one nested fields" do
+      meta_description_hint = "A very meta description"
+      product = create(:product)
+
+      translations = {
+        administrate: {
+          field_hints: {
+            product_meta_tag: {
+              meta_description: meta_description_hint
+            }
+          }
+        }
+      }
+
+      with_translations(:en, translations) do
+        visit edit_admin_product_path(product)
+        expect(page).to have_css(".field-unit__hint", text: meta_description_hint)
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently the filed hints work on the `application/_form.html.erb`, but when a nested form is used, they are not displayed. 

This is basically copying those lines from the form partial, ~~with the difference that we're using `f.object_name`instead.~~