### PR TITLE
Remove use of deprecated method String#mb_chars

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -111,7 +111,7 @@ module Administrate
       fields_count = search_attributes.sum do |attr|
         searchable_fields(attr).count
       end
-      ["%#{term.mb_chars.downcase}%"] * fields_count
+      ["%#{term.downcase}%"] * fields_count
     end
 
     def search_attributes


### PR DESCRIPTION
Removes use of the deprecated method `String#mb_chars`.

`String#mb_chars` was needed historically because Ruby's `String#downcase` didn't handle Unicode properly. Since Ruby 2.4+, String#downcase (and upcase, capitalize, etc.) handle Unicode correctly by default.

Fixes https://github.com/thoughtbot/administrate/issues/2965

