### PR TITLE
Scope Bundler Audit to Dependabot Bundler PRs

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -1,14 +1,12 @@
 ---
 name: Bundler Audit
 on:
-  push:
-    branches:
-      - 'main'
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   audit:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/bundler/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
I’m not sure we need to run this audit on every PR.
Would it make sense to limit it to Dependabot PRs only?

Also, since this workflow checks Bundler dependencies specifically, I additionally scoped it to Dependabot Bundler PRs (dependabot/bundler/*).

What do you think?