### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -11,6 +11,10 @@ Gem::Specification.new do |s|
   s.summary = "A Rails engine for creating super-flexible admin dashboards"
   s.license = "MIT"
 
+  s.metadata = {
+    "rubygems_mfa_required" => "true"
+  }
+
   s.files = Dir["{app,lib,docs}/**/*", "config/locales/**/*", "LICENSE", "Rakefile"]
 
   s.add_dependency "actionpack", ">= 6.0", "< 9.0"


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the recent NPM Axios compromise: https://socket.dev/blog/axios-npm-package-compromised

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/