### PR TITLE
Replace form_for with form_with

### DIFF
--- a/app/views/administrate/application/_form.html.erb
+++ b/app/views/administrate/application/_form.html.erb
@@ -14,7 +14,7 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+<%= form_with(model: page.resource, url: [namespace, page.resource], scope: page.resource, local: true, class: "form") do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
       <h2>

--- a/spec/administrate/views/fields/rich_text/_form_spec.rb
+++ b/spec/administrate/views/fields/rich_text/_form_spec.rb
@@ -32,9 +32,9 @@ describe "fields/rich_text/_form", type: :view do
     end
 
     expect(rendered).to have_field(
-      "trix_input_product", type: "hidden", with: product.banner.body.to_trix_html
+      "product_banner_trix_input_product", type: "hidden", with: product.banner.body.to_trix_html
     ).and(have_element(
-      "trix-editor", input: "trix_input_product"
+      "trix-editor", input: "product_banner_trix_input_product"
     ))
   end
 end

--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -29,6 +29,7 @@ module AdministratePrototype
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.active_record.time_zone_aware_types = %i[datetime time]
     config.active_support.to_time_preserves_timezone = :zone
+    config.action_view.form_with_generates_ids = true
 
     # Opt-out of FLoC: https://amifloced.org/
     config.action_dispatch


### PR DESCRIPTION
Since `form_for` has been deprecated in Rails 5.1, I replaced it with `form_with`.
The change required minimal adjustments thanks to good compatibility.

In the demo app, we need to set `config.action_view.form_with_generates_ids = true` to automatically generate `id` and `for` attributes.  
However, this is already `true` by default in `load_defaults` from Rails 6.0 onward, so it shouldn’t cause problems in most applications.
