### PR TITLE
Fix routes template indentation

### DIFF
--- a/lib/generators/administrate/routes/templates/routes.rb.erb
+++ b/lib/generators/administrate/routes/templates/routes.rb.erb
@@ -1,5 +1,5 @@
 namespace :<%= namespace %> do
-<% dashboard_resources.each do |resource| %>    resources :<%= resource %>
-<%end%>
-    root to: "<%= dashboard_resources.first %>#index"
-  end
+<% dashboard_resources.each do |resource| %>  resources :<%= resource %>
+<% end %>
+  root to: "<%= dashboard_resources.first %>#index"
+end


### PR DESCRIPTION
## Problem

The routes template generates misaligned code in `config/routes.rb`:

```ruby
namespace :admin do
    resources :users

    root to: "users#index"
  end
```

This happens because the template includes extra indentation that compounds with Rails' `route()` method, which automatically adds indentation when injecting routes.

## Fix

Adjusted the indentation in `routes.rb.erb` so that the generated output is properly aligned:

```ruby
namespace :admin do
  resources :users

  root to: "users#index"
end
```

## Tests

All existing route generator specs pass.