### PR TITLE
feature: add Administrate.deprecator to the host app

### DIFF
--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -30,6 +30,10 @@ module Administrate
       end
     end
 
+    initializer "administrate.deprecator" do |app|
+      app.deprecators[:administrate] = Administrate.deprecator if app.respond_to?(:deprecators)
+    end
+
     def self.add_javascript(script)
       @@javascripts << script
     end

--- a/spec/administrate/engine_spec.rb
+++ b/spec/administrate/engine_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+require "administrate/engine"
+
+describe Administrate::Engine do
+  if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new("7.1")
+    it "deprecator is added to application deprecators" do
+      expect(Rails.application.deprecators[:administrate]).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This auto-adds `Administrate.deprecator` to the host app, helping with tools like [next_rails deprecation tracker](https://github.com/fastruby/next_rails?tab=readme-ov-file#deprecation-tracking)

Without this change, app needs to add it in initializer, e.g.

```ruby
# config/initializers/administrate.rb
Rails.application.deprecators[:administrate] = Administrate.deprecator
```

This code is based on [how the devise gem does it](https://github.com/heartcombo/devise/blob/c8a64b549c8b37e494eaca7be2def136a7e1b236/lib/devise/rails.rb#L20).