### PR TITLE
Conventional location and name for HasManyVariant in demo app

### DIFF
--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -1,4 +1,3 @@
-require "administrate/field/has_many_variant"
 require "administrate/base_dashboard"
 
 class CustomerDashboard < Administrate::BaseDashboard
@@ -9,7 +8,7 @@ class CustomerDashboard < Administrate::BaseDashboard
     lifetime_value: Field::Number.with_options(prefix: "$", decimals: 2, sortable: false),
     name: Field::String,
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
-    log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),
+    log_entries: HasManyVariantField.with_options(limit: 2, sort_by: :id),
     updated_at: Field::DateTime,
     kind: Field::Select,
     territory: Field::BelongsTo.with_options(

--- a/spec/example_app/app/fields/has_many_variant_field.rb
+++ b/spec/example_app/app/fields/has_many_variant_field.rb
@@ -1,0 +1,3 @@
+class HasManyVariantField < Administrate::Field::HasMany
+  # Only here to test that this works out of the box
+end

--- a/spec/example_app/lib/administrate/field/has_many_variant.rb
+++ b/spec/example_app/lib/administrate/field/has_many_variant.rb
@@ -1,9 +1,0 @@
-require "administrate/field/has_many"
-
-module Administrate
-  module Field
-    class HasManyVariant < HasMany
-      # Only here to test that this works out of the box
-    end
-  end
-end

--- a/spec/helpers/administrate/application_helper_spec.rb
+++ b/spec/helpers/administrate/application_helper_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 require "administrate/field/has_many"
-require "administrate/field/has_many_variant"
 
 RSpec.describe Administrate::ApplicationHelper do
   describe "#find_partial_prefix" do
@@ -13,7 +12,7 @@ RSpec.describe Administrate::ApplicationHelper do
 
     context "when the field does not have a partial and the superclass does" do
       it "returns the superclass prefix" do
-        field = Administrate::Field::HasManyVariant.new(:name, "hello", :show)
+        field = HasManyVariantField.new(:name, "hello", :show)
         expect(find_partial_prefix(field)).to eq("fields/has_many")
       end
     end


### PR DESCRIPTION
Yesterday I had some confusion with the `administrate:field` generator, until I realised that it uses a convention different from the one used by the custom field `HasManyVariant`, as present in the demo app.

After thinking about which of the two styles is right or wrong, I think the generator is doing the right thing. This PR moves `HasManyVariant` and renames it `HasManyVariantField`, in order to follow the convention set out by the generator (which is also the one shown in the docs).

Notes:
- The field class is generated under `app/fields`. The location means it's autoloaded and we don't need a `require`.
- The `Field` suffix may seem annoying, but it's not different from controllers, helpers, etc, and removes the need for a namespace (eg: `Field::HasManyVariant`).
- This establishes a difference between the official field types (eg: `Administrate::Field::String`) and custom ones (eg: `MyStringField`), but I think this is fine.

Tangentially, I also noticed that, if for any reason a user puts the template files in the wrong place, this is difficult to debug as Administrate will just fail silently, rendering empty templates. This is due to the changes introduced at https://github.com/thoughtbot/administrate/pull/2467. This should not be an issue if using the generator, but might be if creating the field manually.
