### PR TITLE
Add APIs to remove and clear custom CSS and JS files

### DIFF
--- a/docs/customizing_page_views.md
+++ b/docs/customizing_page_views.md
@@ -141,3 +141,27 @@ you of this step if you miss it):
 //= link admin.css
 //= link admin.js
 ```
+
+## Removing custom CSS and JS
+
+Administrate also provides APIs to remove added CSS or JS files, or clear all
+at once.
+
+Sometimes you may want to remove custom CSS or JS files that you previously
+added to Administrate　—　for example, when cleaning up unused assets,
+switching to a new design, or troubleshooting conflicts. Administrate provides
+simple APIs to help you manage these files directly from your configuration.
+
+To remove a specific CSS or JS file, use:
+
+```ruby
+Administrate::Engine.delete_stylesheet("admin")
+Administrate::Engine.delete_javascript("admin")
+```
+
+If you want to clear all custom CSS or JS files at once, use:
+
+```ruby
+Administrate::Engine.clear_stylesheets
+Administrate::Engine.clear_javascripts
+```

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -42,6 +42,22 @@ module Administrate
       @@stylesheets << stylesheet
     end
 
+    def self.delete_stylesheet(stylesheet)
+      @@stylesheets.delete(stylesheet)
+    end
+
+    def self.delete_javascript(script)
+      @@javascripts.delete(script)
+    end
+
+    def self.clear_stylesheets
+      @@stylesheets.clear
+    end
+
+    def self.clear_javascripts
+      @@javascripts.clear
+    end
+
     def self.stylesheets
       @@stylesheets
     end


### PR DESCRIPTION
The following methods have been added:

- `Administrate::Engine.delete_stylesheet`
- `Administrate::Engine.delete_javascript`
- `Administrate::Engine.clear_stylesheets`
- `Administrate::Engine.clear_javascripts`

While custom CSS and JS are automatically injected by plugins, there are cases where application developers may not need them. For example, if their application has already migrated to Stimulus and no longer requires jQuery-based JavaScript, these APIs make it easy to remove or clear unnecessary assets.