### PR TITLE
Fix SVG symbol tag closure in icons template

### DIFF
--- a/app/views/administrate/application/_icons.html.erb
+++ b/app/views/administrate/application/_icons.html.erb
@@ -17,5 +17,5 @@
     <circle cx="12" cy="12" r="10"></circle>
     <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
     <line x1="12" y1="17" x2="12.01" y2="17"></line>
-  <symbol>
+  </symbol>
 </svg>

--- a/app/views/administrate/application/_icons.html.erb
+++ b/app/views/administrate/application/_icons.html.erb
@@ -13,7 +13,7 @@
     <polyline points="18 15 12 9 6 15"></polyline>
   </symbol>
 
-  <symbol id="icon-question-mark" viewBox="0 0 24 24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <symbol id="icon-question-mark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="10"></circle>
     <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
     <line x1="12" y1="17" x2="12.01" y2="17"></line>


### PR DESCRIPTION
add missing closure for `symbol`