### PR TITLE
Minimise exemptions to StandardRB rules

### DIFF
--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 # Test Authorization by using the Pundit concern and an example policy,
 # which will test all the authorization functionality.
 
-# standard:disable Lint/ConstantDefinitionInBlock
 describe Admin::OrdersController, type: :controller do
   context "with namespaced Punditize concern" do
     controller(Admin::OrdersController) do
@@ -107,4 +106,3 @@ describe Admin::OrdersController, type: :controller do
     end
   end
 end
-# standard:enable Lint/ConstantDefinitionInBlock

--- a/spec/features/authorization_spec.rb
+++ b/spec/features/authorization_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-# standard:disable Lint/ConstantDefinitionInBlock
 describe "authorization" do
   before do
+    # standard:disable Lint/ConstantDefinitionInBlock
     class TestProductPolicy < ProductPolicy
       class Scope < ProductPolicy::Scope
         def resolve
@@ -14,6 +14,7 @@ describe "authorization" do
         false
       end
     end
+    # standard:enable Lint/ConstantDefinitionInBlock
 
     @original_product_policy = Product.policy_class
     Product.policy_class = TestProductPolicy
@@ -55,4 +56,3 @@ describe "authorization" do
     expect(page).to have_css(".js-table-row", count: 1)
   end
 end
-# standard:enable Lint/ConstantDefinitionInBlock

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -10,9 +10,9 @@ require "administrate/field/number"
 require "administrate/base_dashboard"
 require "administrate/search"
 
-# standard:disable Lint/ConstantDefinitionInBlock
 describe Administrate::Search do
   before :all do
+    # standard:disable Lint/ConstantDefinitionInBlock
     module Administrate
       module SearchSpecMocks
         class MockRecord < ApplicationRecord
@@ -69,6 +69,7 @@ describe Administrate::Search do
         end
       end
     end
+    # standard:enable Lint/ConstantDefinitionInBlock
   end
 
   after :all do
@@ -225,4 +226,3 @@ describe Administrate::Search do
     end
   end
 end
-# standard:enable Lint/ConstantDefinitionInBlock


### PR DESCRIPTION
While reviewing something else, I noticed that the `standard:disable` in `spec/controllers/admin/orders_controller_spec.rb` wasn't necessary. I went and remove it, as well as reduced the scope of two other instances that are actually necessary.