### PR TITLE
Selectize polymorphic select field

### DIFF
--- a/app/views/fields/polymorphic/_form.html.erb
+++ b/app/views/fields/polymorphic/_form.html.erb
@@ -22,7 +22,7 @@ This partial renders an input element for polymorphic relationships.
 
   <div class="field-unit__field">
     <%= pf.hidden_field(:type, value: field.class.name) %>
-    <%= pf.select(:value, {}, data: {controller: field.html_controller}) do %>
+    <%= pf.select(:value, nil, {}, data: {controller: field.html_controller}) do %>
       <%= grouped_options_for_select(field.associated_resource_grouped_options, field.selected_global_id, prompt: true) %>
     <% end %>
   </div>

--- a/spec/features/edit_page_spec.rb
+++ b/spec/features/edit_page_spec.rb
@@ -104,4 +104,18 @@ describe "customer edit page" do
     customer.reload
     expect(customer.territory).to eq(country)
   end
+
+  it "allows selecting a resource and submitting the form", :js do
+    _blog_post = create(:blog_post, title: "How to Bake Bread")
+    _blog_post2 = create(:blog_post, title: "How to Play Guitar")
+    tag = create(:blog_tag)
+
+    visit edit_admin_blog_tag_path(tag)
+    find(".selectize-input").click
+    find(".selectize-input").fill_in(with: "Bake Bread")
+    find(".option", text: "How to Bake Bread").click
+    click_button "Update Tag"
+
+    expect(page).to have_content("How to Bake Bread")
+  end
 end

--- a/spec/features/log_entries_form_spec.rb
+++ b/spec/features/log_entries_form_spec.rb
@@ -15,6 +15,20 @@ describe "log entry form" do
     )
   end
 
+  it "allows to type in the select field to find a match and select it", :js do
+    _customer = create(:customer, name: "Brucey")
+    _customer2 = create(:customer, name: "Nacho")
+
+    visit new_admin_log_entry_path
+    fill_in "Action", with: "create"
+    find(".selectize-input").click
+    find(".selectize-input").fill_in(with: "Brucey")
+    find(".option", text: "Brucey").click
+    click_on "Create Log entry"
+
+    expect(page).to have_content("Brucey")
+  end
+
   it "shows the selected logeable value" do
     customer = create(:customer)
     log_entry = create(:log_entry, logeable: customer)

--- a/spec/features/new_page_spec.rb
+++ b/spec/features/new_page_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Admin creates a new tag", type: :feature, js: true do
+  it "allows selecting a resource and submitting the form" do
+    _blog_post = create(:blog_post, title: "How to Bake Bread")
+    _blog_post2 = create(:blog_post, title: "How to Play Guitar")
+
+    visit "/admin/blog/tags/new"
+    find(".selectize-input").click
+    find(".selectize-input").fill_in(with: "Bake Bread")
+    find(".option", text: "How to Bake Bread").click
+    click_button "Create Tag"
+
+    expect(page).to have_content("How to Bake Bread")
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/thoughtbot/administrate/issues/2821

When building the select field in the polymorphic form, we omitted to
pass `nil` to the choices argument, which resulted in an erroneous
argument order, and a `{}` was passed to it instead.
This caused the selectize gem to fail applying the `.selectize` method
under the hood.

Passing `nil` will now restore its intended behavior and  allow selectize
to perform the dynamic search in the select field again.

Adding a feature spec for the /new form where we type in the input field to
make use of the selectize function.

### References
Where it started: https://github.com/thoughtbot/administrate/pull/2447
Where I looked for answers: https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select
And here: https://github.com/thoughtbot/administrate/pull/2447/files#diff-75dadcafc8eab3ca77123a071efca9c25c06adf2db9a3f8c4827419f23e698d7R26

### Screenshots
![Screenshot 2025-04-28 at 12 51 34](https://github.com/user-attachments/assets/fbe734eb-4173-41ac-8384-21d85c4e9209)
![Screenshot 2025-04-28 at 12 51 40](https://github.com/user-attachments/assets/d6ffcf42-fecf-445e-8751-b3bdf3bf51c0)
![Screenshot 2025-04-28 at 12 51 51](https://github.com/user-attachments/assets/07523d38-189c-45bd-b7c6-b8c8f4efcaa2)


