### PR TITLE
Restrict attributes shown on the Customer index

### DIFF
--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -21,8 +21,17 @@ class CustomerDashboard < Administrate::BaseDashboard
     password: Field::Password
   }
 
-  COLLECTION_ATTRIBUTES = ATTRIBUTE_TYPES.keys - %i[created_at updated_at]
+  COLLECTION_ATTRIBUTES = [
+    :name,
+    :email,
+    :email_subscriber,
+    :orders,
+    :territory,
+    :example_time
+  ]
+
   SHOW_PAGE_ATTRIBUTES = ATTRIBUTE_TYPES.keys - [:name]
+
   FORM_ATTRIBUTES = [
     :name,
     :email,


### PR DESCRIPTION
As we've added more attributes to the `Customer`, the index has gotten wider and wider until the page layout has broken. It's the first page you land on when looking at the demo, so in addition to setting a bad first impression, it's not reflective of what someone would setup themselves.

We fix this by reducing the attributes shown to be sensible, but avoid breaking the page layout.

Before:
<img width="1493" alt="Screenshot 2025-03-17 at 15 29 16" src="https://github.com/user-attachments/assets/fbd605da-519e-4da7-b6dc-3aaeb83677a6" />

After:
<img width="1479" alt="Screenshot 2025-03-17 at 15 25 42" src="https://github.com/user-attachments/assets/c68c5539-2a29-45dd-8508-9b4c7c6a077c" />
