### PR TITLE
Fix CI (no idea of why this is needed)

### DIFF
--- a/spec/example_app/app/controllers/docs_controller.rb
+++ b/spec/example_app/app/controllers/docs_controller.rb
@@ -24,7 +24,7 @@ class DocsController < ApplicationController
     title ||= page.title
     @page_title = [title, "Administrate"].compact.join(" - ")
     # rubocop:disable Rails/OutputSafety
-    render layout: "docs", html: page.body.html_safe
+    render layout: "docs", html: page.body.html_safe, formats: :html
     # rubocop:enable Rails/OutputSafety
   rescue DocPage::PageNotAllowed, DocPage::PageNotFound
     render(


### PR DESCRIPTION
I've spent some time this morning trying to figure out why CI is failing. We cannot reproduce the issue locally and are forced to debug in CI, which is a pain. This is what I have so far.

The issue is with `spec/features/documentation_spec.rb`. The expectations that check for `div.main` fail because the layout is not being rendered in the `$filename.md` case. It does render in the case that does not use the `md` extension. This is with Rails 8.0, and again: only in CI.

Two things I've been able to tell:
- When the `md` extension is provided, internally Rails has the "format" as `md` and tries for the `md` renderer.
- In this case, the `view_paths` don't include `/home/runner/work/administrate/administrate/spec/example_app/app/views`, which is included in the non-failing cases.

Explicitly telling Rails that the output format is HTML appears to fix the issue.