### PR TITLE
Typo

### DIFF
--- a/spec/lib/fields/polymorphic_spec.rb
+++ b/spec/lib/fields/polymorphic_spec.rb
@@ -156,7 +156,7 @@ describe Administrate::Field::Polymorphic do
 
       expect(result).to eq(expected_result)
     ensure
-      remove_constants :Comment, :Artcile, :Recipe
+      remove_constants :Comment, :Article, :Recipe
     end
   end
 end


### PR DESCRIPTION
I was seeing the following warning when running the tests:

```
Warning from ConstantHelpers::remove_constants:
	constant Object::Artcile not defined
```

Looks like we all missed a typo at https://github.com/thoughtbot/administrate/pull/2797 :sweat_smile: 