### PR TITLE
Use Field::RichText type for ActionText has_rich_text associations

### DIFF
--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -128,7 +128,10 @@ module Administrate
 
       def association_type(attribute)
         relationship = klass.reflections[attribute.to_s]
-        if relationship.has_one?
+        if relationship.name.start_with?("rich_text_") &&
+            relationship.options[:class_name]&.start_with?("ActionText::")
+          "Field::RichText"
+        elsif relationship.has_one?
           "Field::HasOne"
         elsif relationship.collection?
           "Field::HasMany"


### PR DESCRIPTION
- detects ActionText rich text associations based on class name and attribution name and if it's a match, returns the built-in Field::RichText type
Closes #2925 