### PR TITLE
fix: bug for host in link

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -32,7 +32,7 @@ to display a collection of resources in an HTML table.
           <% end %>
         >
           <% if attr_type.sortable? %>
-            <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+            <%= link_to(params: sanitized_order_params(page, collection_field_name).merge(
               collection_presenter.order_params_for(attr_name, key: collection_field_name)
             )) do %>
               <%= t(

--- a/spec/example_app/app/controllers/admin/hosts_controller.rb
+++ b/spec/example_app/app/controllers/admin/hosts_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class HostsController < Admin::ApplicationController
+  end
+end

--- a/spec/example_app/app/dashboards/host_dashboard.rb
+++ b/spec/example_app/app/dashboards/host_dashboard.rb
@@ -1,0 +1,30 @@
+require "administrate/base_dashboard"
+
+class HostDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    created_at
+    updated_at
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    created_at
+    updated_at
+  ].freeze
+
+  FORM_ATTRIBUTES = %i[
+    name
+  ].freeze
+
+  COLLECTION_FILTERS = {}.freeze
+end

--- a/spec/example_app/app/models/host.rb
+++ b/spec/example_app/app/models/host.rb
@@ -1,0 +1,2 @@
+class Host < ApplicationRecord
+end

--- a/spec/example_app/app/policies/host_policy.rb
+++ b/spec/example_app/app/policies/host_policy.rb
@@ -1,0 +1,2 @@
+class HostPolicy < ApplicationPolicy
+end

--- a/spec/example_app/config/routes.rb
+++ b/spec/example_app/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     end
 
     resources :stats, only: [:index]
+    resources :hosts, only: [:index]
 
     root to: "customers#index"
   end

--- a/spec/example_app/db/migrate/20250705215532_create_hosts.rb
+++ b/spec/example_app/db/migrate/20250705215532_create_hosts.rb
@@ -1,0 +1,9 @@
+class CreateHosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :hosts do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/example_app/db/schema.rb
+++ b/spec/example_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_13_130741) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_05_215532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -94,6 +94,12 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_13_130741) do
     t.time "example_time"
     t.string "password"
     t.boolean "hidden", default: false, null: false
+  end
+
+  create_table "hosts", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "line_items", id: :serial, force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -74,5 +74,9 @@ FactoryBot.define do
     sequence(:code) { |n| "C#{n}" }
   end
 
+  factory :host do
+    name { Faker::Internet.ip_v4_address }
+  end
+
   factory :page
 end

--- a/spec/features/hosts_index_page_spec.rb
+++ b/spec/features/hosts_index_page_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+feature "hosts index page" do
+  scenario "user views hosts" do
+    host = create(:host)
+
+    visit admin_hosts_path
+
+    expect(page).to have_header("Hosts")
+    expect(page).to have_content(host.name)
+  end
+end


### PR DESCRIPTION
This PR fixes the bug described in this issue: https://github.com/thoughtbot/administrate/issues/2718

The bug happens in the `app/views/administrate/application/_collection.html.erb` view file.

There is a line that calls `link_to` helper with parameters that look like `{"host" => {"order" => :id, "direction" => :asc}}`.
Some method inside Rails thinks that `host` corresponds to a URL host and not to a URL parameter called host, so it raises an error when trying to generate the route.

<details>
<summary>Example of the error message</summary>

```
ActionView::Template::Error (unable to convert unpermitted parameters to hash)
Caused by: ActionController::UnfilteredParameters (unable to convert unpermitted parameters to hash)

Information for: ActionView::Template::Error (unable to convert unpermitted parameters to hash):
    29:         scope="col"
    30:         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
    31:         <%# <%= debugger %> %>
    32:         <%= link_to(sanitized_order_params(page, collection_field_name).merge(
    33:           collection_presenter.order_params_for(attr_name, key: collection_field_name)
    34:         )) do %>
    35:         <%= t(

actionpack (8.0.2) lib/action_controller/metal/strong_parameters.rb:335:in 'ActionController::Parameters#to_h'
actionpack (8.0.2) lib/action_controller/metal/strong_parameters.rb:1166:in 'ActionController::Parameters#convert_parameters_to_hashes'
actionpack (8.0.2) lib/action_controller/metal/strong_parameters.rb:1162:in 'block in ActionController::Parameters#convert_parameters_to_hashes'
activesupport (8.0.2) lib/active_support/hash_with_indifferent_access.rb:335:in 'Hash#transform_values!'
activesupport (8.0.2) lib/active_support/hash_with_indifferent_access.rb:335:in 'block in ActiveSupport::HashWithIndifferentAccess#transform_values'
<internal:kernel>:91:in 'Kernel#tap'
activesupport (8.0.2) lib/active_support/hash_with_indifferent_access.rb:335:in 'ActiveSupport::HashWithIndifferentAccess#transform_values'
actionpack (8.0.2) lib/action_controller/metal/strong_parameters.rb:1161:in 'ActionController::Parameters#convert_parameters_to_hashes'
actionpack (8.0.2) lib/action_controller/metal/strong_parameters.rb:333:in 'ActionController::Parameters#to_h'
actionpack (8.0.2) lib/action_dispatch/routing/url_for.rb:188:in 'ActionDispatch::Routing::UrlFor#full_url_for'
actionpack (8.0.2) lib/action_dispatch/routing/url_for.rb:179:in 'ActionDispatch::Routing::UrlFor#url_for'
actionview (8.0.2) lib/action_view/routing_url_for.rb:96:in 'ActionView::RoutingUrlFor#url_for'
actionview (8.0.2) lib/action_view/helpers/url_helper.rb:702:in 'ActionView::Helpers::UrlHelper#url_target'
actionview (8.0.2) lib/action_view/helpers/url_helper.rb:204:in 'ActionView::Helpers::UrlHelper#link_to'
administrate (0.19.0) app/views/administrate/application/_collection.html.erb:32
```
</details>

I believe that it can happen with other names too, like `domain` or `port` which is quite annoying.

There is an easy way to solve it: wrap these parameters into a hash `params: ...` before calling the `link_to` method. This way Rails will understand that it's not a url host value.

- [x] Checked that it works locally
- [x] A test for this bug is added