### PR TITLE
Removed the link role from the index table

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -69,7 +69,7 @@ to display a collection of resources in an HTML table.
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           <% if accessible_action?(resource, :show) %>
-            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+            <%= %(tabindex=0 data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>


### PR DESCRIPTION
Each row of the collection table had a `role=link` attribute, which was removing the default "row" role. This caused screen readers to ignore all of the table's rows. Removing the attribute resolves this issue.