### PR TITLE
Add support for custom validation contexts in resource creation and update

### DIFF
--- a/app/controllers/administrate/application_controller.rb
+++ b/app/controllers/administrate/application_controller.rb
@@ -58,7 +58,7 @@ module Administrate
         authorize_resource(resource)
       end
 
-      if resource.save
+      if resource.save(context: validation_contexts_on_create(resource))
         yield(resource) if block_given?
         redirect_to(
           after_resource_created_path(resource),
@@ -75,7 +75,9 @@ module Administrate
 
     def update
       @resource = resource = requested_resource
-      if resource.update(resource_params)
+      resource.assign_attributes(resource_params)
+
+      if resource.save(context: validation_contexts_on_update(resource))
         redirect_to(
           after_resource_updated_path(resource),
           notice: translate_with_resource("update.success"),
@@ -291,6 +293,26 @@ module Administrate
           resource: resource
         )
       end
+    end
+
+    # Override this if you want to provide additional validation contexts.
+    #
+    # @param resource [ActiveRecord::Base] The resource to be validated.
+    # @return [Array<Symbol>] The validation contexts to be used.
+    def validation_contexts_on_create(resource)
+      default_validation_contexts(resource)
+    end
+
+    # Override this if you want to provide additional validation contexts.
+    #
+    # @param resource [ActiveRecord::Base] The resource to be validated.
+    # @return [Array<Symbol>] The validation contexts to be used.
+    def validation_contexts_on_update(resource)
+      default_validation_contexts(resource)
+    end
+
+    def default_validation_contexts(resource)
+      resource.new_record? ? [:create] : [:update]
     end
 
     def paginate_resources(resources)

--- a/docs/customizing_controller_actions.md
+++ b/docs/customizing_controller_actions.md
@@ -107,3 +107,30 @@ def create
   end
 end
 ```
+
+## Validation Contexts
+
+You can customize the context when saving a resource in the controller.  
+For example, with the following settings, regular admins are required to input a name, but super admins can update the resource *without* a name.
+
+```ruby
+# Model
+validates :name, presence: true, on: :save_by_regular_admin
+
+# Controller
+def validation_contexts_on_create(resource)
+  if current_user.super_admin?
+    super + [:save_by_super_admin]
+  else
+    super + [:save_by_regular_admin]
+  end
+end
+
+def validation_contexts_on_update(resource)
+  if current_user.super_admin?
+    super + [:save_by_super_admin]
+  else
+    super + [:save_by_regular_admin]
+  end
+end
+```

--- a/spec/controllers/admin/application_controller_spec.rb
+++ b/spec/controllers/admin/application_controller_spec.rb
@@ -100,4 +100,38 @@ RSpec.describe Admin::ApplicationController, type: :controller do
         .to raise_error(Administrate::NotAuthorizedError)
     end
   end
+
+  describe "validation contexts" do
+    render_views
+    controller(Admin::ProductsController) do
+      def validation_contexts_on_create(resource)
+        super + [:some_unclear_situation]
+      end
+
+      def validation_contexts_on_update(resource)
+        super + [:some_unclear_situation]
+      end
+    end
+
+    context "on create" do
+      it "raise a validation error due to custom validation context" do
+        params = attributes_for(:product)
+        post :create, params: {product: params}
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("Product meta tag can&#39;t be blank")
+      end
+    end
+
+    context "on update" do
+      it "raise a validation error due to custom validation context" do
+        product = create(:product, product_meta_tag: nil)
+        params = {name: "New Name"}
+        put :update, params: {id: product.to_param, product: params}
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("Product meta tag can&#39;t be blank")
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Separated from #2457 

---

This pull request introduces support for customizable validation contexts when creating or updating resources in the `Administrate` controllers. This allows developers to specify different validation scenarios based on user roles or other conditions, providing more flexibility for resource validation logic. Documentation and tests have been updated to reflect and verify this new functionality.

**Controller enhancements for validation contexts:**

* Added `validation_contexts_on_create` and `validation_contexts_on_update` methods to `Administrate::ApplicationController`, allowing developers to override and specify custom validation contexts for resource creation and update. The default context is `:create` or `:update` based on whether the record is new. (`app/controllers/administrate/application_controller.rb`)

**Documentation updates:**

* Added a new section in `docs/customizing_controller_actions.md`.

**Testing improvements:**

* Added controller specs in `spec/controllers/admin/application_controller_spec.rb`.

---

**Usage:**


```ruby
# Model
validates :name, presence: true, on: :save_by_regular_admin

# Controller
def validation_contexts_on_create(resource)
  if current_user.super_admin?
    super + [:save_by_super_admin]
  else
    super + [:save_by_regular_admin]
  end
end

def validation_contexts_on_update(resource)
  if current_user.super_admin?
    super + [:save_by_super_admin]
  else
    super + [:save_by_regular_admin]
  end
end
```