### PR TITLE
`bundle audit`: Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     database_cleaner (2.1.0)
@@ -179,7 +179,7 @@ GEM
       reline (>= 0.4.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.3)
+    json (2.21.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -202,7 +202,7 @@ GEM
       logger (~> 1.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -276,8 +276,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (8.0.1)
       i18n (>= 0.7, < 2)
@@ -396,7 +396,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
The following diff was generated by executing the following:

```sh
bundle update \
  crass
  json
  loofah
  rails-html-sanitizer
  websocket-driver
```

This commit updates the following gems based on [CI failure output][ci]:

* [crass](https://github.com/rgrove/crass/)
* [json](https://github.com/ruby/json)
* [loofah](https://github.com/flavorjones/loofah)
* [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer)
* [websocket-driver](https://github.com/faye/websocket-driver-ruby)

```yaml
ruby-advisory-db:
  advisories:	1209 advisories
  last updated:	2026-07-15 19:08:00 -0400
  commit:	32a64d01964828d2f71ba17fb623a73142e03a3d
Name: crass
Version: 1.0.6
GHSA: GHSA-6jxj-px6v-747w
Criticality: Unknown
URL: https://github.com/rgrove/crass/security/advisories/GHSA-6jxj-px6v-747w
Title: Deeply nested CSS blocks and functions can trigger a SystemStackError or excessive memory usage
Solution: update to '>= 1.0.7'

Name: crass
Version: 1.0.6
GHSA: GHSA-6wmf-3r64-vcwv
Criticality: Unknown
URL: https://github.com/rgrove/crass/security/advisories/GHSA-6wmf-3r64-vcwv
Title: Large numeric exponents cause CPU and memory denial of service
Solution: update to '>= 1.0.7'

Name: crass
Version: 1.0.6
GHSA: GHSA-8vfg-2r28-hvhj
Criticality: Unknown
URL: https://github.com/rgrove/crass/security/advisories/GHSA-8vfg-2r28-hvhj
Title: Non-ASCII characters cause superlinear CPU consumption
Solution: update to '>= 1.0.7'

Name: crass
Version: 1.0.6
GHSA: GHSA-wwpr-jff3-395c
Criticality: Unknown
URL: https://github.com/rgrove/crass/security/advisories/GHSA-wwpr-jff3-395c
Title: A large number of adjacent CSS comments can trigger a SystemStackError
Solution: update to '>= 1.0.7'

Name: json
Version: 2.19.3
CVE: CVE-2026-54696
GHSA: GHSA-x2f5-4prf-w687
Criticality: Low
URL: https://nvd.nist.gov/vuln/detail/CVE-2026-54696
Title: JSON generator heap buffer overflow when streaming to an IO
Solution: update to '>= 2.19.9'

Name: websocket-driver
Version: 0.7.7
CVE: CVE-2026-54463
GHSA: GHSA-ghhp-3qvg-889p
Criticality: Unknown
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54463
Title: Memory exhaustion via abuse of protocol length headers
Solution: update to '>= 0.8.1'

Name: websocket-driver
Version: 0.7.7
CVE: CVE-2026-54464
GHSA: GHSA-33ph-fccm-39pj
Criticality: Unknown
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54464
Title: Resource limit bypass via message compression
Solution: update to '>= 0.8.1'

Name: websocket-driver
Version: 0.7.7
CVE: CVE-2026-54465
GHSA: GHSA-8j3g-f24p-4mpw
Criticality: Unknown
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54465
Title: Memory exhaustion in HTTP header parser
Solution: update to '>= 0.8.1'

Name: websocket-driver
Version: 0.7.7
GHSA: GHSA-2x63-gw47-w4mm
Criticality: Unknown
URL: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
Title: Denial of service via malformed Host header
Solution: update to '>= 0.8.2'
```

[ci]: https://github.com/thoughtbot/administrate/actions/runs/29583386810/job/87894269438#step:4:8