### PR TITLE
Add support for page-specific look

### DIFF
--- a/docs/customizing_dashboards.md
+++ b/docs/customizing_dashboards.md
@@ -705,3 +705,11 @@ fields/base/looks/customer_card/
 fields/base/looks/default/
 fields/base/
 ```
+
+You can also select a different look for each page by passing a Hash to `look` option.
+
+```ruby
+ATTRIBUTE_TYPES = {
+  created_at: Field::DateTime.with_options(look: {index: :relative})
+}
+```

--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -108,7 +108,17 @@ module Administrate
       end
 
       def look
-        (options.fetch(:look, :default).presence || :default).to_sym
+        val = options.fetch(:look, :default).presence || :default
+        case val
+        when Symbol
+          val
+        when ::String
+          val.to_sym
+        when Hash
+          val.fetch(page, :default).to_sym
+        else
+          :default
+        end
       end
 
       def required?

--- a/spec/example_app/app/dashboards/log_entry_dashboard.rb
+++ b/spec/example_app/app/dashboards/log_entry_dashboard.rb
@@ -6,12 +6,13 @@ class LogEntryDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     action: Field::String,
-    logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order])
+    logeable: Field::Polymorphic.with_options(classes: [Customer, ::Order]),
+    created_at: Field::DateTime.with_options(look: {index: :relative})
   }.freeze
 
-  COLLECTION_ATTRIBUTES = [:id] + ATTRIBUTES
+  COLLECTION_ATTRIBUTES = [:id] + ATTRIBUTES + [:created_at]
   FORM_ATTRIBUTES = ATTRIBUTES
-  SHOW_PAGE_ATTRIBUTES = ATTRIBUTES
+  SHOW_PAGE_ATTRIBUTES = ATTRIBUTES + [:created_at]
 
   def display_resource(resource)
     "#{resource.action}[#{safe_display_logeable(resource.logeable)}]"

--- a/spec/example_app/app/views/fields/date_time/looks/relative/_index.html.erb
+++ b/spec/example_app/app/views/fields/date_time/looks/relative/_index.html.erb
@@ -1,0 +1,5 @@
+<% if field.data %>
+  <span title="<%= field.datetime %>">
+    <%= time_ago_in_words(field.data) %>
+  </span>
+<% end %>

--- a/spec/example_app/spec/features/date_time_relative_look_spec.rb
+++ b/spec/example_app/spec/features/date_time_relative_look_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require "administrate/field/date_time"
+
+RSpec.feature "DateTime relative look", type: :feature do
+  let(:c1) { create(:customer, name: "John Petrucci") }
+  let(:o1) { create(:order, customer: c1) }
+
+  it "renders the created_at field with a relative look on the index page" do
+    create(:log_entry, action: "create", logeable: o1, created_at: 2.days.ago)
+
+    visit admin_log_entries_path
+
+    expect(page).to have_content("2 days")
+  end
+
+  it "renders the created_at field with a default look on the show page" do
+    log_entry = create(:log_entry, action: "create", logeable: o1, created_at: 3.hours.ago)
+    formatted_date_time = Administrate::Field::DateTime.new(:created_at, log_entry.created_at, :show).datetime
+
+    visit admin_log_entry_path(log_entry)
+
+    expect(page).to have_content(formatted_date_time)
+  end
+end

--- a/spec/lib/fields/base_spec.rb
+++ b/spec/lib/fields/base_spec.rb
@@ -46,6 +46,34 @@ describe Administrate::Field::Base do
         end
       end
 
+      context "when the look option is a hash" do
+        it "returns the partial prefixes based on the look option and page" do
+          field = field_class.new(:attribute, nil, :show, look: {show: :custom_show, form: :custom_form})
+          allow(field_class).to receive(:to_s).and_return("Administrate::Field::String")
+
+          prefixes = field.partial_prefixes
+
+          expect(prefixes).to eq([
+            "fields/string/looks/custom_show", "fields/string/looks/default", "fields/string",
+            "fields/base/looks/custom_show", "fields/base/looks/default", "fields/base"
+          ])
+        end
+
+        context "when the page is not in the look option" do
+          it "returns the partial prefixes based on the default look" do
+            field = field_class.new(:attribute, nil, :show, look: {form: :custom_form})
+            allow(field_class).to receive(:to_s).and_return("Administrate::Field::String")
+
+            prefixes = field.partial_prefixes
+
+            expect(prefixes).to eq([
+              "fields/string/looks/default", "fields/string",
+              "fields/base/looks/default", "fields/base"
+            ])
+          end
+        end
+      end
+
       context "when the look option is explicitly default" do
         it "returns the partial prefixes based on the field class" do
           field = field_class.new(:attribute, nil, :show, look: :default)
@@ -63,6 +91,20 @@ describe Administrate::Field::Base do
       context "when the look option is explicitly nil" do
         it "returns the partial prefixes based on the field class" do
           field = field_class.new(:attribute, nil, :show, look: nil)
+          allow(field_class).to receive(:to_s).and_return("Administrate::Field::String")
+
+          prefixes = field.partial_prefixes
+
+          expect(prefixes).to eq([
+            "fields/string/looks/default", "fields/string",
+            "fields/base/looks/default", "fields/base"
+          ])
+        end
+      end
+
+      context "when the look option is an unexpected type (ex. Array)" do
+        it "returns the partial prefixes based on the default look (instead of raising an error)" do
+          field = field_class.new(:attribute, nil, :show, look: [])
           allow(field_class).to receive(:to_s).and_return("Administrate::Field::String")
 
           prefixes = field.partial_prefixes


### PR DESCRIPTION
I’ve added support for changing the `look` per page.

For example, like in the sample app, you can use a `time_ago_in_words` look only on the index page.

```ruby
ATTRIBUTE_TYPES = {
  created_at: Field::DateTime.with_options(look: {index: :relative})
}
```

| index | show |
| -- | -- |
| `relative` look | `default` look |
| <img width="1063" height="606" alt="image" src="https://github.com/user-attachments/assets/5754851e-eba9-40e0-b948-050363d530ba" /> | <img width="1063" height="606" alt="image" src="https://github.com/user-attachments/assets/a0029670-abdf-4b42-9f3a-6da93a3a2dbd" /> |

What do you think?
