### PR TITLE
Fix become button header

### DIFF
--- a/spec/example_app/app/views/admin/customers/_collection_header_actions.html.erb
+++ b/spec/example_app/app/views/admin/customers/_collection_header_actions.html.erb
@@ -2,7 +2,7 @@
   [
     existing_action?(collection_presenter.resource_name, :edit),
     existing_action?(collection_presenter.resource_name, :destroy),
-    resources.class == Customer, # "Become" action
+    resources.klass == Customer, # "Become" action
   ].count(true).times do %>
   <th scope="col" class="cell-label--action-button"></th>
 <% end %>


### PR DESCRIPTION
- fix #2787 

I made a mistake during the work on #2787 — the condition wasn’t evaluated correctly, so the table header for the Become button wasn't being rendered.  

Before:

![image](https://github.com/user-attachments/assets/254e2cf5-1e06-44cb-8bb7-da5351932e06)

After:

![image](https://github.com/user-attachments/assets/bdcc69b5-28a6-4db9-9cd4-1ef0f6d44c3b)
