### PR TITLE
Fix destroy button click navigating to show page on index

### DIFF
--- a/app/assets/javascripts/administrate/controllers/table_controller.js
+++ b/app/assets/javascripts/administrate/controllers/table_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
         event.keyCode == keycodes.space ||
         event.keyCode == keycodes.enter) {
 
-      if (event.target.href) {
+      if (event.target.closest("a[href], button, input[type='submit']")) {
         return;
       }
 

--- a/spec/features/orders_index_spec.rb
+++ b/spec/features/orders_index_spec.rb
@@ -57,6 +57,17 @@ feature "order index page" do
     )
   end
 
+  scenario "clicking destroy does not navigate to show page", js: true do
+    create(:order)
+
+    visit admin_orders_path
+    dismiss_confirm do
+      click_on t("administrate.actions.destroy")
+    end
+
+    expect(page).to have_current_path(admin_orders_path)
+  end
+
   scenario "cannot delete because associated payment", js: true do
     create(:payment, order: create(:order))
 


### PR DESCRIPTION
## What

Fixes #2978

Clicking the "Destroy" button on the index page collection table
was navigating to the resource's show page instead of triggering
the delete action.

## Why

The `visitDataUrl` action in `table_controller.js` checked
`event.target.href` to decide whether to skip row navigation.
Since `button_to` generates a `<form>` with a `<button>` (which
has no `href` attribute), the check was bypassed, causing
`Turbo.visit(dataUrl)` to fire.

## How

Replaced `event.target.href` with
`event.target.closest("a[href], button, input[type='submit']")`
to properly detect interactive elements that should not trigger
row navigation. This also handles:

- `<button>` elements (the reported bug)
- `<input type="submit">` elements (future safety)
- Child elements inside links/buttons (e.g. icons)

Added a feature spec that verifies dismissing the destroy
confirmation keeps the user on the index page.

## Changed files

- `app/assets/javascripts/administrate/controllers/table_controller.js` (1 line)
- `spec/features/orders_index_spec.rb` (+11 lines)