### PR TITLE
Remove unused association attribute from Order

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -1,9 +1,8 @@
 module Administrate
   class Order
-    def initialize(attribute = nil, direction = nil, association_attribute: nil, sorting_column: nil)
+    def initialize(attribute = nil, direction = nil, sorting_column: nil)
       @attribute = attribute
       @direction = sanitize_direction(direction)
-      # @association_attribute = association_attribute
       @sorting_column = sorting_column || attribute
     end
 
@@ -34,7 +33,7 @@ module Administrate
 
     private
 
-    attr_reader :attribute, :association_attribute, :sorting_column
+    attr_reader :attribute, :sorting_column
 
     def sanitize_direction(direction)
       %w[asc desc].include?(direction.to_s) ? direction.to_sym : :asc


### PR DESCRIPTION
This PR removes an unused attribute from `AdministrateOrder`. The original change was done in this commit https://github.com/thoughtbot/administrate/commit/b1bf9523

The attribute seems to be unused and it can be safely removed.