### PR TITLE
fix: Replace data.count with data.size in HasMany field

### DIFF
--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -72,7 +72,7 @@ module Administrate
       end
 
       def more_than_limit?
-        paginate? && data.count(:all) > limit
+        paginate? && data.size > limit
       end
 
       def data

--- a/spec/support/mock_relation.rb
+++ b/spec/support/mock_relation.rb
@@ -17,8 +17,7 @@ class MockRelation
     @data.first(n)
   end
 
-  def count(column = nil)
-    return @data.count if column == :all
-    @data.count(column)
+  def size
+    @data.size
   end
 end


### PR DESCRIPTION
This patch updates the `HasMany` field in the core Administrate library to avoid unnecessary `COUNT(*)` database queries by changing the `more_than_limit?` method to use `data.size` instead of `data.count(:all)`.

### When this makes a difference

With eager-loaded associations: Administrate preloads child records via `resources.includes(*includes)` when you configure `collection_includes` on your dashboard. On an eager-loaded `ActiveRecord::Relation`, calling `data.size` returns the in-memory `Array#size`, so **no additional SQL** is issued.

Without eager-loading: If you haven’t configured any `includes`, then `data` remains an unloaded relation. In that case, `data.size` will fall back to issuing a `SELECT COUNT(*)`, ensuring the behavior stays correct but without the benefit of preloading.

In contrast, the original `data.count(:all)` always triggers a `SELECT COUNT(*)` SQL query, even when the records are already loaded, resulting in unnecessary database round-trips.