### PR TITLE
Update gem `uri` which has a vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
+    uri (1.1.0)
     useragent (0.16.11)
     webmock (3.25.1)
       addressable (>= 2.8.0)


### PR DESCRIPTION
Gem had a CVE and was breaking CI.

Example CI failure: https://github.com/thoughtbot/administrate/actions/runs/18840928961/job/53752788415

```
Download ruby-advisory-db ...
Cloning into '/github/home/.local/share/ruby-advisory-db'...
ruby-advisory-db:
  advisories:	1032 advisories
  last updated:	2025-10-23 12:50:11 -0700
  commit:	c506afcbb18a7062701940fe5c58ccc1698e15d4
Name: uri
Version: 1.0.3
CVE: CVE-2025-61594
Criticality: Unknown
URL: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594
Title: CVE-2025-61594 - URI Credential Leakage Bypass over CVE-2025-27221
Solution: update to '~> 0.12.5', '~> 0.13.3', '>= 1.0.4'

Vulnerabilities found!
```