### PR TITLE
Undeprecations of `:class_name` I missed last time

### DIFF
--- a/lib/administrate/field/has_one.rb
+++ b/lib/administrate/field/has_one.rb
@@ -7,7 +7,6 @@ module Administrate
         resource_class = options[:resource_class]
         final_associated_class_name =
           if options.key?(:class_name)
-            Administrate.warn_of_deprecated_option(:class_name)
             options.fetch(:class_name)
           elsif resource_class
             associated_class_name(resource_class, attr)

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -133,7 +133,6 @@ module Administrate
         provided_class_name = attribute_types[attr].options[:class_name]
         unquoted_table_name =
           if provided_class_name
-            Administrate.warn_of_deprecated_option(:class_name)
             provided_class_name.constantize.table_name
           else
             @scoped_resource.reflect_on_association(attr).klass.table_name

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -208,20 +208,6 @@ describe Administrate::Search do
           have_received(:where).with(*expected_query)
         )
       end
-
-      it "triggers a deprecation warning" do
-        allow(scoped_object).to receive(:where)
-        allow(scoped_object).to(
-          receive(:left_joins)
-            .with(%i[role author address])
-            .and_return(scoped_object)
-        )
-
-        search.run
-
-        expect(Administrate.deprecator).to have_received(:warn)
-          .with(/:class_name is deprecated/)
-      end
     end
 
     it "searches using a filter" do

--- a/spec/lib/fields/has_one_spec.rb
+++ b/spec/lib/fields/has_one_spec.rb
@@ -60,20 +60,6 @@ describe Administrate::Field::HasOne do
         expect(attributes[:"#{field_name}_attributes"])
           .to eq(%i[meta_title meta_description id])
       end
-
-      it "triggers a deprecation warning" do
-        field = Administrate::Field::Deferred.new(
-          Administrate::Field::HasOne,
-          class_name: :product_meta_tag
-        )
-        field_name = "product_meta_tag"
-        field.permitted_attribute(
-          field_name,
-          resource_class: Product
-        )
-        expect(Administrate.deprecator).to have_received(:warn)
-          .with(/:class_name is deprecated/)
-      end
     end
   end
 


### PR DESCRIPTION
I missed these at #2697. I checked manually if they need to be removed indeed:

- I can confirm that the undeprecation at `lib/administrate/search.rb` is necessary. I reproduced the scenario described at https://github.com/thoughtbot/administrate/issues/2384#issuecomment-2101442125 and got the warnings when I used the search.
- The other one was a bit trickier as I'm having difficulty putting the scenario together. Still, I did undeprecate it in the docs last time, so it should be undeprecated in the code.