### PR TITLE
Set ActiveStorage to use the local disk

### DIFF
--- a/spec/example_app/config/environments/production.rb
+++ b/spec/example_app/config/environments/production.rb
@@ -86,6 +86,11 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [:id]
 
+  # Configure local disk for ActiveStorage
+  # Running on Heroku means that the filesystem is ephemeral, but we rebuild the
+  # demo app daily.
+  config.active_storage.service = :local
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com


### PR DESCRIPTION
Since a recent Rails upgrade, we've been seeing a regular Sentry error be reported. It seems that since it's meant that the daily demo app reset has been broken, which is a more urgent problem.

This manually configures ActiveSupport to use the local disk. Running the application on Heroku means that this is ephemeral, but we throw away the data daily anyway. That said, a comment is valuable for when doing Rails updates because this sort of context is easily forgotten.

Fixes #3010.