### PR TITLE
add load_defaults option to example_app

### DIFF
--- a/spec/example_app/app/models/customer.rb
+++ b/spec/example_app/app/models/customer.rb
@@ -4,7 +4,8 @@ class Customer < ApplicationRecord
     :territory,
     class_name: "Country",
     foreign_key: :country_code,
-    primary_key: :code
+    primary_key: :code,
+    optional: true
   )
   has_many :log_entries, as: :logeable
 
@@ -12,7 +13,7 @@ class Customer < ApplicationRecord
   validates :email, presence: true
 
   if Rails.gem_version >= Gem::Version.new("7.0")
-    enum :kind, {"standard" => "kind:std", "vip" => "kind:vip"}
+    enum :kind, {"standard" => "kind:std", "vip" => "kind:vip"}, default: "standard"
   else
     enum kind: {"standard" => "kind:std", "vip" => "kind:vip"}
   end

--- a/spec/example_app/config/application.rb
+++ b/spec/example_app/config/application.rb
@@ -14,6 +14,7 @@ Bundler.require(*Rails.groups)
 
 module AdministratePrototype
   class Application < Rails::Application
+    config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
     config.i18n.enforce_available_locales = true
 
     config.generators do |generate|
@@ -27,9 +28,9 @@ module AdministratePrototype
     end
 
     config.action_controller.action_on_unpermitted_parameters = :raise
-    config.active_record.time_zone_aware_types = %i[datetime time]
-    config.active_support.to_time_preserves_timezone = :zone
-    config.action_view.form_with_generates_ids = true
+    if Rails.gem_version < Gem::Version.new("7.0")
+      config.active_support.to_time_preserves_timezone = :zone
+    end
 
     # Opt-out of FLoC: https://amifloced.org/
     config.action_dispatch

--- a/spec/example_app/db/seeds.rb
+++ b/spec/example_app/db/seeds.rb
@@ -32,6 +32,7 @@ customer_attributes = Array.new(100) do
     name: name,
     email: Faker::Internet.email(name: name),
     territory: countries.sample,
+    kind: ["standard", "vip"].sample,
     example_time: Faker::Time.between(from: "00:00:00", to: "23:59:59"),
     password: Faker::Internet.password
   }

--- a/spec/example_app/spec/features/pagination_spec.rb
+++ b/spec/example_app/spec/features/pagination_spec.rb
@@ -71,11 +71,11 @@ RSpec.feature "Pagination", type: :feature do
 
   context "with resources of type Page" do
     it "can paginate and sort" do
-      FactoryBot.create(:page, title: "Page 2")
-      FactoryBot.create(:page, title: "Page 4")
-      FactoryBot.create(:page, title: "Page 1")
-      FactoryBot.create(:page, title: "Page 5")
-      FactoryBot.create(:page, title: "Page 3")
+      create(:page, title: "Page 2")
+      create(:page, title: "Page 4")
+      create(:page, title: "Page 1")
+      create(:page, title: "Page 5")
+      create(:page, title: "Page 3")
 
       visit admin_pages_path(per_page: 3)
       click_on "Title"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,11 +43,14 @@ FactoryBot.define do
     image_url do
       "https://cdn.recombu.com/mobile/images/news/M11370/1264769196_w670.jpg"
     end
-    product_meta_tag
+    trait :with_product_meta_tag do
+      association :product_meta_tag
+    end
     release_year { [2018, 2019, 2020].sample }
   end
 
   factory :product_meta_tag do
+    association :product
     meta_title { "meta_title" }
     meta_description { "meta_description" }
   end
@@ -78,5 +81,9 @@ FactoryBot.define do
     name { Faker::Internet.ip_v4_address }
   end
 
-  factory :page
+  factory :page do
+    sequence(:title) { |n| "Page #{n}" }
+    body { "Sample body text" }
+    association :product
+  end
 end

--- a/spec/features/products_form_spec.rb
+++ b/spec/features/products_form_spec.rb
@@ -60,7 +60,7 @@ describe "product form has_one relationship" do
   end
 
   it "edits product and meta tag data correctly", js: true do
-    product = create(:product, banner: <<~HTML)
+    product = create(:product, :with_product_meta_tag, banner: <<~HTML)
       <div>A banner with a <a href="https://example.com">link</a>.</div>
     HTML
 


### PR DESCRIPTION
To ensure tests run correctly on each Rails version, I think it's better to set `load_defaults` accordingly.

I tried setting it, but it resulted in a large number of errors. I plan to fix them gradually over time.
Once all errors are resolved, I will open a PR.

If you have any concerns or a different direction in mind, please let me know.