### PR TITLE
Fix Sentry configuration

### DIFF
--- a/spec/example_app/app/views/layouts/application.html.erb
+++ b/spec/example_app/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= csrf_meta_tags %>
   <%= render "javascript" %>
+  <%= Sentry.get_trace_propagation_meta.html_safe %>
 </head>
 
 <body class="<%= body_class %>">

--- a/spec/example_app/config/initializers/sentry.rb
+++ b/spec/example_app/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger]
+  config.dsn = ENV["SENTRY_DSN"]
+  config.environment = ENV["SENTRY_ENV"]
+  config.traces_sample_rate = 1.0
+end


### PR DESCRIPTION
We've long used Sentry for exception monitoring, but it's not been used for a long time. This re-follows the getting started guide, and introduces an initialiser, and the HTML addition.

If they're set, `SENTRY_DSN` and `SENTRY_ENV` will be used from the environment. The environment is set to be "prerelease" and "release" for each Heroku app.