### PR TITLE
Fix Appraisals requiring ruby-vips

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,13 +97,12 @@ jobs:
       - run: cp spec/example_app/config/database.yml.sample spec/example_app/config/database.yml
       - name: Prepare main database schema
         run: bin/generate-database-schema
-
-
       # Workaround for https://github.com/ruby/rubygems/issues/9284.
       - name: Remove pre-installed Ruby 4.0
         if: ${{ matrix.ruby == '4.0' }}
         run: rm -rf /opt/hostedtoolcache/Ruby/4.0*
-
+      - name: Install libvips-dev
+        run: sudo apt-get -q update && sudo apt-get install -yq libvips-dev
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -18,8 +18,10 @@ end
 
 appraise "rails80" do
   gem "rails", "~> 8.0"
+  gem "ruby-vips"
 end
 
 appraise "pundit21" do
   gem "pundit", "~> 2.1.0"
+  gem "ruby-vips"
 end

--- a/gemfiles/pundit21.gemfile
+++ b/gemfiles/pundit21.gemfile
@@ -22,6 +22,7 @@ gem "tsort"
 gem "cssbundling-rails", "~> 1.4"
 gem "jsbundling-rails", "~> 1.3"
 gem "sprockets-rails", "~> 3.5"
+gem "ruby-vips"
 
 group :development, :test do
   gem "appraisal"

--- a/gemfiles/rails80.gemfile
+++ b/gemfiles/rails80.gemfile
@@ -23,6 +23,7 @@ gem "cssbundling-rails", "~> 1.4"
 gem "jsbundling-rails", "~> 1.3"
 gem "sprockets-rails", "~> 3.5"
 gem "rails", "~> 8.0"
+gem "ruby-vips"
 
 group :development, :test do
   gem "appraisal"


### PR DESCRIPTION
This started being required, but wasn't included for these Appraisals which meant they all started failing.